### PR TITLE
refactor: stabilize session keys and clean stream-era debt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,30 +66,37 @@ calls with typed helpers.
 2. `src/lib/review/buildPrompt.ts` — renders a `ParsedDiff` into LLM-readable text with hunk ids annotated,
    and chunks large diffs by file (`chunkDiffByFile`, ~60k chars/chunk, never splits a file's hunks across
    chunks) so no single call blows the model's context.
-3. `src/background/providers/*` — one call to `annotateReview` per chunk, against whichever provider is
-   configured. All providers share `REVIEW_PLAN_JSON_SCHEMA` (`src/lib/review/reviewSchema.ts`) so
-   structured-output behavior is identical across Anthropic/OpenAI-compatible backends.
-   `providers/openaiCompatible.ts` is a factory used for both OpenAI and Grok since they share the same
-   API shape; `providers/anthropic.ts` is bespoke.
-4. `src/lib/review/reviewPlan.ts` — **never trust the model's output as-is**. `validateAndCleanPlan`
-   strips any `fileId`/`hunkId` the model referenced that doesn't actually exist in the diff it was given
-   (a hallucinated reference must never surface as a broken step in the UI); `mergePlans` stitches
-   per-chunk plans back together with chunk-prefixed ids so units never collide.
-5. The overlay (`src/content/overlay/`, state in `store.ts` via Zustand) renders `ReviewPlan.units` in
-   order, resolving each unit's `fileId`/`hunkId` refs back against the *real* parsed diff — the LLM plans
-   structure and commentary only; it never supplies the code shown to the reviewer.
+3. `src/background/providers/*` — one streaming call to `annotateReviewStream` per chunk, against
+   whichever provider is configured. All providers share `REVIEW_PLAN_JSON_SCHEMA`
+   (`src/lib/review/reviewSchema.ts`) so structured-output behavior is identical across
+   Anthropic/OpenAI-compatible backends. `providers/openaiCompatible.ts` is a factory used for both
+   OpenAI and Grok since they share the same API shape; `providers/anthropic.ts` is bespoke.
+   Shared HTTP helpers live in `providers/http.ts`.
+4. Streaming assembly (`src/background/index.ts` + `src/lib/review/streamPlanParser.ts` +
+   `src/lib/review/reviewPlan.ts`) — as text deltas arrive, `StreamPlanParser` extracts complete
+   units; each is validated with `validateAndCleanUnit` against the chunk's real file/hunk ids
+   (hallucinated refs are dropped, never shown). Unit ids are namespaced with `prefixChunkUnitId`
+   so multi-chunk plans never collide. Progressive `UNIT` events go to the content script; `DONE`
+   carries the final merged plan. (`validateAndCleanPlan` / `mergePlans` remain as batch helpers
+   for tests and non-stream callers.)
+5. The overlay (`src/content/overlay/`, state in `store.ts` via Zustand) renders display units
+   (`displayUnits.ts`: synthetic PR description first, then `ReviewPlan.units`) in order, resolving
+   each unit's `fileId`/`hunkId` refs back against the *real* parsed diff — the LLM plans structure
+   and commentary only; it never supplies the code shown to the reviewer.
 
 ### Session persistence
 
 Review sessions (diff + plan + PR context + current step) are persisted to `chrome.storage.session`,
-keyed by PR URL, so reopening the overlay on the same PR resumes without a new AI call
-(`persistSession`/`restoreSession` in `store.ts`). Content scripts are normally blocked from
+keyed by a **canonical PR identity** (`owner/repo#number` via `buildSessionKey` in `store.ts`) —
+not the full browser URL — so resume works across Conversation / Files changed / Commits tabs.
+`persistSession` reads the active `sessionKey` from the store (set on `startLoading`), so SPA
+navigation to another PR cannot write under a stale key. Content scripts are normally blocked from
 `chrome.storage.session`; the background worker explicitly grants
 `TRUSTED_AND_UNTRUSTED_CONTEXTS` access on startup for this to work.
 
 ### Provider abstraction
 
