### PR TITLE
Add GitHub Actions CI for unit and e2e tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Run unit tests
+        run: npm test
+
+  e2e:
+    name: End-to-end tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npm run test:e2e:install
+
+      - name: Run e2e tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow (`.github/workflows/tests.yml`) that runs on pushes and pull requests to `main`.
- **Unit** job: install deps, typecheck, and run Vitest unit tests.
- **E2E** job: install deps, install Playwright Chromium, run the e2e suite, and upload the Playwright report on failure.

## Test plan
- [ ] Confirm the workflow runs on this PR
- [ ] Verify the unit job passes (typecheck + `npm test`)
- [ ] Verify the e2e job passes (`npm run test:e2e`)
- [ ] On a forced failure, confirm the Playwright report artifact is uploaded