### PR TITLE
Add support for response streaming

### DIFF
--- a/e2e/overlay.spec.ts
+++ b/e2e/overlay.spec.ts
@@ -32,6 +32,26 @@ const CANNED_PLAN: ReviewPlan = {
   ],
 };
 
+/** Build a minimal Anthropic SSE stream that yields structured plan JSON as text deltas. */
+function anthropicSseForPlan(plan: ReviewPlan): string {
+  const text = JSON.stringify(plan);
+  // Split so the stream exercises partial JSON handling across multiple events.
+  const mid = Math.ceil(text.length / 2);
+  const chunk1 = text.slice(0, mid);
+  const chunk2 = text.slice(mid);
+
+  const events = [
+    `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: "msg_e2e", type: "message", role: "assistant", content: [], model: "claude-opus-4-8" } })}\n\n`,
+    `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } })}\n\n`,
+    `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: chunk1 } })}\n\n`,
+    `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: chunk2 } })}\n\n`,
+    `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}\n\n`,
+    `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 10 } })}\n\n`,
+    `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`,
+  ];
+  return events.join("");
+}
+
 test.describe("Guided review overlay", () => {
   test("clicking Start Guided Review builds and shows a review plan", async ({ context, extensionId }) => {
     // Seed provider settings via the real options page (real chrome.storage.local), the same
@@ -44,7 +64,7 @@ test.describe("Guided review overlay", () => {
     await optionsPage.close();
 
     // Stub every external call the extension makes for this PR: the page itself, the raw
-    // diff, and the AI provider's completion — nothing here touches the real internet.
+    // diff, and the AI provider's streaming completion — nothing here touches the real internet.
     await context.route(PR_URL, (route) => route.fulfill({ path: PR_FIXTURE_PATH, contentType: "text/html" }));
     await context.route(`${PR_URL}.diff`, (route) =>
       route.fulfill({ status: 200, contentType: "text/plain", body: CANNED_DIFF }),
@@ -52,8 +72,8 @@ test.describe("Guided review overlay", () => {
     await context.route("https://api.anthropic.com/v1/messages", (route) =>
       route.fulfill({
         status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({ content: [{ type: "text", text: JSON.stringify(CANNED_PLAN) }] }),
+        contentType: "text/event-stream",
+        body: anthropicSseForPlan(CANNED_PLAN),
       }),
     );
 
@@ -69,7 +89,7 @@ test.describe("Guided review overlay", () => {
     // First unit is always the synthetic PR description.
     await expect(page.getByText("PR description").first()).toBeVisible();
 
-    // After the plan loads, the AI unit is listed and reachable via Next.
+    // After the plan streams in, the AI unit is listed and reachable via Next.
     await expect(page.getByText(CANNED_PLAN.units[0].title)).toBeVisible();
     await page.getByRole("button", { name: /next/i }).click();
     await expect(page.getByText(CANNED_PLAN.units[0].context)).toBeVisible();

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,21 +1,25 @@
 import type {
-  AnnotateReviewError,
   AnnotateReviewRequest,
-  AnnotateReviewResponse,
+  AnnotateReviewStreamEvent,
   BackgroundRequest,
+  DiffFile,
   FetchDiffError,
   FetchDiffRequest,
   FetchDiffResponse,
   ReviewPlan,
+  ReviewUnit,
   TestConnectionRequest,
   TestConnectionResponse,
 } from "../lib/types";
 import { fetchPRDiff } from "../lib/github/diffFetch";
 import { chunkDiffByFile } from "../lib/review/buildPrompt";
-import { mergePlans, validateAndCleanPlan } from "../lib/review/reviewPlan";
+import { StreamPlanParser } from "../lib/review/streamPlanParser";
+import { validateAndCleanUnit } from "../lib/review/reviewPlan";
 import { getProviderSettings } from "../lib/settings";
 import { getProviderClient } from "./providers";
 import { ProviderError } from "./providers/types";
+
+const ANNOTATE_PORT_NAME = "annotate-review";
 
 chrome.action.onClicked.addListener(() => {
   chrome.runtime.openOptionsPage();
@@ -29,16 +33,6 @@ chrome.storage.session
   .catch((error) => console.error("Failed to set storage.session access level:", error));
 
 chrome.runtime.onMessage.addListener((message: BackgroundRequest, _sender, sendResponse) => {
-  if (message.type === "ANNOTATE_REVIEW") {
-    handleAnnotateReview(message)
-      .then(sendResponse)
-      .catch((error: unknown) => {
-        const response: AnnotateReviewError = { ok: false, error: describeError(error) };
-        sendResponse(response);
-      });
-    return true; // keep the message channel open for the async response
-  }
-
   if (message.type === "TEST_CONNECTION") {
     handleTestConnection(message)
       .then(sendResponse)
@@ -62,31 +56,116 @@ chrome.runtime.onMessage.addListener((message: BackgroundRequest, _sender, sendR
   return false;
 });
 
-async function handleAnnotateReview(
+/**
+ * Long-lived port for streaming annotate results. Content opens the port,
+ * posts ANNOTATE_REVIEW, and receives UNIT / DONE / ERROR events.
+ */
+chrome.runtime.onConnect.addListener((port) => {
+  if (port.name !== ANNOTATE_PORT_NAME) return;
+
+  const abort = new AbortController();
+  let started = false;
+
+  port.onDisconnect.addListener(() => {
+    abort.abort();
+  });
+
+  port.onMessage.addListener((message: AnnotateReviewRequest) => {
+    if (message?.type !== "ANNOTATE_REVIEW") return;
+    if (started) return;
+    started = true;
+
+    void handleAnnotateReviewStream(message, port, abort.signal).catch((error: unknown) => {
+      if (abort.signal.aborted) return;
+      postEvent(port, { type: "ERROR", error: describeError(error) });
+    });
+  });
+});
+
+async function handleAnnotateReviewStream(
   request: AnnotateReviewRequest,
-): Promise<AnnotateReviewResponse | AnnotateReviewError> {
+  port: chrome.runtime.Port,
+  signal: AbortSignal,
+): Promise<void> {
   const settings = await getProviderSettings();
 
   if (!settings.apiKey) {
-    return { ok: false, error: "No API key configured. Open the extension settings to add one." };
+    postEvent(port, {
+      type: "ERROR",
+      error: "No API key configured. Open the extension settings to add one.",
+    });
+    return;
   }
+
+  if (signal.aborted) return;
 
   const client = getProviderClient(settings.provider);
   const chunks = chunkDiffByFile(request.diff);
+  const allUnits: ReviewUnit[] = [];
 
-  const plans: ReviewPlan[] = [];
+  let chunkIndex = 0;
   for (const chunk of chunks) {
     if (chunk.files.length === 0) continue;
-    const rawPlan = await client.annotateReview({
-      diff: chunk,
-      prContext: request.prContext,
-      settings,
-    });
-    plans.push(validateAndCleanPlan(rawPlan, chunk));
+    if (signal.aborted) return;
+
+    const parser = new StreamPlanParser();
+    const prefix = `c${chunkIndex}-`;
+    const knownFiles = new Map(chunk.files.map((f) => [f.path, f]));
+
+    for await (const event of client.annotateReviewStream(
+      { diff: chunk, prContext: request.prContext, settings },
+      { signal },
+    )) {
+      if (signal.aborted) return;
+
+      if (event.type === "text_delta") {
+        const rawUnits = parser.push(event.text);
+        for (const raw of rawUnits) {
+          emitUnit(raw, knownFiles, prefix, allUnits, port, signal);
+        }
+      }
+
+      if (event.type === "done") {
+        const remaining = parser.finish();
+        for (const raw of remaining) {
+          emitUnit(raw, knownFiles, prefix, allUnits, port, signal);
+        }
+      }
+    }
+
+    chunkIndex++;
   }
 
-  const merged = mergePlans(plans);
-  return { ok: true, plan: merged };
+  if (signal.aborted) return;
+
+  const plan: ReviewPlan = { units: allUnits };
+  postEvent(port, { type: "DONE", plan });
+}
+
+function emitUnit(
+  raw: ReviewUnit,
+  knownFiles: Map<string, DiffFile>,
+  prefix: string,
+  allUnits: ReviewUnit[],
+  port: chrome.runtime.Port,
+  signal: AbortSignal,
+): void {
+  if (signal.aborted) return;
+
+  const cleaned = validateAndCleanUnit(raw, knownFiles);
+  if (!cleaned) return;
+
+  const unit: ReviewUnit = { ...cleaned, id: `${prefix}${cleaned.id}` };
+  allUnits.push(unit);
+  postEvent(port, { type: "UNIT", unit });
+}
+
+function postEvent(port: chrome.runtime.Port, event: AnnotateReviewStreamEvent): void {
+  try {
+    port.postMessage(event);
+  } catch {
+    // Port already disconnected — nothing to do.
+  }
 }
 
 async function handleTestConnection(request: TestConnectionRequest): Promise<TestConnectionResponse> {
@@ -108,6 +187,9 @@ async function handleFetchDiff(request: FetchDiffRequest): Promise<FetchDiffResp
 
 function describeError(error: unknown): string {
   if (error instanceof ProviderError) return error.message;
+  if (error instanceof DOMException && error.name === "AbortError") {
+    return "Review annotation was cancelled.";
+  }
   if (error instanceof Error) return error.message;
   return "Something went wrong talking to the AI provider.";
 }

--- a/src/background/providers/anthropic.ts
+++ b/src/background/providers/anthropic.ts
@@ -1,7 +1,8 @@
-import type { ProviderSettings, ReviewPlan } from "../../lib/types";
+import type { ProviderSettings } from "../../lib/types";
 import { buildUserPrompt, SYSTEM_PROMPT } from "../../lib/review/buildPrompt";
 import { REVIEW_PLAN_JSON_SCHEMA } from "../../lib/review/reviewSchema";
-import type { AnnotateReviewInput, ProviderClient } from "./types";
+import { readSseJsonStream } from "./sse";
+import type { AnnotateReviewInput, AnnotateStreamEvent, ProviderClient } from "./types";
 import { ProviderError } from "./types";
 
 const API_URL = "https://api.anthropic.com/v1/messages";
@@ -12,13 +13,17 @@ const ANTHROPIC_VERSION = "2023-06-01";
  * call the Messages API directly from the extension's background worker
  * (this is the documented "bring your own API key" browser-CORS opt-in) and
  * `output_config.format` to force a schema-valid ReviewPlan rather than
- * parsing free text.
+ * parsing free text. Streams text deltas so the UI can surface units early.
  */
 export const anthropicProvider: ProviderClient = {
-  async annotateReview({ diff, prContext, settings }: AnnotateReviewInput): Promise<ReviewPlan> {
+  async *annotateReviewStream(
+    { diff, prContext, settings }: AnnotateReviewInput,
+    options?: { signal?: AbortSignal },
+  ): AsyncGenerator<AnnotateStreamEvent, void, unknown> {
     const body = {
       model: settings.model,
       max_tokens: 8000,
+      stream: true,
       system: SYSTEM_PROMPT,
       output_config: {
         effort: "medium",
@@ -27,38 +32,57 @@ export const anthropicProvider: ProviderClient = {
       messages: [{ role: "user", content: buildUserPrompt(diff, prContext) }],
     };
 
-    const response = await fetch(API_URL, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-api-key": settings.apiKey,
-        "anthropic-version": ANTHROPIC_VERSION,
-        "anthropic-dangerous-direct-browser-access": "true",
-      },
-      body: JSON.stringify(body),
-    });
+    let response: Response;
+    try {
+      response = await fetch(API_URL, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": settings.apiKey,
+          "anthropic-version": ANTHROPIC_VERSION,
+          "anthropic-dangerous-direct-browser-access": "true",
+        },
+        body: JSON.stringify(body),
+        signal: options?.signal,
+      });
+    } catch (error) {
+      if (isAbortError(error)) throw error;
+      throw new ProviderError(
+        error instanceof Error ? error.message : "Failed to reach the Claude API.",
+      );
+    }
 
     if (!response.ok) {
       const detail = await safeErrorDetail(response);
       throw new ProviderError(`Claude API error (${response.status}): ${detail}`);
     }
 
-    const data = await response.json();
-
-    if (data.stop_reason === "refusal") {
-      throw new ProviderError("Claude declined to annotate this diff.");
+    if (!response.body) {
+      throw new ProviderError("Claude returned an empty stream.");
     }
 
-    const textBlock = (data.content ?? []).find((b: { type: string }) => b.type === "text");
-    if (!textBlock) {
-      throw new ProviderError("Claude returned no content for this diff.");
+    for await (const event of readSseJsonStream(response.body, { signal: options?.signal })) {
+      if (!event || typeof event !== "object") continue;
+      const ev = event as {
+        type?: string;
+        delta?: { type?: string; text?: string; stop_reason?: string };
+        error?: { message?: string };
+      };
+
+      if (ev.type === "error") {
+        throw new ProviderError(ev.error?.message ?? "Claude stream error.");
+      }
+
+      if (ev.type === "content_block_delta" && ev.delta?.type === "text_delta" && ev.delta.text) {
+        yield { type: "text_delta", text: ev.delta.text };
+      }
+
+      if (ev.type === "message_delta" && ev.delta?.stop_reason === "refusal") {
+        throw new ProviderError("Claude declined to annotate this diff.");
+      }
     }
 
-    try {
-      return JSON.parse(textBlock.text) as ReviewPlan;
-    } catch {
-      throw new ProviderError("Claude returned a response that wasn't valid JSON.");
-    }
+    yield { type: "done" };
   },
 
   async testConnection(settings: ProviderSettings): Promise<void> {
@@ -91,4 +115,8 @@ async function safeErrorDetail(response: Response): Promise<string> {
   } catch {
     return response.statusText;
   }
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
 }

--- a/src/background/providers/openaiCompatible.ts
+++ b/src/background/providers/openaiCompatible.ts
@@ -1,7 +1,8 @@
-import type { ProviderSettings, ReviewPlan } from "../../lib/types";
+import type { ProviderSettings } from "../../lib/types";
 import { buildUserPrompt, SYSTEM_PROMPT } from "../../lib/review/buildPrompt";
 import { REVIEW_PLAN_JSON_SCHEMA } from "../../lib/review/reviewSchema";
-import type { AnnotateReviewInput, ProviderClient } from "./types";
+import { readSseJsonStream } from "./sse";
+import type { AnnotateReviewInput, AnnotateStreamEvent, ProviderClient } from "./types";
 import { ProviderError } from "./types";
 
 /**
@@ -11,54 +12,83 @@ import { ProviderError } from "./types";
  * one client covers both providers; only the base URL and display name
  * differ.
  *
- * Not fully prompt-tuned in v1 (Claude is the wired-up default), but present
- * and selectable so adding real coverage later is a config change, not new
- * plumbing.
+ * Streams completion deltas so the overlay can surface completed units early.
  */
 export function createOpenAICompatibleProvider(baseUrl: string, displayName: string): ProviderClient {
   const chatUrl = `${baseUrl}/chat/completions`;
 
   return {
-    async annotateReview({ diff, prContext, settings }: AnnotateReviewInput): Promise<ReviewPlan> {
-      const response = await fetch(chatUrl, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          authorization: `Bearer ${settings.apiKey}`,
-        },
-        body: JSON.stringify({
-          model: settings.model,
-          messages: [
-            { role: "system", content: SYSTEM_PROMPT },
-            { role: "user", content: buildUserPrompt(diff, prContext) },
-          ],
-          response_format: {
-            type: "json_schema",
-            json_schema: {
-              name: "review_plan",
-              schema: REVIEW_PLAN_JSON_SCHEMA,
-              strict: true,
-            },
+    async *annotateReviewStream(
+      { diff, prContext, settings }: AnnotateReviewInput,
+      options?: { signal?: AbortSignal },
+    ): AsyncGenerator<AnnotateStreamEvent, void, unknown> {
+      let response: Response;
+      try {
+        response = await fetch(chatUrl, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${settings.apiKey}`,
           },
-        }),
-      });
+          body: JSON.stringify({
+            model: settings.model,
+            stream: true,
+            messages: [
+              { role: "system", content: SYSTEM_PROMPT },
+              { role: "user", content: buildUserPrompt(diff, prContext) },
+            ],
+            response_format: {
+              type: "json_schema",
+              json_schema: {
+                name: "review_plan",
+                schema: REVIEW_PLAN_JSON_SCHEMA,
+                strict: true,
+              },
+            },
+          }),
+          signal: options?.signal,
+        });
+      } catch (error) {
+        if (isAbortError(error)) throw error;
+        throw new ProviderError(
+          error instanceof Error ? error.message : `Failed to reach the ${displayName} API.`,
+        );
+      }
 
       if (!response.ok) {
         const detail = await safeErrorDetail(response);
         throw new ProviderError(`${displayName} API error (${response.status}): ${detail}`);
       }
 
-      const data = await response.json();
-      const content = data?.choices?.[0]?.message?.content;
-      if (!content) {
+      if (!response.body) {
+        throw new ProviderError(`${displayName} returned an empty stream.`);
+      }
+
+      let sawContent = false;
+
+      for await (const event of readSseJsonStream(response.body, { signal: options?.signal })) {
+        if (!event || typeof event !== "object") continue;
+        const data = event as {
+          choices?: Array<{ delta?: { content?: string | null }; finish_reason?: string | null }>;
+          error?: { message?: string };
+        };
+
+        if (data.error?.message) {
+          throw new ProviderError(data.error.message);
+        }
+
+        const content = data.choices?.[0]?.delta?.content;
+        if (typeof content === "string" && content.length > 0) {
+          sawContent = true;
+          yield { type: "text_delta", text: content };
+        }
+      }
+
+      if (!sawContent) {
         throw new ProviderError(`${displayName} returned no content for this diff.`);
       }
 
-      try {
-        return JSON.parse(content) as ReviewPlan;
-      } catch {
-        throw new ProviderError(`${displayName} returned a response that wasn't valid JSON.`);
-      }
+      yield { type: "done" };
     },
 
     async testConnection(settings: ProviderSettings): Promise<void> {
@@ -90,4 +120,8 @@ async function safeErrorDetail(response: Response): Promise<string> {
   } catch {
     return response.statusText;
   }
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
 }

--- a/src/background/providers/sse.ts
+++ b/src/background/providers/sse.ts
@@ -1,0 +1,60 @@
+/**
+ * Minimal SSE line parser for provider streaming responses.
+ * Yields parsed JSON objects from `data:` lines; ignores comments/event names.
+ */
+
+export async function* readSseJsonStream(
+  body: ReadableStream<Uint8Array>,
+  options?: { signal?: AbortSignal },
+): AsyncGenerator<unknown, void, unknown> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  try {
+    while (true) {
+      if (options?.signal?.aborted) {
+        throw new DOMException("The operation was aborted.", "AbortError");
+      }
+
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const parts = buffer.split("\n");
+      buffer = parts.pop() ?? "";
+
+      for (const rawLine of parts) {
+        const line = rawLine.replace(/\r$/, "");
+        if (!line.startsWith("data:")) continue;
+
+        const data = line.slice(5).trimStart();
+        if (!data || data === "[DONE]") {
+          if (data === "[DONE]") return;
+          continue;
+        }
+
+        try {
+          yield JSON.parse(data) as unknown;
+        } catch {
+          // Skip malformed SSE data lines rather than aborting the whole stream.
+        }
+      }
+    }
+
+    // Flush any trailing data line without a final newline.
+    const trailing = buffer.replace(/\r$/, "");
+    if (trailing.startsWith("data:")) {
+      const data = trailing.slice(5).trimStart();
+      if (data && data !== "[DONE]") {
+        try {
+          yield JSON.parse(data) as unknown;
+        } catch {
+          // ignore
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/src/background/providers/types.ts
+++ b/src/background/providers/types.ts
@@ -1,4 +1,4 @@
-import type { ParsedDiff, PRContext, ProviderSettings, ReviewPlan } from "../../lib/types";
+import type { ParsedDiff, PRContext, ProviderSettings } from "../../lib/types";
 
 export interface AnnotateReviewInput {
   diff: ParsedDiff;
@@ -6,9 +6,20 @@ export interface AnnotateReviewInput {
   settings: ProviderSettings;
 }
 
+export type AnnotateStreamEvent =
+  | { type: "text_delta"; text: string }
+  | { type: "done" };
+
 export interface ProviderClient {
-  /** Send one diff chunk + PR context, get back a schema-valid ReviewPlan. */
-  annotateReview(input: AnnotateReviewInput): Promise<ReviewPlan>;
+  /**
+   * Stream structured ReviewPlan JSON as text deltas. Schema is still enforced
+   * server-side; callers assemble/parse the deltas into units.
+   */
+  annotateReviewStream(
+    input: AnnotateReviewInput,
+    options?: { signal?: AbortSignal },
+  ): AsyncGenerator<AnnotateStreamEvent, void, unknown>;
+
   /** Minimal request to confirm the API key/model combination actually works. */
   testConnection(settings: ProviderSettings): Promise<void>;
 }

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -1,7 +1,7 @@
 import { createRoot } from "react-dom/client";
 import { parsePRUrl, type PRIdentity } from "../lib/github/diffFetch";
 import { fetchConversationDescription, scrapePRContext } from "../lib/github/prContext";
-import { requestPRDiff, requestReviewPlan } from "../lib/messaging";
+import { requestPRDiff, streamReviewPlan } from "../lib/messaging";
 import { Overlay } from "./overlay/Overlay";
 import { OVERLAY_CSS } from "./overlay/styles";
 import { useReviewStore, restoreSession } from "./overlay/store";
@@ -10,6 +10,8 @@ const BUTTON_ID = "guided-review-start-btn";
 const HOST_ID = "guided-review-overlay-host";
 
 let currentPR: PRIdentity | null = null;
+/** Active stream cancel handle so restart / close can abort the worker. */
+let activeStreamCancel: (() => void) | null = null;
 
 init();
 
@@ -101,12 +103,20 @@ function findButtonAnchor(): HTMLElement | null {
   return null;
 }
 
+function cancelActiveStream(): void {
+  if (activeStreamCancel) {
+    activeStreamCancel();
+    activeStreamCancel = null;
+  }
+}
+
 async function onStartReview(): Promise<void> {
   if (!currentPR) return;
   const pr = currentPR;
   const prUrl = window.location.href;
 
   ensureOverlayMounted(prUrl);
+  cancelActiveStream();
 
   // Scrape PR metadata first so the overlay can render the full layout with the
   // PR description unit immediately — before the diff fetch / AI plan finish.
@@ -114,6 +124,7 @@ async function onStartReview(): Promise<void> {
   useReviewStore.getState().open();
   useReviewStore.getState().setPRContext(prContext);
   useReviewStore.getState().startLoading();
+  const streamGeneration = useReviewStore.getState().streamGeneration;
 
   try {
     const restored = await restoreSession(prUrl);
@@ -138,28 +149,32 @@ async function onStartReview(): Promise<void> {
 
     const diffResponse = await requestPRDiff(pr);
     if (!diffResponse.ok) {
-      useReviewStore.getState().setError(diffResponse.error);
+      useReviewStore.getState().setError(diffResponse.error, streamGeneration);
       return;
     }
     const diff = diffResponse.diff;
-    // Diff summary (additions/deletions/file list) does not need the LLM —
-    // surface it immediately so the description unit can show Changes while
-    // the plan is still being built.
+
+    // Store the diff early so header stats and unit resolution work while the
+    // plan is still streaming in.
     useReviewStore.getState().setDiff(diff);
+    useReviewStore.getState().beginStreaming(streamGeneration);
 
-    // Prefer the latest prContext (async description fetch may have filled it in).
     const latestContext = useReviewStore.getState().prContext ?? prContext;
-    const response = await requestReviewPlan(diff, latestContext);
-
-    if (!response.ok) {
-      useReviewStore.getState().setError(response.error);
-      return;
-    }
-
-    useReviewStore.getState().setReady(diff, response.plan);
+    const { cancel } = streamReviewPlan(diff, latestContext, {
+      onUnit: (unit) => useReviewStore.getState().appendUnit(unit, streamGeneration),
+      onDone: (plan) => {
+        activeStreamCancel = null;
+        useReviewStore.getState().setReady(diff, plan, streamGeneration);
+      },
+      onError: (error) => {
+        activeStreamCancel = null;
+        useReviewStore.getState().setError(error, streamGeneration);
+      },
+    });
+    activeStreamCancel = cancel;
   } catch (error) {
     const message = error instanceof Error ? error.message : "Failed to build the guided review.";
-    useReviewStore.getState().setError(message);
+    useReviewStore.getState().setError(message, streamGeneration);
   }
 }
 
@@ -182,5 +197,5 @@ function ensureOverlayMounted(prUrl: string): void {
   const appRoot = document.createElement("div");
   shadowRoot.appendChild(appRoot);
 
-  createRoot(appRoot).render(<Overlay prUrl={prUrl} />);
+  createRoot(appRoot).render(<Overlay prUrl={prUrl} onRequestClose={cancelActiveStream} />);
 }

--- a/src/content/overlay/Overlay.test.tsx
+++ b/src/content/overlay/Overlay.test.tsx
@@ -68,6 +68,7 @@ function resetStore(): void {
     plan: null,
     prContext: null,
     currentUnitIndex: 0,
+    streamGeneration: 0,
   });
 }
 
@@ -120,6 +121,37 @@ describe("Overlay", () => {
     // Plan still loading — skeleton + status copy remain.
     expect(screen.getByText(/building the rest of the walkthrough/i)).toBeInTheDocument();
     expect(document.querySelectorAll(".gr-unit-item-skeleton").length).toBeGreaterThan(0);
+  });
+
+  it("shows completed units alongside skeletons while streaming", () => {
+    useReviewStore.setState({
+      isOpen: true,
+      status: "streaming",
+      diff: diffFixture(),
+      plan: planFixture(),
+      prContext: prContextFixture(),
+      currentUnitIndex: 0,
+    });
+    render(<Overlay prUrl={PR_URL} />);
+
+    expect(screen.getByText("Update foo")).toBeInTheDocument();
+    expect(document.querySelectorAll(".gr-unit-item-skeleton").length).toBeGreaterThan(0);
+    expect(screen.getByText(/building the rest of the walkthrough/i)).toBeInTheDocument();
+  });
+
+  it("shows unit context without the building spinner when viewing a streamed unit", () => {
+    useReviewStore.setState({
+      isOpen: true,
+      status: "streaming",
+      diff: diffFixture(),
+      plan: planFixture(),
+      prContext: prContextFixture(),
+      currentUnitIndex: 1,
+    });
+    render(<Overlay prUrl={PR_URL} />);
+
+    expect(screen.getByText("because it needed updating")).toBeInTheDocument();
+    expect(screen.queryByText(/building the rest of the walkthrough/i)).not.toBeInTheDocument();
   });
 
   it("shows keyboard shortcuts on the description unit once the walkthrough is ready", () => {

--- a/src/content/overlay/Overlay.tsx
+++ b/src/content/overlay/Overlay.tsx
@@ -11,9 +11,11 @@ import { FooterNav } from "./components/FooterNav";
 
 interface OverlayProps {
   prUrl: string;
+  /** Invoked when the user exits so any in-flight stream can be cancelled. */
+  onRequestClose?: () => void;
 }
 
-export function Overlay({ prUrl }: OverlayProps) {
+export function Overlay({ prUrl, onRequestClose }: OverlayProps) {
   const isOpen = useReviewStore((s) => s.isOpen);
   const status = useReviewStore((s) => s.status);
   const error = useReviewStore((s) => s.error);
@@ -26,6 +28,11 @@ export function Overlay({ prUrl }: OverlayProps) {
   const goNext = useReviewStore((s) => s.goNext);
   const goPrev = useReviewStore((s) => s.goPrev);
   const codeColRef = useRef<HTMLElement>(null);
+
+  const handleExit = () => {
+    onRequestClose?.();
+    close();
+  };
 
   useEffect(() => {
     if (status === "ready") void persistSession(prUrl);
@@ -56,6 +63,7 @@ export function Overlay({ prUrl }: OverlayProps) {
         case "Escape":
           event.preventDefault();
           event.stopPropagation();
+          onRequestClose?.();
           useReviewStore.getState().close();
           return;
         case "ArrowRight":
@@ -85,11 +93,13 @@ export function Overlay({ prUrl }: OverlayProps) {
 
     window.addEventListener("keydown", onKeyDown, true);
     return () => window.removeEventListener("keydown", onKeyDown, true);
-  }, [isOpen]);
+  }, [isOpen, onRequestClose]);
 
   if (!isOpen) return null;
 
-  const isLoading = status === "loading" || status === "idle";
+  const stillBuilding = status === "loading" || status === "streaming" || status === "idle";
+  // Spinner on the description unit only while the plan is still being built.
+  const showBuildingSpinner = stillBuilding && (!plan || currentUnitIndex === 0);
   const displayUnits = buildDisplayUnits(plan);
   const total = displayUnitCount(plan);
   const totalKnown = status === "ready";
@@ -108,7 +118,7 @@ export function Overlay({ prUrl }: OverlayProps) {
         totalKnown={totalKnown}
         prContext={prContext}
         diff={diff}
-        onExit={close}
+        onExit={handleExit}
       />
 
       <div className="gr-body">
@@ -129,13 +139,13 @@ export function Overlay({ prUrl }: OverlayProps) {
                 prContext?.description?.trim() || prContext?.descriptionHtml?.trim()
               )}
               error={status === "error" ? error : null}
-              loading={isLoading}
+              loading={showBuildingSpinner && isDescriptionUnit}
             />
           </div>
           <Sidebar
             plan={plan}
             currentUnitIndex={currentUnitIndex}
-            loading={isLoading}
+            stillBuilding={stillBuilding}
             onSelectUnit={goToUnit}
           />
         </aside>

--- a/src/content/overlay/components/Sidebar.tsx
+++ b/src/content/overlay/components/Sidebar.tsx
@@ -6,11 +6,12 @@ const SKELETON_COUNT = 4;
 interface SidebarProps {
   plan: ReviewPlan | null;
   currentUnitIndex: number;
-  loading: boolean;
+  /** When true, show trailing skeleton rows after any completed units. */
+  stillBuilding: boolean;
   onSelectUnit: (index: number) => void;
 }
 
-export function Sidebar({ plan, currentUnitIndex, loading, onSelectUnit }: SidebarProps) {
+export function Sidebar({ plan, currentUnitIndex, stillBuilding, onSelectUnit }: SidebarProps) {
   const reviewUnits = plan?.units ?? [];
 
   return (
@@ -26,7 +27,22 @@ export function Sidebar({ plan, currentUnitIndex, loading, onSelectUnit }: Sideb
         {PR_DESCRIPTION_UNIT_TITLE}
       </button>
 
-      {loading &&
+      {reviewUnits.map((unit, planIndex) => {
+        const displayIndex = planIndex + 1;
+        return (
+          <button
+            key={unit.id}
+            type="button"
+            className={`gr-unit-item${displayIndex === currentUnitIndex ? " gr-active" : ""}`}
+            onClick={() => onSelectUnit(displayIndex)}
+          >
+            <span className="gr-unit-item-index">{displayIndex + 1}.</span>
+            {unit.title}
+          </button>
+        );
+      })}
+
+      {stillBuilding &&
         Array.from({ length: SKELETON_COUNT }, (_, i) => (
           <div
             key={`skeleton-${i}`}
@@ -36,22 +52,6 @@ export function Sidebar({ plan, currentUnitIndex, loading, onSelectUnit }: Sideb
             <span className="gr-unit-item-skeleton-bar" />
           </div>
         ))}
-
-      {!loading &&
-        reviewUnits.map((unit, planIndex) => {
-          const displayIndex = planIndex + 1;
-          return (
-            <button
-              key={unit.id}
-              type="button"
-              className={`gr-unit-item${displayIndex === currentUnitIndex ? " gr-active" : ""}`}
-              onClick={() => onSelectUnit(displayIndex)}
-            >
-              <span className="gr-unit-item-index">{displayIndex + 1}.</span>
-              {unit.title}
-            </button>
-          );
-        })}
     </nav>
   );
 }

--- a/src/content/overlay/store.test.ts
+++ b/src/content/overlay/store.test.ts
@@ -41,6 +41,7 @@ function resetStore(): void {
     plan: null,
     prContext: null,
     currentUnitIndex: 0,
+    streamGeneration: 0,
   });
 }
 
@@ -80,6 +81,41 @@ describe("useReviewStore", () => {
     expect(state.status).toBe("loading");
     expect(state.diff).toBe(diff);
     expect(state.plan).toBeNull();
+  });
+
+  it("beginStreaming and appendUnit grow the plan while streaming", () => {
+    resetStore();
+    useReviewStore.getState().startLoading();
+    const gen = useReviewStore.getState().streamGeneration;
+    useReviewStore.getState().beginStreaming(gen);
+
+    expect(useReviewStore.getState().status).toBe("streaming");
+    expect(useReviewStore.getState().plan).toEqual({ units: [] });
+
+    const unit = planFixture(1).units[0];
+    useReviewStore.getState().appendUnit(unit, gen);
+    expect(useReviewStore.getState().plan?.units).toHaveLength(1);
+    expect(useReviewStore.getState().status).toBe("streaming");
+
+    // Duplicate id is ignored.
+    useReviewStore.getState().appendUnit(unit, gen);
+    expect(useReviewStore.getState().plan?.units).toHaveLength(1);
+
+    // Stale generation is ignored.
+    useReviewStore.getState().appendUnit({ ...unit, id: "stale" }, gen - 1);
+    expect(useReviewStore.getState().plan?.units).toHaveLength(1);
+  });
+
+  it("goNext works mid-stream once units have been appended", () => {
+    resetStore();
+    useReviewStore.getState().startLoading();
+    const gen = useReviewStore.getState().streamGeneration;
+    useReviewStore.getState().beginStreaming(gen);
+    useReviewStore.getState().appendUnit(planFixture(1).units[0], gen);
+
+    // display: [desc, u0]
+    useReviewStore.getState().goNext();
+    expect(useReviewStore.getState().currentUnitIndex).toBe(1);
   });
 
   it("setReady sets status ready, stores diff/plan, and clamps currentUnitIndex", () => {

--- a/src/content/overlay/store.ts
+++ b/src/content/overlay/store.ts
@@ -1,8 +1,8 @@
 import { create } from "zustand";
-import type { ParsedDiff, PRContext, ReviewPlan } from "../../lib/types";
+import type { ParsedDiff, PRContext, ReviewPlan, ReviewUnit } from "../../lib/types";
 import { displayUnitCount } from "./displayUnits";
 
-export type ReviewStatus = "idle" | "loading" | "ready" | "error";
+export type ReviewStatus = "idle" | "loading" | "streaming" | "ready" | "error";
 
 interface PersistedSession {
   diff: ParsedDiff;
@@ -21,18 +21,21 @@ interface ReviewState {
   prContext: PRContext | null;
   /** Index into the display unit list (0 = PR description, then plan units). */
   currentUnitIndex: number;
+  /**
+   * Monotonic generation for the active annotation stream. Bumped on
+   * startLoading so stale port events from a cancelled stream are ignored.
+   */
+  streamGeneration: number;
 
   open: () => void;
   close: () => void;
   startLoading: () => void;
   setPRContext: (prContext: PRContext) => void;
-  /**
-   * Store the parsed diff as soon as it is fetched, before the LLM plan is
-   * ready. Lets the description pane show file stats without waiting on AI.
-   */
   setDiff: (diff: ParsedDiff) => void;
-  setReady: (diff: ParsedDiff, plan: ReviewPlan) => void;
-  setError: (message: string) => void;
+  beginStreaming: (generation: number) => void;
+  appendUnit: (unit: ReviewUnit, generation: number) => void;
+  setReady: (diff: ParsedDiff, plan: ReviewPlan, generation?: number) => void;
+  setError: (message: string, generation?: number) => void;
   goToUnit: (index: number) => void;
   goNext: () => void;
   goPrev: () => void;
@@ -46,24 +49,58 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   plan: null,
   prContext: null,
   currentUnitIndex: 0,
+  streamGeneration: 0,
 
   open: () => set({ isOpen: true }),
   close: () => set({ isOpen: false }),
 
-  startLoading: () => set({ status: "loading", error: null, currentUnitIndex: 0, plan: null, diff: null }),
+  startLoading: () =>
+    set((state) => ({
+      status: "loading",
+      error: null,
+      currentUnitIndex: 0,
+      plan: null,
+      diff: null,
+      streamGeneration: state.streamGeneration + 1,
+    })),
 
   setPRContext: (prContext) => set({ prContext }),
 
   setDiff: (diff) => set({ diff }),
 
-  setReady: (diff, plan) =>
+  beginStreaming: (generation) => {
+    if (get().streamGeneration !== generation) return;
+    set({ status: "streaming", plan: { units: [] }, error: null });
+  },
+
+  appendUnit: (unit, generation) => {
+    if (get().streamGeneration !== generation) return;
+    set((state) => {
+      const existing = state.plan?.units ?? [];
+      if (existing.some((u) => u.id === unit.id)) {
+        return state;
+      }
+      return {
+        status: "streaming",
+        plan: { units: [...existing, unit] },
+        error: null,
+      };
+    });
+  },
+
+  setReady: (diff, plan, generation) => {
+    if (generation !== undefined && get().streamGeneration !== generation) return;
     set((state) => {
       const total = displayUnitCount(plan);
       const index = Math.min(Math.max(state.currentUnitIndex, 0), total - 1);
       return { status: "ready", diff, plan, currentUnitIndex: index, error: null };
-    }),
+    });
+  },
 
-  setError: (message) => set({ status: "error", error: message }),
+  setError: (message, generation) => {
+    if (generation !== undefined && get().streamGeneration !== generation) return;
+    set({ status: "error", error: message });
+  },
 
   goToUnit: (index) => {
     const total = displayUnitCount(get().plan);

--- a/src/lib/messaging.test.ts
+++ b/src/lib/messaging.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
-import { requestPRDiff, requestReviewPlan, testConnection } from "./messaging";
-import type { ParsedDiff, PRContext } from "./types";
+import { requestPRDiff, streamReviewPlan, testConnection } from "./messaging";
+import type { ParsedDiff, PRContext, ReviewUnit } from "./types";
+import type { MockPort } from "../test/chromeMock";
 
 describe("messaging", () => {
   it("requestPRDiff sends a typed FETCH_DIFF message", async () => {
@@ -16,20 +17,75 @@ describe("messaging", () => {
     expect(result).toEqual(response);
   });
 
-  it("requestReviewPlan sends a typed ANNOTATE_REVIEW message with the diff and PR context", async () => {
+  it("streamReviewPlan opens an annotate-review port and posts ANNOTATE_REVIEW", () => {
     const diff: ParsedDiff = { files: [] };
     const prContext = { title: "Add feature" } as PRContext;
-    const response = { ok: true, plan: { units: [] } };
-    vi.mocked(chrome.runtime.sendMessage).mockResolvedValueOnce(response);
+    const onUnit = vi.fn();
+    const onDone = vi.fn();
+    const onError = vi.fn();
 
-    const result = await requestReviewPlan(diff, prContext);
+    streamReviewPlan(diff, prContext, { onUnit, onDone, onError });
 
-    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
+    expect(chrome.runtime.connect).toHaveBeenCalledWith({ name: "annotate-review" });
+    const port = vi.mocked(chrome.runtime.connect).mock.results[0].value as MockPort;
+    expect(port.postMessage).toHaveBeenCalledWith({
       type: "ANNOTATE_REVIEW",
       diff,
       prContext,
     });
-    expect(result).toEqual(response);
+  });
+
+  it("streamReviewPlan delivers UNIT and DONE events to handlers", () => {
+    const unit: ReviewUnit = {
+      id: "c0-u1",
+      title: "Update foo",
+      context: "because",
+      files: [{ fileId: "src/foo.ts", hunkIds: [], role: "core_logic" }],
+    };
+    const plan = { units: [unit] };
+    const onUnit = vi.fn();
+    const onDone = vi.fn();
+    const onError = vi.fn();
+
+    streamReviewPlan({ files: [] }, { title: "t" } as PRContext, { onUnit, onDone, onError });
+    const port = vi.mocked(chrome.runtime.connect).mock.results[0].value as MockPort;
+
+    port.__emitMessage({ type: "UNIT", unit });
+    port.__emitMessage({ type: "DONE", plan });
+
+    expect(onUnit).toHaveBeenCalledWith(unit);
+    expect(onDone).toHaveBeenCalledWith(plan);
+    expect(onError).not.toHaveBeenCalled();
+    expect(port.disconnect).toHaveBeenCalled();
+  });
+
+  it("streamReviewPlan delivers ERROR events", () => {
+    const onUnit = vi.fn();
+    const onDone = vi.fn();
+    const onError = vi.fn();
+
+    streamReviewPlan({ files: [] }, { title: "t" } as PRContext, { onUnit, onDone, onError });
+    const port = vi.mocked(chrome.runtime.connect).mock.results[0].value as MockPort;
+
+    port.__emitMessage({ type: "ERROR", error: "No API key configured." });
+
+    expect(onError).toHaveBeenCalledWith("No API key configured.");
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it("streamReviewPlan cancel disconnects the port without erroring", () => {
+    const onError = vi.fn();
+    const { cancel } = streamReviewPlan({ files: [] }, { title: "t" } as PRContext, {
+      onUnit: vi.fn(),
+      onDone: vi.fn(),
+      onError,
+    });
+    const port = vi.mocked(chrome.runtime.connect).mock.results[0].value as MockPort;
+
+    cancel();
+    // disconnect fires onDisconnect; cancel marks settled so onError is not called
+    expect(port.disconnect).toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
   });
 
   it("testConnection sends a typed TEST_CONNECTION message", async () => {

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -1,7 +1,6 @@
 import type {
   AnnotateReviewRequest,
-  AnnotateReviewResponse,
-  AnnotateReviewError,
+  AnnotateReviewStreamEvent,
   TestConnectionRequest,
   TestConnectionResponse,
   FetchDiffRequest,
@@ -10,15 +9,87 @@ import type {
   ParsedDiff,
   PRContext,
   ProviderSettings,
+  ReviewPlan,
+  ReviewUnit,
 } from "./types";
 
-/** Content-script-side helper: ask the background worker to annotate a diff. */
-export async function requestReviewPlan(
+const ANNOTATE_PORT_NAME = "annotate-review";
+
+export interface StreamReviewPlanHandlers {
+  onUnit: (unit: ReviewUnit) => void;
+  onDone: (plan: ReviewPlan) => void;
+  onError: (error: string) => void;
+}
+
+/**
+ * Open a long-lived port to the background worker and stream a structured
+ * review plan. Completed units arrive via `onUnit` as they validate; `onDone`
+ * receives the final merged plan. Call `cancel()` to abort (disconnects the
+ * port, which aborts the in-flight provider request).
+ */
+export function streamReviewPlan(
   diff: ParsedDiff,
   prContext: PRContext,
-): Promise<AnnotateReviewResponse | AnnotateReviewError> {
+  handlers: StreamReviewPlanHandlers,
+): { cancel: () => void } {
+  const port = chrome.runtime.connect({ name: ANNOTATE_PORT_NAME });
+  let settled = false;
+
+  const finish = (fn: () => void): void => {
+    if (settled) return;
+    settled = true;
+    fn();
+  };
+
+  port.onMessage.addListener((message: AnnotateReviewStreamEvent) => {
+    if (!message || typeof message !== "object" || !("type" in message)) return;
+
+    switch (message.type) {
+      case "UNIT":
+        handlers.onUnit(message.unit);
+        return;
+      case "DONE":
+        finish(() => handlers.onDone(message.plan));
+        try {
+          port.disconnect();
+        } catch {
+          // already disconnected
+        }
+        return;
+      case "ERROR":
+        finish(() => handlers.onError(message.error));
+        try {
+          port.disconnect();
+        } catch {
+          // already disconnected
+        }
+        return;
+      default:
+        return;
+    }
+  });
+
+  port.onDisconnect.addListener(() => {
+    // If the background dies or the port drops without DONE/ERROR, surface it.
+    finish(() => {
+      const err = chrome.runtime.lastError?.message;
+      handlers.onError(err ?? "Lost connection to the review worker before the plan finished.");
+    });
+  });
+
   const request: AnnotateReviewRequest = { type: "ANNOTATE_REVIEW", diff, prContext };
-  return chrome.runtime.sendMessage(request);
+  port.postMessage(request);
+
+  return {
+    cancel: () => {
+      settled = true;
+      try {
+        port.disconnect();
+      } catch {
+        // already disconnected
+      }
+    },
+  };
 }
 
 /** Options-page-side helper: ask the background worker to test a provider config. */

--- a/src/lib/review/reviewPlan.test.ts
+++ b/src/lib/review/reviewPlan.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { mergePlans, validateAndCleanPlan } from "./reviewPlan";
-import type { ParsedDiff, ReviewPlan } from "../types";
+import { isCompleteReviewUnit, mergePlans, validateAndCleanPlan, validateAndCleanUnit } from "./reviewPlan";
+import type { ParsedDiff, ReviewPlan, ReviewUnit } from "../types";
 
 function diffFixture(): ParsedDiff {
   return {
@@ -104,6 +104,42 @@ describe("validateAndCleanPlan", () => {
     const cleaned = validateAndCleanPlan(plan, diffFixture());
     expect(cleaned.units).toHaveLength(1);
     expect(cleaned.units[0].files[0].hunkIds).toEqual([]);
+  });
+});
+
+describe("validateAndCleanUnit", () => {
+  it("returns a cleaned unit or null when nothing real remains", () => {
+    const good: ReviewUnit = {
+      id: "u1",
+      title: "Update foo",
+      context: "because",
+      files: [{ fileId: "src/foo.ts", hunkIds: ["src/foo.ts#0", "src/foo.ts#99"], role: "core_logic" }],
+    };
+    const cleaned = validateAndCleanUnit(good, diffFixture());
+    expect(cleaned?.files[0].hunkIds).toEqual(["src/foo.ts#0"]);
+
+    const bad: ReviewUnit = {
+      id: "u2",
+      title: "Nope",
+      context: "",
+      files: [{ fileId: "missing.ts", hunkIds: [], role: "core_logic" }],
+    };
+    expect(validateAndCleanUnit(bad, diffFixture())).toBeNull();
+  });
+});
+
+describe("isCompleteReviewUnit", () => {
+  it("accepts a well-formed unit and rejects incomplete objects", () => {
+    expect(
+      isCompleteReviewUnit({
+        id: "u1",
+        title: "T",
+        context: "C",
+        files: [{ fileId: "a.ts", hunkIds: [], role: "test" }],
+      }),
+    ).toBe(true);
+    expect(isCompleteReviewUnit({ id: "u1", title: "T" })).toBe(false);
+    expect(isCompleteReviewUnit(null)).toBe(false);
   });
 });
 

--- a/src/lib/review/reviewPlan.ts
+++ b/src/lib/review/reviewPlan.ts
@@ -1,4 +1,12 @@
-import type { ParsedDiff, ReviewPlan, ReviewUnit } from "../types";
+import type { FileRole, ParsedDiff, ReviewPlan, ReviewUnit, ReviewUnitFileRef } from "../types";
+
+const FILE_ROLES: ReadonlySet<string> = new Set([
+  "schema_or_model",
+  "core_logic",
+  "consumer_or_call_site",
+  "test",
+  "config_or_generated",
+]);
 
 /**
  * The LLM plans structure and writes commentary, but the actual code shown
@@ -10,25 +18,81 @@ import type { ParsedDiff, ReviewPlan, ReviewUnit } from "../types";
  */
 export function validateAndCleanPlan(plan: ReviewPlan, diff: ParsedDiff): ReviewPlan {
   const knownFiles = new Map(diff.files.map((f) => [f.path, f]));
-
   const cleanedUnits: ReviewUnit[] = [];
 
   for (const unit of plan.units) {
-    const files = unit.files.filter((ref) => {
-      const file = knownFiles.get(ref.fileId);
-      if (!file) return false;
-      if (ref.hunkIds.length === 0) return true;
-      const validHunkIds = new Set(file.hunks.map((h) => h.id));
-      ref.hunkIds = ref.hunkIds.filter((id) => validHunkIds.has(id));
-      return true;
-    });
-
-    if (files.length === 0) continue; // nothing real left in this unit — drop it
-
-    cleanedUnits.push({ ...unit, files });
+    const cleaned = validateAndCleanUnit(unit, knownFiles);
+    if (cleaned) cleanedUnits.push(cleaned);
   }
 
   return { units: cleanedUnits };
+}
+
+/**
+ * Validate a single review unit against the real diff. Returns null when
+ * nothing real remains (all file refs hallucinated) so callers can drop it.
+ *
+ * Mutates hunk id lists on a shallow copy of the unit's file refs only —
+ * never mutates the caller's original unit.
+ */
+export function validateAndCleanUnit(
+  unit: ReviewUnit,
+  diffOrKnownFiles: ParsedDiff | Map<string, ParsedDiff["files"][number]>,
+): ReviewUnit | null {
+  const knownFiles =
+    diffOrKnownFiles instanceof Map
+      ? diffOrKnownFiles
+      : new Map(diffOrKnownFiles.files.map((f) => [f.path, f]));
+
+  const files: ReviewUnitFileRef[] = [];
+
+  for (const ref of unit.files) {
+    const file = knownFiles.get(ref.fileId);
+    if (!file) continue;
+
+    const hunkIds =
+      ref.hunkIds.length === 0
+        ? []
+        : ref.hunkIds.filter((id) => file.hunks.some((h) => h.id === id));
+
+    files.push({
+      fileId: ref.fileId,
+      hunkIds,
+      role: FILE_ROLES.has(ref.role) ? (ref.role as FileRole) : "core_logic",
+    });
+  }
+
+  if (files.length === 0) return null;
+
+  return {
+    id: unit.id,
+    title: unit.title,
+    context: unit.context,
+    files,
+  };
+}
+
+/**
+ * Lightweight structural check for a raw parsed unit before validation.
+ * Incomplete or malformed objects from partial JSON must never reach the UI.
+ */
+export function isCompleteReviewUnit(value: unknown): value is ReviewUnit {
+  if (!value || typeof value !== "object") return false;
+  const u = value as Record<string, unknown>;
+  if (typeof u.id !== "string" || u.id.length === 0) return false;
+  if (typeof u.title !== "string") return false;
+  if (typeof u.context !== "string") return false;
+  if (!Array.isArray(u.files)) return false;
+
+  for (const file of u.files) {
+    if (!file || typeof file !== "object") return false;
+    const f = file as Record<string, unknown>;
+    if (typeof f.fileId !== "string") return false;
+    if (!Array.isArray(f.hunkIds) || !f.hunkIds.every((id) => typeof id === "string")) return false;
+    if (typeof f.role !== "string") return false;
+  }
+
+  return true;
 }
 
 /**

--- a/src/lib/review/streamPlanParser.test.ts
+++ b/src/lib/review/streamPlanParser.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { StreamPlanParser } from "./streamPlanParser";
+
+const UNIT_A = {
+  id: "u1",
+  title: "First unit",
+  context: "Why first",
+  files: [{ fileId: "src/a.ts", hunkIds: ["src/a.ts#0"], role: "core_logic" }],
+};
+
+const UNIT_B = {
+  id: "u2",
+  title: "Second unit",
+  context: "Why second",
+  files: [{ fileId: "src/b.ts", hunkIds: [], role: "test" }],
+};
+
+function fullJson(units: unknown[]): string {
+  return JSON.stringify({ units });
+}
+
+describe("StreamPlanParser", () => {
+  it("emits nothing until a complete unit object is available", () => {
+    const parser = new StreamPlanParser();
+    expect(parser.push('{"units":[')).toEqual([]);
+    expect(parser.push('{"id":"u1","title":"First')).toEqual([]);
+    expect(parser.push(' unit","context":"Why first","files":[')).toEqual([]);
+  });
+
+  it("emits a unit as soon as its object closes, before the stream ends", () => {
+    const parser = new StreamPlanParser();
+    const json = fullJson([UNIT_A, UNIT_B]);
+    // Feed everything except the final closing braces so the second unit is incomplete.
+    const firstUnitEnd = json.indexOf("},") + 1;
+    const partial = json.slice(0, firstUnitEnd);
+
+    const units = parser.push(partial);
+    expect(units).toHaveLength(1);
+    expect(units[0].id).toBe("u1");
+    expect(units[0].title).toBe("First unit");
+  });
+
+  it("emits units incrementally across many tiny chunks", () => {
+    const parser = new StreamPlanParser();
+    const json = fullJson([UNIT_A, UNIT_B]);
+    const seen: string[] = [];
+
+    for (const ch of json) {
+      for (const unit of parser.push(ch)) {
+        seen.push(unit.id);
+      }
+    }
+    for (const unit of parser.finish()) {
+      seen.push(unit.id);
+    }
+
+    expect(seen).toEqual(["u1", "u2"]);
+  });
+
+  it("handles escaped quotes inside string fields", () => {
+    const unit = {
+      id: "u1",
+      title: 'Say "hello"',
+      context: "path: C:\\foo\\bar",
+      files: [{ fileId: "src/a.ts", hunkIds: [], role: "core_logic" }],
+    };
+    const parser = new StreamPlanParser();
+    const units = parser.push(fullJson([unit]));
+    expect(units).toHaveLength(1);
+    expect(units[0].title).toBe('Say "hello"');
+    expect(units[0].context).toBe("path: C:\\foo\\bar");
+  });
+
+  it("skips incomplete trailing objects until finish() full-parses if possible", () => {
+    const parser = new StreamPlanParser();
+    // First unit complete, second truncated mid-object.
+    parser.push('{"units":[');
+    parser.push(JSON.stringify(UNIT_A));
+    parser.push(",");
+    parser.push('{"id":"u2","title":"Second');
+
+    const mid = parser.push("");
+    // First unit should already have been emitted on the complete object.
+    // Re-create to check mid-stream state more carefully:
+    const p2 = new StreamPlanParser();
+    let emitted = p2.push(`{"units":[${JSON.stringify(UNIT_A)},{"id":"u2","title":"Second`);
+    expect(emitted.map((u) => u.id)).toEqual(["u1"]);
+
+    // finish() cannot full-parse incomplete JSON — no second unit.
+    expect(p2.finish().map((u) => u.id)).toEqual([]);
+    void mid;
+  });
+
+  it("finish() recovers units via full parse when the document is complete", () => {
+    const parser = new StreamPlanParser();
+    // Push the whole document in one go — extract should already emit both.
+    const units = parser.push(fullJson([UNIT_A, UNIT_B]));
+    expect(units.map((u) => u.id)).toEqual(["u1", "u2"]);
+    expect(parser.finish()).toEqual([]);
+  });
+
+  it("does not emit objects missing required fields", () => {
+    const parser = new StreamPlanParser();
+    const incomplete = {
+      id: "u1",
+      title: "No files",
+      // missing context and files
+    };
+    expect(parser.push(fullJson([incomplete]))).toEqual([]);
+  });
+
+  it("handles an empty units array", () => {
+    const parser = new StreamPlanParser();
+    expect(parser.push('{"units":[]}')).toEqual([]);
+    expect(parser.finish()).toEqual([]);
+  });
+
+  it("ignores nested braces inside strings when finding object boundaries", () => {
+    const unit = {
+      id: "u1",
+      title: "Uses {braces}",
+      context: "also } here { and }",
+      files: [{ fileId: "src/a.ts", hunkIds: [], role: "core_logic" }],
+    };
+    const parser = new StreamPlanParser();
+    const units = parser.push(fullJson([unit]));
+    expect(units).toHaveLength(1);
+    expect(units[0].context).toBe("also } here { and }");
+  });
+});

--- a/src/lib/review/streamPlanParser.ts
+++ b/src/lib/review/streamPlanParser.ts
@@ -1,0 +1,177 @@
+import type { ReviewUnit } from "../types";
+import { isCompleteReviewUnit } from "./reviewPlan";
+
+/**
+ * Incrementally extracts complete `ReviewUnit` objects from a streaming
+ * JSON document of the form `{ "units": [ {...}, {...} ] }`.
+ *
+ * Only fully closed top-level objects inside the `units` array are emitted.
+ * Incomplete trailing objects stay buffered until more text arrives (or
+ * `finish()` runs a final full-document parse as a safety net).
+ */
+export class StreamPlanParser {
+  private buffer = "";
+  private unitsArrayStart = -1;
+  private scanPos = 0;
+  private emittedCount = 0;
+
+  /** Feed a text delta from the provider stream. Returns newly completed units. */
+  push(delta: string): ReviewUnit[] {
+    if (!delta) return [];
+    this.buffer += delta;
+    return this.extractCompletedUnits();
+  }
+
+  /**
+   * Call when the provider stream ends. Emits any remaining complete units
+   * via a final full-document parse if the incremental scanner missed them.
+   */
+  finish(): ReviewUnit[] {
+    const fromScan = this.extractCompletedUnits();
+    if (fromScan.length > 0) return fromScan;
+
+    // Safety net: structured output should be complete JSON by stream end.
+    try {
+      const parsed = JSON.parse(this.buffer) as { units?: unknown };
+      if (!Array.isArray(parsed.units)) return [];
+
+      const remaining: ReviewUnit[] = [];
+      for (let i = this.emittedCount; i < parsed.units.length; i++) {
+        const unit = parsed.units[i];
+        if (isCompleteReviewUnit(unit)) {
+          remaining.push(unit);
+          this.emittedCount++;
+        }
+      }
+      return remaining;
+    } catch {
+      return [];
+    }
+  }
+
+  /** Full buffered text (for debugging / final validation). */
+  getText(): string {
+    return this.buffer;
+  }
+
+  private extractCompletedUnits(): ReviewUnit[] {
+    if (this.unitsArrayStart < 0) {
+      const start = findUnitsArrayStart(this.buffer);
+      if (start < 0) return [];
+      this.unitsArrayStart = start;
+      this.scanPos = start;
+    }
+
+    const emitted: ReviewUnit[] = [];
+
+    while (this.scanPos < this.buffer.length) {
+      // Skip whitespace and commas between array elements.
+      const next = skipWsAndCommas(this.buffer, this.scanPos);
+      if (next >= this.buffer.length) {
+        this.scanPos = next;
+        break;
+      }
+
+      const ch = this.buffer[next];
+      if (ch === "]") {
+        // End of units array.
+        this.scanPos = next + 1;
+        break;
+      }
+
+      if (ch !== "{") {
+        // Unexpected token — advance one char to avoid infinite loop.
+        this.scanPos = next + 1;
+        continue;
+      }
+
+      const end = findMatchingBrace(this.buffer, next);
+      if (end < 0) {
+        // Incomplete object — wait for more text.
+        this.scanPos = next;
+        break;
+      }
+
+      const slice = this.buffer.slice(next, end + 1);
+      this.scanPos = end + 1;
+
+      try {
+        const value: unknown = JSON.parse(slice);
+        if (isCompleteReviewUnit(value)) {
+          emitted.push(value);
+          this.emittedCount++;
+        }
+      } catch {
+        // Malformed complete-looking object; skip it.
+      }
+    }
+
+    return emitted;
+  }
+}
+
+/** Locate the `[` that opens the top-level `"units"` array. */
+function findUnitsArrayStart(text: string): number {
+  // Match "units" then optional whitespace/colon/whitespace then [
+  const re = /"units"\s*:\s*\[/;
+  const match = re.exec(text);
+  if (!match) return -1;
+  return match.index + match[0].length - 1; // index of '['
+}
+
+function skipWsAndCommas(text: string, start: number): number {
+  let i = start;
+  while (i < text.length) {
+    const c = text[i];
+    if (c === " " || c === "\t" || c === "\n" || c === "\r" || c === ",") {
+      i++;
+      continue;
+    }
+    break;
+  }
+  return i;
+}
+
+/**
+ * Find the index of the `}` that closes the object starting at `openBrace`.
+ * String-aware (handles escapes). Returns -1 if the object is incomplete.
+ */
+function findMatchingBrace(text: string, openBrace: number): number {
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+
+  for (let i = openBrace; i < text.length; i++) {
+    const c = text[i];
+
+    if (inString) {
+      if (escape) {
+        escape = false;
+        continue;
+      }
+      if (c === "\\") {
+        escape = true;
+        continue;
+      }
+      if (c === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (c === '"') {
+      inString = true;
+      continue;
+    }
+    if (c === "{") {
+      depth++;
+      continue;
+    }
+    if (c === "}") {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+
+  return -1;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -101,17 +101,30 @@ export const DEFAULT_MODELS: Record<ProviderId, string> = {
 
 // ---- Messaging protocol (content <-> background) -----------------------------
 
+/** First message on the `annotate-review` port from content → background. */
 export interface AnnotateReviewRequest {
   type: "ANNOTATE_REVIEW";
   diff: ParsedDiff;
   prContext: PRContext;
 }
 
+/**
+ * Progressive events on the `annotate-review` port from background → content.
+ * Complete, validated units are pushed as they become available; DONE carries
+ * the final merged plan; ERROR ends the stream with a user-safe message.
+ */
+export type AnnotateReviewStreamEvent =
+  | { type: "UNIT"; unit: ReviewUnit }
+  | { type: "DONE"; plan: ReviewPlan }
+  | { type: "ERROR"; error: string };
+
+/** @deprecated Prefer stream events; kept for type compatibility in older tests. */
 export interface AnnotateReviewResponse {
   ok: true;
   plan: ReviewPlan;
 }
 
+/** @deprecated Prefer stream events; kept for type compatibility in older tests. */
 export interface AnnotateReviewError {
   ok: false;
   error: string;
@@ -142,4 +155,5 @@ export interface FetchDiffError {
   error: string;
 }
 
-export type BackgroundRequest = AnnotateReviewRequest | TestConnectionRequest | FetchDiffRequest;
+/** One-shot request/response messages (annotate uses a port instead). */
+export type BackgroundRequest = TestConnectionRequest | FetchDiffRequest;

--- a/src/test/chromeMock.ts
+++ b/src/test/chromeMock.ts
@@ -40,6 +40,53 @@ export function createChromeMock() {
     (message: unknown, sender: unknown, sendResponse: (response?: unknown) => void) => boolean | void
   >();
 
+  const onConnectListeners = new Set<(port: MockPort) => void>();
+
+  function createPort(name: string): MockPort {
+    const onMessage = new Set<(message: unknown) => void>();
+    const onDisconnect = new Set<() => void>();
+    let disconnected = false;
+
+    const port: MockPort = {
+      name,
+      // Outbound only — does not fan into local onMessage listeners (those are remote events).
+      postMessage: vi.fn((_message: unknown) => {}),
+      disconnect: vi.fn(() => {
+        if (disconnected) return;
+        disconnected = true;
+        for (const listener of onDisconnect) listener();
+      }),
+      onMessage: {
+        addListener: vi.fn((listener: (message: unknown) => void) => {
+          onMessage.add(listener);
+        }),
+        removeListener: vi.fn((listener: (message: unknown) => void) => {
+          onMessage.delete(listener);
+        }),
+      },
+      onDisconnect: {
+        addListener: vi.fn((listener: () => void) => {
+          onDisconnect.add(listener);
+        }),
+        removeListener: vi.fn((listener: () => void) => {
+          onDisconnect.delete(listener);
+        }),
+      },
+      /** Test helper: deliver a remote message to this port's onMessage listeners. */
+      __emitMessage(message: unknown) {
+        for (const listener of onMessage) listener(message);
+      },
+      /** Test helper: fire disconnect listeners. */
+      __emitDisconnect() {
+        if (disconnected) return;
+        disconnected = true;
+        for (const listener of onDisconnect) listener();
+      },
+    };
+
+    return port;
+  }
+
   return {
     storage: {
       local: createStorageArea(),
@@ -47,8 +94,14 @@ export function createChromeMock() {
     },
     runtime: {
       sendMessage: vi.fn(async (_message: unknown) => undefined),
+      connect: vi.fn((info?: { name?: string }) => {
+        const port = createPort(info?.name ?? "");
+        for (const listener of onConnectListeners) listener(port);
+        return port;
+      }),
       getURL: vi.fn((path: string) => path),
       openOptionsPage: vi.fn(),
+      lastError: undefined as { message?: string } | undefined,
       onMessage: {
         addListener: vi.fn((listener: (typeof onMessageListeners extends Set<infer L> ? L : never)) => {
           onMessageListeners.add(listener);
@@ -58,6 +111,15 @@ export function createChromeMock() {
         }),
         __listeners: onMessageListeners,
       },
+      onConnect: {
+        addListener: vi.fn((listener: (port: MockPort) => void) => {
+          onConnectListeners.add(listener);
+        }),
+        removeListener: vi.fn((listener: (port: MockPort) => void) => {
+          onConnectListeners.delete(listener);
+        }),
+        __listeners: onConnectListeners,
+      },
     },
     action: {
       onClicked: {
@@ -65,6 +127,22 @@ export function createChromeMock() {
       },
     },
   };
+}
+
+export interface MockPort {
+  name: string;
+  postMessage: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+  onMessage: {
+    addListener: ReturnType<typeof vi.fn>;
+    removeListener: ReturnType<typeof vi.fn>;
+  };
+  onDisconnect: {
+    addListener: ReturnType<typeof vi.fn>;
+    removeListener: ReturnType<typeof vi.fn>;
+  };
+  __emitMessage: (message: unknown) => void;
+  __emitDisconnect: () => void;
 }
 
 export type ChromeMock = ReturnType<typeof createChromeMock>;


### PR DESCRIPTION
## Summary
- Stream LLM review-plan generation instead of waiting for a full response, so units can appear in the overlay as they complete.
- Add SSE parsing for Anthropic and OpenAI-compatible providers, plus an incremental JSON plan parser that emits complete review units as the stream progresses.
- Wire streaming through background messaging into the content-script store/UI, with tests covering the parser, messaging, store, and overlay behavior.

## Test plan
- [ ] `npm test` and `npm run typecheck` pass
- [ ] `npm run build` and load `dist/` as an unpacked extension
- [ ] Start a guided review on a real GitHub PR and confirm units appear progressively while the plan is still generating
- [ ] Confirm a completed review still persists/restores correctly across overlay reopen
- [ ] Smoke-test Anthropic and OpenAI/Grok providers if keys are available