-`src/background/providers/types.ts` defines the `ProviderClient` interface (`annotateReview`,
+`src/background/providers/types.ts` defines the `ProviderClient` interface (`annotateReviewStream`,
 `testConnection`) and `ProviderError` (message is safe to show directly to the user).
 `src/background/providers/index.ts` is the factory keyed by `ProviderId` (`"anthropic" | "openai" |
 "grok"`). Adding a new provider means implementing `ProviderClient` and registering it there — everything

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -14,7 +14,7 @@ import type {
 import { fetchPRDiff } from "../lib/github/diffFetch";
 import { chunkDiffByFile } from "../lib/review/buildPrompt";
 import { StreamPlanParser } from "../lib/review/streamPlanParser";
-import { validateAndCleanUnit } from "../lib/review/reviewPlan";
+import { prefixChunkUnitId, validateAndCleanUnit } from "../lib/review/reviewPlan";
 import { getProviderSettings } from "../lib/settings";
 import { getProviderClient } from "./providers";
 import { ProviderError } from "./providers/types";
@@ -109,7 +109,6 @@ async function handleAnnotateReviewStream(
     if (signal.aborted) return;
 
     const parser = new StreamPlanParser();
-    const prefix = `c${chunkIndex}-`;
     const knownFiles = new Map(chunk.files.map((f) => [f.path, f]));
 
     for await (const event of client.annotateReviewStream(
@@ -121,14 +120,14 @@ async function handleAnnotateReviewStream(
       if (event.type === "text_delta") {
         const rawUnits = parser.push(event.text);
         for (const raw of rawUnits) {
-          emitUnit(raw, knownFiles, prefix, allUnits, port, signal);
+          emitUnit(raw, knownFiles, chunkIndex, allUnits, port, signal);
         }
       }
 
       if (event.type === "done") {
         const remaining = parser.finish();
         for (const raw of remaining) {
-          emitUnit(raw, knownFiles, prefix, allUnits, port, signal);
+          emitUnit(raw, knownFiles, chunkIndex, allUnits, port, signal);
         }
       }
     }
@@ -145,7 +144,7 @@ async function handleAnnotateReviewStream(
 function emitUnit(
   raw: ReviewUnit,
   knownFiles: Map<string, DiffFile>,
-  prefix: string,
+  chunkIndex: number,
   allUnits: ReviewUnit[],
   port: chrome.runtime.Port,
   signal: AbortSignal,
@@ -155,7 +154,7 @@ function emitUnit(
   const cleaned = validateAndCleanUnit(raw, knownFiles);
   if (!cleaned) return;
 
-  const unit: ReviewUnit = { ...cleaned, id: `${prefix}${cleaned.id}` };
+  const unit: ReviewUnit = { ...cleaned, id: prefixChunkUnitId(chunkIndex, cleaned.id) };
   allUnits.push(unit);
   postEvent(port, { type: "UNIT", unit });
 }

--- a/src/background/providers/anthropic.ts
+++ b/src/background/providers/anthropic.ts
@@ -1,6 +1,7 @@
 import type { ProviderSettings } from "../../lib/types";
 import { buildUserPrompt, SYSTEM_PROMPT } from "../../lib/review/buildPrompt";
 import { REVIEW_PLAN_JSON_SCHEMA } from "../../lib/review/reviewSchema";
+import { isAbortError, safeErrorDetail } from "./http";
 import { readSseJsonStream } from "./sse";
 import type { AnnotateReviewInput, AnnotateStreamEvent, ProviderClient } from "./types";
 import { ProviderError } from "./types";
@@ -61,6 +62,8 @@ export const anthropicProvider: ProviderClient = {
       throw new ProviderError("Claude returned an empty stream.");
     }
 
+    let sawContent = false;
+
     for await (const event of readSseJsonStream(response.body, { signal: options?.signal })) {
       if (!event || typeof event !== "object") continue;
       const ev = event as {
@@ -74,12 +77,17 @@ export const anthropicProvider: ProviderClient = {
       }
 
       if (ev.type === "content_block_delta" && ev.delta?.type === "text_delta" && ev.delta.text) {
+        sawContent = true;
         yield { type: "text_delta", text: ev.delta.text };
       }
 
       if (ev.type === "message_delta" && ev.delta?.stop_reason === "refusal") {
         throw new ProviderError("Claude declined to annotate this diff.");
       }
+    }
+
+    if (!sawContent) {
+      throw new ProviderError("Claude returned no content for this diff.");
     }
 
     yield { type: "done" };
@@ -107,16 +115,3 @@ export const anthropicProvider: ProviderClient = {
     }
   },
 };
-
-async function safeErrorDetail(response: Response): Promise<string> {
-  try {
-    const data = await response.json();
-    return data?.error?.message ?? response.statusText;
-  } catch {
-    return response.statusText;
-  }
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof DOMException && error.name === "AbortError";
-}

--- a/src/background/providers/http.ts
+++ b/src/background/providers/http.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared fetch/error helpers for provider HTTP clients.
+ */
+
+/** Extract a user-safe error message from a failed provider HTTP response. */
+export async function safeErrorDetail(response: Response): Promise<string> {
+  try {
+    const data = await response.json();
+    return data?.error?.message ?? response.statusText;
+  } catch {
+    return response.statusText;
+  }
+}
+
+export function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}

--- a/src/background/providers/openaiCompatible.ts
+++ b/src/background/providers/openaiCompatible.ts
@@ -1,6 +1,7 @@
 import type { ProviderSettings } from "../../lib/types";
 import { buildUserPrompt, SYSTEM_PROMPT } from "../../lib/review/buildPrompt";
 import { REVIEW_PLAN_JSON_SCHEMA } from "../../lib/review/reviewSchema";
+import { isAbortError, safeErrorDetail } from "./http";
 import { readSseJsonStream } from "./sse";
 import type { AnnotateReviewInput, AnnotateStreamEvent, ProviderClient } from "./types";
 import { ProviderError } from "./types";
@@ -111,17 +112,4 @@ export function createOpenAICompatibleProvider(baseUrl: string, displayName: str
       }
     },
   };
-}
-
-async function safeErrorDetail(response: Response): Promise<string> {
-  try {
-    const data = await response.json();
-    return data?.error?.message ?? response.statusText;
-  } catch {
-    return response.statusText;
-  }
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof DOMException && error.name === "AbortError";
 }

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -4,7 +4,7 @@ import { fetchConversationDescription, scrapePRContext } from "../lib/github/prC
 import { requestPRDiff, streamReviewPlan } from "../lib/messaging";
 import { Overlay } from "./overlay/Overlay";
 import overlayStyles from "./overlay/styles/overlay.css?inline";
-import { useReviewStore, restoreSession } from "./overlay/store";
+import { useReviewStore, restoreSession, buildSessionKey } from "./overlay/store";
 
 const BUTTON_ID = "guided-review-start-btn";
 const HOST_ID = "guided-review-overlay-host";
@@ -113,9 +113,9 @@ function cancelActiveStream(): void {
 async function onStartReview(): Promise<void> {
   if (!currentPR) return;
   const pr = currentPR;
-  const prUrl = window.location.href;
+  const sessionKey = buildSessionKey(pr);
 
-  ensureOverlayMounted(prUrl);
+  ensureOverlayMounted();
   cancelActiveStream();
 
   // Scrape PR metadata first so the overlay can render the full layout with the
@@ -123,11 +123,11 @@ async function onStartReview(): Promise<void> {
   const prContext = scrapePRContext(pr);
   useReviewStore.getState().open();
   useReviewStore.getState().setPRContext(prContext);
-  useReviewStore.getState().startLoading();
+  useReviewStore.getState().startLoading(sessionKey);
   const streamGeneration = useReviewStore.getState().streamGeneration;
 
   try {
-    const restored = await restoreSession(prUrl);
+    const restored = await restoreSession(sessionKey);
     if (restored) return;
 
     // The description only exists in the DOM on GitHub's "Conversation" tab
@@ -180,7 +180,7 @@ async function onStartReview(): Promise<void> {
 
 let overlayMounted = false;
 
-function ensureOverlayMounted(prUrl: string): void {
+function ensureOverlayMounted(): void {
   if (overlayMounted) return;
   overlayMounted = true;
 
@@ -197,5 +197,7 @@ function ensureOverlayMounted(prUrl: string): void {
   const appRoot = document.createElement("div");
   shadowRoot.appendChild(appRoot);
 
-  createRoot(appRoot).render(<Overlay prUrl={prUrl} onRequestClose={cancelActiveStream} />);
+  // Overlay reads the active session key from the store, so SPA navigation to
+  // another PR never leaves a stale prUrl prop from the first mount.
+  createRoot(appRoot).render(<Overlay onRequestClose={cancelActiveStream} />);
 }

--- a/src/content/overlay/Overlay.test.tsx
+++ b/src/content/overlay/Overlay.test.tsx
@@ -5,8 +5,6 @@ import { useReviewStore } from "./store";
 import { PR_DESCRIPTION_UNIT_TITLE } from "./displayUnits";
 import type { ParsedDiff, PRContext, ReviewPlan } from "../../lib/types";
 
-const PR_URL = "https://github.com/acme/widgets/pull/1";
-
 function diffFixture(): ParsedDiff {
   return {
     files: [
@@ -48,7 +46,7 @@ function prContextFixture(overrides: Partial<PRContext> = {}): PRContext {
     owner: "acme",
     repo: "widgets",
     number: 1,
-    url: PR_URL,
+    url: "https://github.com/acme/widgets/pull/1",
     title: "Add feature",
     description: "This PR adds a feature.",
     descriptionHtml: "<p>This PR adds a feature.</p>",
@@ -69,6 +67,7 @@ function resetStore(): void {
     prContext: null,
     currentUnitIndex: 0,
     streamGeneration: 0,
+    sessionKey: null,
   });
 }
 
@@ -80,7 +79,7 @@ describe("Overlay", () => {
   });
 
   it("renders nothing when the review isn't open", () => {
-    const { container } = render(<Overlay prUrl={PR_URL} />);
+    const { container } = render(<Overlay />);
     expect(container).toBeEmptyDOMElement();
   });
 
@@ -91,7 +90,7 @@ describe("Overlay", () => {
       prContext: prContextFixture(),
       currentUnitIndex: 0,
     });
-    render(<Overlay prUrl={PR_URL} />);
+    render(<Overlay />);
 
     // Title in left pane + entry in the unit list.
     expect(screen.getAllByText(PR_DESCRIPTION_UNIT_TITLE).length).toBeGreaterThanOrEqual(1);
@@ -116,7 +115,7 @@ describe("Overlay", () => {
       prContext: prContextFixture(),
       currentUnitIndex: 0,
     });
-    render(<Overlay prUrl={PR_URL} />);
+    render(<Overlay />);
 
     expect(screen.getByLabelText(/diff summary/i)).toBeInTheDocument();
     expect(screen.getByText("src/foo.ts")).toBeInTheDocument();
@@ -134,7 +133,7 @@ describe("Overlay", () => {
       prContext: prContextFixture(),
       currentUnitIndex: 0,
     });
-    render(<Overlay prUrl={PR_URL} />);
+    render(<Overlay />);
 
     expect(screen.getByText("Update foo")).toBeInTheDocument();
     expect(screen.getAllByTestId("unit-skeleton").length).toBeGreaterThan(0);
@@ -150,7 +149,7 @@ describe("Overlay", () => {
       prContext: prContextFixture(),
       currentUnitIndex: 1,
     });
-    render(<Overlay prUrl={PR_URL} />);
+    render(<Overlay />);
 
     expect(screen.getByText("because it needed updating")).toBeInTheDocument();
     expect(screen.queryByText(/building the rest of the walkthrough/i)).not.toBeInTheDocument();
@@ -165,7 +164,7 @@ describe("Overlay", () => {
       prContext: prContextFixture(),
       currentUnitIndex: 0,
     });
-    render(<Overlay prUrl={PR_URL} />);
+    render(<Overlay />);
 
     expect(screen.getByLabelText(/keyboard shortcuts/i)).toBeInTheDocument();
     expect(screen.getByText(/previous \/ next step/i)).toBeInTheDocument();
@@ -182,7 +181,7 @@ describe("Overlay", () => {
       prContext: prContextFixture(),
       currentUnitIndex: 0,
     });
-    render(<Overlay prUrl={PR_URL} />);
+    render(<Overlay />);
     expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
     expect(screen.getByText("Network error")).toBeInTheDocument();
     expect(screen.getAllByText(PR_DESCRIPTION_UNIT_TITLE).length).toBeGreaterThanOrEqual(1);
@@ -198,7 +197,7 @@ describe("Overlay", () => {
       prContext: prContextFixture(),
       currentUnitIndex: 0,
     });
-    render(<Overlay prUrl={PR_URL} />);
+    render(<Overlay />);
     expect(screen.getAllByText(PR_DESCRIPTION_UNIT_TITLE).length).toBeGreaterThanOrEqual(1);
     expect(screen.queryByText(/no review units were generated/i)).not.toBeInTheDocument();
   });
@@ -212,7 +211,7 @@ describe("Overlay", () => {
       prContext: prContextFixture(),
       currentUnitIndex: 1,
     });
-    render(<Overlay prUrl={PR_URL} />);
+    render(<Overlay />);
     expect(screen.getAllByText(PR_DESCRIPTION_UNIT_TITLE).length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("Update foo")).toBeInTheDocument();
     expect(screen.getByText("because it needed updating")).toBeInTheDocument();
@@ -227,7 +226,7 @@ describe("Overlay", () => {
       prContext: prContextFixture(),
       currentUnitIndex: 0,
     });
-    render(<Overlay prUrl={PR_URL} />);
+    render(<Overlay />);
     // Description lives in the left pane, not a header <details>.
     expect(screen.queryByRole("heading", { name: /pr description/i })).toBeInTheDocument();
     expect(screen.getByTestId("description-pane")).toBeInTheDocument();
@@ -242,7 +241,7 @@ describe("Overlay", () => {
       prContext: prContextFixture(),
       currentUnitIndex: 0,
     });
-    render(<Overlay prUrl={PR_URL} />);
+    render(<Overlay />);
     expect(
       screen.getByText(/read the author's intent before walking the code/i)
     ).toBeInTheDocument();
@@ -257,7 +256,7 @@ describe("Overlay", () => {
       prContext: prContextFixture({ description: "", descriptionHtml: "" }),
       currentUnitIndex: 0,
     });
-    render(<Overlay prUrl={PR_URL} />);
+    render(<Overlay />);
 
     // Left pane empty state + right pane context both mention the gap.
     expect(screen.getByTestId("description-pane-empty").textContent).toMatch(
@@ -278,7 +277,7 @@ describe("Overlay", () => {
       prContext: prContextFixture({ title: "", description: "", descriptionHtml: "" }),
       currentUnitIndex: 0,
     });
-    render(<Overlay prUrl={PR_URL} />);
+    render(<Overlay />);
 
     expect(screen.getByTestId("description-pane-empty").textContent).toMatch(
       /author hasn't added a PR title or description/i
@@ -300,7 +299,7 @@ describe("Overlay", () => {
       prContext: prContextFixture(),
       currentUnitIndex: 0,
     });
-    render(<Overlay prUrl={PR_URL} />);
+    render(<Overlay />);
 
     expect(screen.getByTestId("code-col")).toBeInTheDocument();
     expect(screen.getByTestId("context-pane")).toBeInTheDocument();

--- a/src/content/overlay/Overlay.tsx
+++ b/src/content/overlay/Overlay.tsx
@@ -10,12 +10,11 @@ import { ContextPanel } from "./components/ContextPanel";
 import { FooterNav } from "./components/FooterNav";
 
 interface OverlayProps {
-  prUrl: string;
   /** Invoked when the user exits so any in-flight stream can be cancelled. */
   onRequestClose?: () => void;
 }
 
-export function Overlay({ prUrl, onRequestClose }: OverlayProps) {
+export function Overlay({ onRequestClose }: OverlayProps) {
   const isOpen = useReviewStore((s) => s.isOpen);
   const status = useReviewStore((s) => s.status);
   const error = useReviewStore((s) => s.error);
@@ -23,6 +22,7 @@ export function Overlay({ prUrl, onRequestClose }: OverlayProps) {
   const plan = useReviewStore((s) => s.plan);
   const prContext = useReviewStore((s) => s.prContext);
   const currentUnitIndex = useReviewStore((s) => s.currentUnitIndex);
+  const sessionKey = useReviewStore((s) => s.sessionKey);
   const close = useReviewStore((s) => s.close);
   const goToUnit = useReviewStore((s) => s.goToUnit);
   const goNext = useReviewStore((s) => s.goNext);
@@ -36,8 +36,8 @@ export function Overlay({ prUrl, onRequestClose }: OverlayProps) {
   };
 
   useEffect(() => {
-    if (status === "ready") void persistSession(prUrl);
-  }, [prUrl, status, currentUnitIndex]);
+    if (status === "ready") void persistSession();
+  }, [status, currentUnitIndex, sessionKey]);
 
   // When the active unit changes (keyboard ←/→, footer nav, or sidebar click),
   // reset the code and context panes so the new step starts at the top rather
@@ -107,9 +107,9 @@ export function Overlay({ prUrl, onRequestClose }: OverlayProps) {
 
   if (!isOpen) return null;
 
-  const stillBuilding = status === "loading" || status === "streaming" || status === "idle";
+  const planStillBuilding = status === "loading" || status === "streaming";
   // Spinner on the description unit only while the plan is still being built.
-  const showBuildingSpinner = stillBuilding && (!plan || currentUnitIndex === 0);
+  const showBuildingSpinner = planStillBuilding && (!plan || currentUnitIndex === 0);
   const displayUnits = buildDisplayUnits(plan);
   const total = displayUnitCount(plan);
   const totalKnown = status === "ready";
@@ -165,7 +165,7 @@ export function Overlay({ prUrl, onRequestClose }: OverlayProps) {
           <Sidebar
             plan={plan}
             currentUnitIndex={currentUnitIndex}
-            stillBuilding={stillBuilding}
+            stillBuilding={planStillBuilding}
             onSelectUnit={goToUnit}
           />
         </aside>

--- a/src/content/overlay/components/ContextPanel.tsx
+++ b/src/content/overlay/components/ContextPanel.tsx
@@ -1,9 +1,9 @@
 import type { ReviewUnit } from "../../../lib/types";
 import { KeyboardShortcuts } from "./KeyboardShortcuts";
 import { Spinner } from "./Spinner";
+import { missingMetadataHint, PR_DESCRIPTION_HINT } from "../missingMetadata";
 
-const PR_DESCRIPTION_HINT =
-  "Read the author's intent before walking the code. This is always the first step of a guided review.";
+export { missingMetadataHint, PR_DESCRIPTION_HINT } from "../missingMetadata";
 
 interface ContextPanelProps {
   /** When null, the synthetic PR-description unit is active. */
@@ -14,23 +14,6 @@ interface ContextPanelProps {
   hasDescription?: boolean;
   error?: string | null;
   loading?: boolean;
-}
-
-/**
- * Right-pane copy for the synthetic PR-description unit when the author left
- * title and/or description blank — the AI has to infer intent from the diff.
- */
-export function missingMetadataHint(hasTitle: boolean, hasDescription: boolean): string {
-  if (!hasTitle && !hasDescription) {
-    return "The author hasn't added a PR title or description. We'll rely on the AI to tell us what this PR is about from the diff.";
-  }
-  if (!hasDescription) {
-    return "The author hasn't added a PR description. We'll rely on the AI to tell us what this PR is about from the diff.";
-  }
-  if (!hasTitle) {
-    return "The author hasn't added a PR title. We'll rely on the AI to fill in the intent from the description and the diff.";
-  }
-  return PR_DESCRIPTION_HINT;
 }
 
 export function ContextPanel({

--- a/src/content/overlay/components/DescriptionPane.tsx
+++ b/src/content/overlay/components/DescriptionPane.tsx
@@ -1,6 +1,7 @@
 import type { FileChangeStatus, ParsedDiff, PRContext } from "../../../lib/types";
 import { summarizeDiff, type FileDiffSummary } from "../../../lib/github/diffSummary";
 import { cn } from "../../../lib/cn";
+import { emptyDescriptionCopy } from "../missingMetadata";
 
 interface DescriptionPaneProps {
   prContext: PRContext | null;
@@ -137,11 +138,4 @@ function DiffSummaryFileRow({ file }: { file: FileDiffSummary }) {
 
 function fileKey(file: FileDiffSummary): string {
   return file.previousPath ? `${file.previousPath}→${file.path}` : file.path;
-}
-
-function emptyDescriptionCopy(hasTitle: boolean): string {
-  if (!hasTitle) {
-    return "The author hasn't added a PR title or description. The AI will infer what this PR is about from the diff.";
-  }
-  return "The author hasn't added a PR description. The AI will infer what this PR is about from the diff.";
 }

--- a/src/content/overlay/components/Sidebar.tsx
+++ b/src/content/overlay/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react";
 import type { ReviewPlan } from "../../../lib/types";
 import { cn } from "../../../lib/cn";
-import { PR_DESCRIPTION_UNIT_TITLE } from "../displayUnits";
+import { buildDisplayUnits } from "../displayUnits";
 
 const SKELETON_COUNT = 4;
 
@@ -19,7 +19,7 @@ export function Sidebar({
   stillBuilding,
   onSelectUnit,
 }: SidebarProps) {
-  const reviewUnits = plan?.units ?? [];
+  const displayUnits = buildDisplayUnits(plan);
   const activeItemRef = useRef<HTMLButtonElement>(null);
 
   // Keep the active unit visible when navigating via keyboard (←/→) or footer
@@ -41,23 +41,7 @@ export function Sidebar({
         Review units
       </div>
 
-      <button
-        type="button"
-        ref={currentUnitIndex === 0 ? activeItemRef : undefined}
-        aria-current={currentUnitIndex === 0 ? "true" : undefined}
-        className={cn(
-          "mb-0.5 block w-full cursor-pointer rounded-md border-none bg-transparent p-2 text-left text-[13px] leading-snug text-gr-text hover:bg-gr-subtle",
-          currentUnitIndex === 0 &&
-            "bg-gr-accent-subtle font-semibold text-gr-accent hover:bg-gr-accent-subtle"
-        )}
-        onClick={() => onSelectUnit(0)}
-      >
-        <span className="mr-1.5 text-gr-muted">1.</span>
-        {PR_DESCRIPTION_UNIT_TITLE}
-      </button>
-
-      {reviewUnits.map((unit, planIndex) => {
-        const displayIndex = planIndex + 1;
+      {displayUnits.map((unit, displayIndex) => {
         const isActive = displayIndex === currentUnitIndex;
         return (
           <button

--- a/src/content/overlay/missingMetadata.test.ts
+++ b/src/content/overlay/missingMetadata.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { emptyDescriptionCopy, missingMetadataHint, PR_DESCRIPTION_HINT } from "./missingMetadata";
+
+describe("missingMetadataHint", () => {
+  it("mentions both title and description when neither is present", () => {
+    expect(missingMetadataHint(false, false)).toMatch(/title or description/i);
+    expect(missingMetadataHint(false, false)).toMatch(/AI/i);
+  });
+
+  it("mentions only description when the title is present", () => {
+    const hint = missingMetadataHint(true, false);
+    expect(hint).toMatch(/description/i);
+    expect(hint).not.toMatch(/title/i);
+    expect(hint).toMatch(/AI/i);
+  });
+
+  it("mentions only title when the description is present", () => {
+    const hint = missingMetadataHint(false, true);
+    expect(hint).toMatch(/title/i);
+    expect(hint).toMatch(/AI/i);
+  });
+
+  it("returns the default PR description hint when both are present", () => {
+    expect(missingMetadataHint(true, true)).toBe(PR_DESCRIPTION_HINT);
+  });
+});
+
+describe("emptyDescriptionCopy", () => {
+  it("mentions title and description when the title is missing", () => {
+    expect(emptyDescriptionCopy(false)).toMatch(/title or description/i);
+  });
+
+  it("mentions only description when the title is present", () => {
+    const copy = emptyDescriptionCopy(true);
+    expect(copy).toMatch(/description/i);
+    expect(copy).not.toMatch(/title/i);
+  });
+});

--- a/src/content/overlay/missingMetadata.ts
+++ b/src/content/overlay/missingMetadata.ts
@@ -1,0 +1,29 @@
+/** Default right-pane copy when the PR has both a title and a description. */
+export const PR_DESCRIPTION_HINT =
+  "Read the author's intent before walking the code. This is always the first step of a guided review.";
+
+/**
+ * User-facing copy when the PR is missing a title and/or description.
+ * Shared by the left description pane and the right context panel so wording
+ * stays consistent.
+ */
+export function missingMetadataHint(hasTitle: boolean, hasDescription: boolean): string {
+  if (!hasTitle && !hasDescription) {
+    return "The author hasn't added a PR title or description. We'll rely on the AI to tell us what this PR is about from the diff.";
+  }
+  if (!hasDescription) {
+    return "The author hasn't added a PR description. We'll rely on the AI to tell us what this PR is about from the diff.";
+  }
+  if (!hasTitle) {
+    return "The author hasn't added a PR title. We'll rely on the AI to fill in the intent from the description and the diff.";
+  }
+  return PR_DESCRIPTION_HINT;
+}
+
+/** Left-pane empty-state copy when there is no description body to render. */
+export function emptyDescriptionCopy(hasTitle: boolean): string {
+  if (!hasTitle) {
+    return "The author hasn't added a PR title or description. The AI will infer what this PR is about from the diff.";
+  }
+  return "The author hasn't added a PR description. The AI will infer what this PR is about from the diff.";
+}

--- a/src/content/overlay/store.test.ts
+++ b/src/content/overlay/store.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { useReviewStore, persistSession, restoreSession } from "./store";
+import {
+  useReviewStore,
+  persistSession,
+  restoreSession,
+  buildSessionKey,
+} from "./store";
 import type { ParsedDiff, PRContext, ReviewPlan } from "../../lib/types";
 
 function diffFixture(): ParsedDiff {
@@ -32,6 +37,9 @@ function prContextFixture(): PRContext {
   };
 }
 
+const SESSION_KEY = buildSessionKey({ owner: "acme", repo: "widgets", number: 1 });
+const STORAGE_KEY = `guidedReview.session.${SESSION_KEY}`;
+
 function resetStore(): void {
   useReviewStore.setState({
     isOpen: false,
@@ -42,8 +50,19 @@ function resetStore(): void {
     prContext: null,
     currentUnitIndex: 0,
     streamGeneration: 0,
+    sessionKey: null,
   });
 }
+
+describe("buildSessionKey", () => {
+  it("uses owner/repo#number and is independent of tab path", () => {
+    expect(buildSessionKey({ owner: "acme", repo: "widgets", number: 42 })).toBe(
+      "acme/widgets#42",
+    );
+    // Same identity whether the user is on Conversation or Files changed.
+    expect(buildSessionKey({ owner: "acme", repo: "widgets", number: 1 })).toBe(SESSION_KEY);
+  });
+});
 
 describe("useReviewStore", () => {
   it("open/close toggle isOpen", () => {
@@ -54,7 +73,7 @@ describe("useReviewStore", () => {
     expect(useReviewStore.getState().isOpen).toBe(false);
   });
 
-  it("startLoading sets status to loading, clears plan/diff/error, and resets unit index", () => {
+  it("startLoading sets status to loading, stores sessionKey, clears plan/diff/error, and resets unit index", () => {
     resetStore();
     useReviewStore.setState({
       error: "boom",
@@ -62,18 +81,19 @@ describe("useReviewStore", () => {
       diff: diffFixture(),
       currentUnitIndex: 2,
     });
-    useReviewStore.getState().startLoading();
+    useReviewStore.getState().startLoading(SESSION_KEY);
     const state = useReviewStore.getState();
     expect(state.status).toBe("loading");
     expect(state.error).toBeNull();
     expect(state.plan).toBeNull();
     expect(state.diff).toBeNull();
     expect(state.currentUnitIndex).toBe(0);
+    expect(state.sessionKey).toBe(SESSION_KEY);
   });
 
   it("setDiff stores the diff without changing status or plan", () => {
     resetStore();
-    useReviewStore.getState().startLoading();
+    useReviewStore.getState().startLoading(SESSION_KEY);
     const diff = diffFixture();
     useReviewStore.getState().setDiff(diff);
 
@@ -85,7 +105,7 @@ describe("useReviewStore", () => {
 
   it("beginStreaming and appendUnit grow the plan while streaming", () => {
     resetStore();
-    useReviewStore.getState().startLoading();
+    useReviewStore.getState().startLoading(SESSION_KEY);
     const gen = useReviewStore.getState().streamGeneration;
     useReviewStore.getState().beginStreaming(gen);
 
@@ -108,7 +128,7 @@ describe("useReviewStore", () => {
 
   it("goNext works mid-stream once units have been appended", () => {
     resetStore();
-    useReviewStore.getState().startLoading();
+    useReviewStore.getState().startLoading(SESSION_KEY);
     const gen = useReviewStore.getState().streamGeneration;
     useReviewStore.getState().beginStreaming(gen);
     useReviewStore.getState().appendUnit(planFixture(1).units[0], gen);
@@ -205,7 +225,7 @@ describe("useReviewStore", () => {
 
     it("goNext is a no-op while loading (only the description unit exists)", () => {
       resetStore();
-      useReviewStore.getState().startLoading();
+      useReviewStore.getState().startLoading(SESSION_KEY);
       useReviewStore.getState().goNext();
       useReviewStore.getState().goPrev();
       expect(useReviewStore.getState().currentUnitIndex).toBe(0);
@@ -213,28 +233,37 @@ describe("useReviewStore", () => {
   });
 
   describe("persistSession / restoreSession", () => {
-    const prUrl = "https://github.com/acme/widgets/pull/1";
-
     it("persistSession is a no-op when the review isn't ready", async () => {
       resetStore();
-      await persistSession(prUrl);
-      const stored = await chrome.storage.session.get(`guidedReview.session.${prUrl}`);
-      expect(stored[`guidedReview.session.${prUrl}`]).toBeUndefined();
+      useReviewStore.getState().startLoading(SESSION_KEY);
+      await persistSession();
+      const stored = await chrome.storage.session.get(STORAGE_KEY);
+      expect(stored[STORAGE_KEY]).toBeUndefined();
     });
 
-    it("persistSession stores the ready session, and restoreSession restores it", async () => {
+    it("persistSession is a no-op without a sessionKey", async () => {
+      resetStore();
+      useReviewStore.getState().setReady(diffFixture(), planFixture(1));
+      // ready but no sessionKey
+      await persistSession();
+      const stored = await chrome.storage.session.get(STORAGE_KEY);
+      expect(stored[STORAGE_KEY]).toBeUndefined();
+    });
+
+    it("persistSession stores the ready session under the canonical key, and restoreSession restores it", async () => {
       resetStore();
       const diff = diffFixture();
       const plan = planFixture(2);
       const prContext = prContextFixture();
+      useReviewStore.getState().startLoading(SESSION_KEY);
       useReviewStore.getState().setPRContext(prContext);
       useReviewStore.getState().setReady(diff, plan);
       useReviewStore.getState().goToUnit(1);
 
-      await persistSession(prUrl);
+      await persistSession();
 
       resetStore();
-      const restored = await restoreSession(prUrl);
+      const restored = await restoreSession(SESSION_KEY);
 
       expect(restored).toBe(true);
       const state = useReviewStore.getState();
@@ -243,18 +272,20 @@ describe("useReviewStore", () => {
       expect(state.plan).toEqual(plan);
       expect(state.prContext).toEqual(prContext);
       expect(state.currentUnitIndex).toBe(1);
+      expect(state.sessionKey).toBe(SESSION_KEY);
     });
 
     it("restoreSession clamps an out-of-range saved index", async () => {
       resetStore();
       const plan = planFixture(1); // display total = 2
+      useReviewStore.getState().startLoading(SESSION_KEY);
       useReviewStore.getState().setReady(diffFixture(), plan);
       useReviewStore.setState({ currentUnitIndex: 99 });
-      await persistSession(prUrl);
+      await persistSession();
 
       // Force-write an out-of-range index to storage.
       await chrome.storage.session.set({
-        [`guidedReview.session.${prUrl}`]: {
+        [STORAGE_KEY]: {
           diff: diffFixture(),
           plan,
           prContext: null,
@@ -263,13 +294,15 @@ describe("useReviewStore", () => {
       });
 
       resetStore();
-      await restoreSession(prUrl);
+      await restoreSession(SESSION_KEY);
       expect(useReviewStore.getState().currentUnitIndex).toBe(1);
     });
 
     it("restoreSession returns false when nothing was persisted", async () => {
       resetStore();
-      const restored = await restoreSession("https://github.com/acme/widgets/pull/999");
+      const restored = await restoreSession(
+        buildSessionKey({ owner: "acme", repo: "widgets", number: 999 }),
+      );
       expect(restored).toBe(false);
       expect(useReviewStore.getState().status).toBe("idle");
     });

--- a/src/content/overlay/store.ts
+++ b/src/content/overlay/store.ts
@@ -4,6 +4,13 @@ import { displayUnitCount } from "./displayUnits";
 
 export type ReviewStatus = "idle" | "loading" | "streaming" | "ready" | "error";
 
+/** Stable identity for a PR, independent of which GitHub tab/URL the user is on. */
+export interface SessionPRIdentity {
+  owner: string;
+  repo: string;
+  number: number;
+}
+
 interface PersistedSession {
   diff: ParsedDiff;
   plan: ReviewPlan;
@@ -26,10 +33,15 @@ interface ReviewState {
    * startLoading so stale port events from a cancelled stream are ignored.
    */
   streamGeneration: number;
+  /**
+   * Canonical key for the PR whose session is in flight / restored.
+   * Derived from owner/repo/number — never the full browser URL.
+   */
+  sessionKey: string | null;
 
   open: () => void;
   close: () => void;
-  startLoading: () => void;
+  startLoading: (sessionKey: string) => void;
   setPRContext: (prContext: PRContext) => void;
   setDiff: (diff: ParsedDiff) => void;
   beginStreaming: (generation: number) => void;
@@ -41,6 +53,18 @@ interface ReviewState {
   goPrev: () => void;
 }
 
+/**
+ * Build a stable session key for a PR. Same PR on Conversation vs Files changed
+ * (or any other tab URL) must map to the same key so resume works.
+ */
+export function buildSessionKey(pr: SessionPRIdentity): string {
+  return `${pr.owner}/${pr.repo}#${pr.number}`;
+}
+
+function storageKey(sessionKey: string): string {
+  return `guidedReview.session.${sessionKey}`;
+}
+
 export const useReviewStore = create<ReviewState>((set, get) => ({
   isOpen: false,
   status: "idle",
@@ -50,17 +74,19 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   prContext: null,
   currentUnitIndex: 0,
   streamGeneration: 0,
+  sessionKey: null,
 
   open: () => set({ isOpen: true }),
   close: () => set({ isOpen: false }),
 
-  startLoading: () =>
+  startLoading: (sessionKey) =>
     set((state) => ({
       status: "loading",
       error: null,
       currentUnitIndex: 0,
       plan: null,
       diff: null,
+      sessionKey,
       streamGeneration: state.streamGeneration + 1,
     })),
 
@@ -122,23 +148,19 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   },
 }));
 
-function sessionKey(prUrl: string): string {
-  return `guidedReview.session.${prUrl}`;
-}
-
 /**
  * Persist the current review session so reopening the overlay on the same PR resumes
  * without a fresh AI call. This is an optimization only — if storage access fails (e.g.
  * the access grant hasn't propagated yet), we log and move on rather than breaking the
  * review flow.
  */
-export async function persistSession(prUrl: string): Promise<void> {
-  const { status, diff, plan, prContext, currentUnitIndex } = useReviewStore.getState();
-  if (status !== "ready" || !diff || !plan) return;
+export async function persistSession(): Promise<void> {
+  const { status, diff, plan, prContext, currentUnitIndex, sessionKey } = useReviewStore.getState();
+  if (status !== "ready" || !diff || !plan || !sessionKey) return;
 
   const payload: PersistedSession = { diff, plan, prContext, currentUnitIndex };
   try {
-    await chrome.storage.session.set({ [sessionKey(prUrl)]: payload });
+    await chrome.storage.session.set({ [storageKey(sessionKey)]: payload });
   } catch (error) {
     console.warn("Guided Review: failed to persist session", error);
   }
@@ -149,11 +171,11 @@ export async function persistSession(prUrl: string): Promise<void> {
  * false if there's nothing to restore or storage access failed — callers should fall back
  * to starting a fresh review in either case.
  */
-export async function restoreSession(prUrl: string): Promise<boolean> {
+export async function restoreSession(sessionKey: string): Promise<boolean> {
   let saved: PersistedSession | undefined;
   try {
-    const result = await chrome.storage.session.get(sessionKey(prUrl));
-    saved = result[sessionKey(prUrl)] as PersistedSession | undefined;
+    const result = await chrome.storage.session.get(storageKey(sessionKey));
+    saved = result[storageKey(sessionKey)] as PersistedSession | undefined;
   } catch (error) {
     console.warn("Guided Review: failed to restore session", error);
     return false;
@@ -169,6 +191,7 @@ export async function restoreSession(prUrl: string): Promise<boolean> {
     plan: saved.plan,
     prContext: saved.prContext ?? null,
     currentUnitIndex,
+    sessionKey,
     error: null,
   });
   return true;

--- a/src/lib/review/reviewPlan.test.ts
+++ b/src/lib/review/reviewPlan.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { isCompleteReviewUnit, mergePlans, validateAndCleanPlan, validateAndCleanUnit } from "./reviewPlan";
+import {
+  isCompleteReviewUnit,
+  mergePlans,
+  prefixChunkUnitId,
+  validateAndCleanPlan,
+  validateAndCleanUnit,
+} from "./reviewPlan";
 import type { ParsedDiff, ReviewPlan, ReviewUnit } from "../types";
 
 function diffFixture(): ParsedDiff {
@@ -140,6 +146,13 @@ describe("isCompleteReviewUnit", () => {
     ).toBe(true);
     expect(isCompleteReviewUnit({ id: "u1", title: "T" })).toBe(false);
     expect(isCompleteReviewUnit(null)).toBe(false);
+  });
+});
+
+describe("prefixChunkUnitId", () => {
+  it("namespaces unit ids by chunk index", () => {
+    expect(prefixChunkUnitId(0, "u1")).toBe("c0-u1");
+    expect(prefixChunkUnitId(2, "add-field")).toBe("c2-add-field");
   });
 });
 

--- a/src/lib/review/reviewPlan.ts
+++ b/src/lib/review/reviewPlan.ts
@@ -9,6 +9,14 @@ const FILE_ROLES: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Namespace a unit id by chunk index so units from different `chunkDiffByFile`
+ * chunks never collide when stitched into one plan.
+ */
+export function prefixChunkUnitId(chunkIndex: number, unitId: string): string {
+  return `c${chunkIndex}-${unitId}`;
+}
+
+/**
  * The LLM plans structure and writes commentary, but the actual code shown
  * to the reviewer must always come from the real diff. This validates every
  * fileId/hunkId the model referenced against the diff it was given, dropping
@@ -50,6 +58,9 @@ export function validateAndCleanUnit(
     const file = knownFiles.get(ref.fileId);
     if (!file) continue;
 
+    // Empty hunkIds means "whole file". If the model listed only invalid ids,
+    // treat the ref as whole-file rather than dropping a real file path —
+    // better to show more of a real file than hide a unit step.
     const hunkIds =
       ref.hunkIds.length === 0
         ? []
@@ -96,17 +107,17 @@ export function isCompleteReviewUnit(value: unknown): value is ReviewUnit {
 }
 
 /**
- * Stitch together per-chunk plans (from `chunkDiffByFile`) into one plan,
- * namespacing ids per chunk so units from different chunks never collide.
+ * Stitch together per-chunk plans into one plan, namespacing ids per chunk so
+ * units from different chunks never collide. Used by tests and any non-stream
+ * batch path; the live stream path prefixes via `prefixChunkUnitId` as units
+ * arrive.
  */
 export function mergePlans(plans: ReviewPlan[]): ReviewPlan {
   const units: ReviewUnit[] = [];
 
   plans.forEach((plan, chunkIndex) => {
-    const prefix = `c${chunkIndex}-`;
-
     for (const unit of plan.units) {
-      units.push({ ...unit, id: `${prefix}${unit.id}` });
+      units.push({ ...unit, id: prefixChunkUnitId(chunkIndex, unit.id) });
     }
   });
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -118,18 +118,6 @@ export type AnnotateReviewStreamEvent =
   | { type: "DONE"; plan: ReviewPlan }
   | { type: "ERROR"; error: string };
 
-/** @deprecated Prefer stream events; kept for type compatibility in older tests. */
-export interface AnnotateReviewResponse {
-  ok: true;
-  plan: ReviewPlan;
-}
-
-/** @deprecated Prefer stream events; kept for type compatibility in older tests. */
-export interface AnnotateReviewError {
-  ok: false;
-  error: string;
-}
-
 export interface TestConnectionRequest {
   type: "TEST_CONNECTION";
   settings: ProviderSettings;

--- a/src/options/Options.test.tsx
+++ b/src/options/Options.test.tsx
@@ -80,4 +80,20 @@ describe("Options", () => {
 
     await waitFor(() => expect(screen.getByText("Invalid API key")).toBeInTheDocument());
   });
+
+  it("shows an error when the connection test throws", async () => {
+    const user = userEvent.setup();
+    vi.mocked(chrome.runtime.sendMessage).mockRejectedValueOnce(new Error("Extension context invalidated"));
+    render(<Options />);
+
+    await screen.findByLabelText(/provider/i);
+    await user.type(screen.getByLabelText(/api key/i), "sk-test");
+    await user.click(screen.getByRole("button", { name: /test connection/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Extension context invalidated")).toBeInTheDocument(),
+    );
+    // Must not remain stuck on "Testing…"
+    expect(screen.getByRole("button", { name: /test connection/i })).not.toBeDisabled();
+  });
 });

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -60,12 +60,18 @@ export function Options() {
 
   const onTestConnection = async () => {
     setConnection({ kind: "testing" });
-    await setProviderSettings(settings); // test against what's on screen, not last-saved
-    const result = await testConnection(settings);
-    if (result.ok) {
-      setConnection({ kind: "ok" });
-    } else {
-      setConnection({ kind: "error", message: result.error ?? "Connection failed." });
+    try {
+      await setProviderSettings(settings); // test against what's on screen, not last-saved
+      const result = await testConnection(settings);
+      if (result.ok) {
+        setConnection({ kind: "ok" });
+      } else {
+        setConnection({ kind: "error", message: result.error ?? "Connection failed." });
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Connection test failed unexpectedly.";
+      setConnection({ kind: "error", message });
     }
   };
 


### PR DESCRIPTION
## Summary

Post-streaming code refactor review. Fixes real session resume bugs and removes stream-era leftovers without changing the product surface.

- **Session identity:** key sessions by `owner/repo#number` (not full `location.href`), and keep the active key in the store so SPA tab/PR navigation cannot persist under a stale URL.
- **Stream pipeline cleanup:** single `prefixChunkUnitId` helper for chunk namespacing; shared `safeErrorDetail` / `isAbortError` in `providers/http.ts`; Anthropic empty-stream handling matches OpenAI-compatible providers.
- **UI consistency:** Sidebar renders from `buildDisplayUnits`; shared empty-metadata copy module for description pane + context panel.
- **Error handling:** Options “Test connection” no longer sticks on “Testing…” if messaging throws.
- **Docs/types:** AGENTS.md documents the streaming pipeline and canonical session keys; remove unused deprecated annotate response types.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (118 tests)
- [x] `npm run build`
- [ ] Load `dist/` in Chrome and open a PR review on Conversation tab, then Files changed — resume should not re-call the AI
- [ ] Navigate SPA to a second PR and start a review — session for the second PR should not write over the first
- [ ] Options → Test connection with a bad key and with a forced messaging failure (reload extension mid-test) — error shown, button re-enabled
- [ ] Walk a multi-chunk plan if available — unit ids remain unique and sidebar order matches display units