### PR TITLE
Show Start Guided Review button on every PR tab

### DIFF
--- a/e2e/fixtures/pr-page-modern.html
+++ b/e2e/fixtures/pr-page-modern.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Add feature · Pull Request #1 · acme/widgets</title>
+  </head>
+  <body>
+    <!--
+      Minimal stand-in for GitHub's modern React PR layout (Conversation /
+      Commits / Checks, and the improved Files changed experience). Uses stable
+      data-component attributes that findButtonAnchor prefers over classic
+      .gh-header-* classes.
+    -->
+    <header data-component="PageHeader">
+      <div data-component="TitleArea">
+        <h1 data-component="PH_Title">
+          <span data-component="Text">Add feature</span>
+        </h1>
+        <div data-component="PH_Actions" class="d-none"></div>
+      </div>
+      <div data-component="PH_Navigation">
+        <div class="right-actions"></div>
+        <nav aria-label="Pull request navigation tabs">
+          <a role="tab" href="/acme/widgets/pull/1" aria-selected="true">Conversation</a>
+          <a role="tab" href="/acme/widgets/pull/1/commits">Commits</a>
+          <a role="tab" href="/acme/widgets/pull/1/files">Files changed</a>
+        </nav>
+      </div>
+    </header>
+  </body>
+</html>

--- a/e2e/overlay.spec.ts
+++ b/e2e/overlay.spec.ts
@@ -6,6 +6,7 @@ import { expect, test } from "./fixtures";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PR_URL = "https://github.com/acme/widgets/pull/1";
 const PR_FIXTURE_PATH = path.resolve(__dirname, "fixtures/pr-page.html");
+const PR_MODERN_FIXTURE_PATH = path.resolve(__dirname, "fixtures/pr-page-modern.html");
 
 const CANNED_DIFF = [
   "diff --git a/src/foo.ts b/src/foo.ts",
@@ -93,5 +94,42 @@ test.describe("Guided review overlay", () => {
     await expect(page.getByText(CANNED_PLAN.units[0].title)).toBeVisible();
     await page.getByRole("button", { name: /next/i }).click();
     await expect(page.getByText(CANNED_PLAN.units[0].context)).toBeVisible();
+  });
+
+  test("injects Start Guided Review on the modern React PR header", async ({ context }) => {
+    await context.route(PR_URL, (route) =>
+      route.fulfill({ path: PR_MODERN_FIXTURE_PATH, contentType: "text/html" }),
+    );
+
+    const page = await context.newPage();
+    await page.goto(PR_URL);
+
+    const startButton = page.getByRole("button", { name: "Start Guided Review" });
+    await expect(startButton).toBeVisible();
+
+    // Button should land in the modern PageHeader actions slot (unhidden), not only the fallback host.
+    await expect(page.locator('[data-component="PH_Actions"] #guided-review-start-btn')).toBeVisible();
+    await expect(page.locator('[data-component="PH_Actions"]')).not.toHaveClass(/d-none/);
+  });
+
+  test("injects Start Guided Review on PR tab subpaths", async ({ context }) => {
+    const tabUrls = [
+      "https://github.com/acme/widgets/pull/1",
+      "https://github.com/acme/widgets/pull/1/files",
+      "https://github.com/acme/widgets/pull/1/commits",
+      "https://github.com/acme/widgets/pull/1/checks",
+    ];
+
+    for (const url of tabUrls) {
+      await context.route(url, (route) =>
+        route.fulfill({ path: PR_MODERN_FIXTURE_PATH, contentType: "text/html" }),
+      );
+    }
+
+    const page = await context.newPage();
+    for (const url of tabUrls) {
+      await page.goto(url);
+      await expect(page.getByRole("button", { name: "Start Guided Review" })).toBeVisible();
+    }
   });
 });

--- a/src/content/buttonAnchor.test.ts
+++ b/src/content/buttonAnchor.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { ensureFallbackHost, FALLBACK_HOST_ID, findButtonAnchor } from "./buttonAnchor";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  document.getElementById(FALLBACK_HOST_ID)?.remove();
+});
+
+describe("findButtonAnchor", () => {
+  it("prefers classic .gh-header-actions", () => {
+    document.body.innerHTML = `
+      <div class="gh-header">
+        <div class="gh-header-actions" id="classic-actions"></div>
+        <div data-component="PH_Actions" id="modern-actions" class="d-none"></div>
+      </div>
+    `;
+    const anchor = findButtonAnchor();
+    expect(anchor?.id).toBe("classic-actions");
+  });
+
+  it("falls back to classic .gh-header-meta and .gh-header-show", () => {
+    document.body.innerHTML = `<div class="gh-header-meta" id="meta"></div>`;
+    expect(findButtonAnchor()?.id).toBe("meta");
+
+    document.body.innerHTML = `<div class="gh-header-show" id="show"></div>`;
+    expect(findButtonAnchor()?.id).toBe("show");
+  });
+
+  it("uses modern PH_Actions and unhides a d-none slot", () => {
+    document.body.innerHTML = `
+      <div data-component="PageHeader">
+        <div data-component="PH_Actions" id="ph-actions" class="d-none"></div>
+      </div>
+    `;
+    const anchor = findButtonAnchor();
+    expect(anchor?.id).toBe("ph-actions");
+    expect(anchor?.classList.contains("d-none")).toBe(false);
+    expect(anchor?.style.display).toBe("flex");
+  });
+
+  it("uses the right-side child of PH_Navigation next to PR tabs", () => {
+    document.body.innerHTML = `
+      <div data-component="PH_Navigation" id="ph-nav">
+        <div id="right-actions"></div>
+        <div class="flex-auto">
+          <nav aria-label="Pull request navigation tabs">
+            <a href="/acme/widgets/pull/1">Conversation</a>
+          </nav>
+        </div>
+      </div>
+    `;
+    expect(findButtonAnchor()?.id).toBe("right-actions");
+  });
+
+  it("uses PH_Navigation itself when there is no right-side child", () => {
+    document.body.innerHTML = `
+      <div data-component="PH_Navigation" id="ph-nav">
+        <nav aria-label="Pull request navigation tabs">
+          <a href="/acme/widgets/pull/1">Conversation</a>
+        </nav>
+      </div>
+    `;
+    // firstElementChild is the nav; findButtonAnchor should fall back to PH_Navigation
+    expect(findButtonAnchor()?.id).toBe("ph-nav");
+  });
+
+  it("falls back to PageHeader when only that is present", () => {
+    document.body.innerHTML = `<div data-component="PageHeader" id="page-header"></div>`;
+    expect(findButtonAnchor()?.id).toBe("page-header");
+  });
+
+  it("returns null when no known anchors exist", () => {
+    document.body.innerHTML = `<main><h1>Some PR shell</h1></main>`;
+    expect(findButtonAnchor()).toBeNull();
+  });
+});
+
+describe("ensureFallbackHost", () => {
+  it("creates a fixed host once and reuses it", () => {
+    const first = ensureFallbackHost();
+    expect(first.id).toBe(FALLBACK_HOST_ID);
+    expect(document.body.contains(first)).toBe(true);
+
+    const second = ensureFallbackHost();
+    expect(second).toBe(first);
+    expect(document.querySelectorAll(`#${FALLBACK_HOST_ID}`)).toHaveLength(1);
+  });
+});

--- a/src/content/buttonAnchor.ts
+++ b/src/content/buttonAnchor.ts
@@ -1,0 +1,90 @@
+/**
+ * GitHub PR header markup differs across the classic Files changed page and the
+ * modern React PR layout (Conversation / Commits / Checks, and the improved
+ * Files changed experience). Prefer stable attributes over hashed CSS-module
+ * class names so anchors survive GitHub deploys.
+ */
+
+const CLASSIC_ANCHORS = [
+  ".gh-header-actions",
+  ".gh-header-meta",
+  '[data-testid="issue-viewer-header-actions"]',
+  ".gh-header-show",
+] as const;
+
+export const FALLBACK_HOST_ID = "guided-review-start-btn-host";
+
+/**
+ * Find a DOM node to append the "Start Guided Review" button into.
+ * Returns null when no known header slot is present yet (caller may create a
+ * fallback host, and the mutation observer will retry as the SPA renders).
+ */
+export function findButtonAnchor(root: ParentNode = document): HTMLElement | null {
+  for (const selector of CLASSIC_ANCHORS) {
+    const el = root.querySelector<HTMLElement>(selector);
+    if (el) return el;
+  }
+
+  const phActions = root.querySelector<HTMLElement>('[data-component="PH_Actions"]');
+  if (phActions) {
+    // GitHub leaves this slot empty + d-none when there are no native actions.
+    phActions.classList.remove("d-none");
+    if (!phActions.style.display || phActions.style.display === "none") {
+      phActions.style.display = "flex";
+    }
+    if (!phActions.style.alignItems) {
+      phActions.style.alignItems = "center";
+    }
+    if (!phActions.style.gap) {
+      phActions.style.gap = "8px";
+    }
+    return phActions;
+  }
+
+  const tabNav =
+    root.querySelector<HTMLElement>('nav[aria-label="Pull request navigation tabs"]') ??
+    root.querySelector<HTMLElement>('nav[aria-label="Pull request"]');
+  const phNav =
+    tabNav?.closest<HTMLElement>('[data-component="PH_Navigation"]') ??
+    root.querySelector<HTMLElement>('[data-component="PH_Navigation"]');
+  if (phNav) {
+    // Prefer the right-side actions cluster (first child next to the tab list).
+    const right = phNav.firstElementChild;
+    if (right instanceof HTMLElement && right !== tabNav && !tabNav?.contains(right)) {
+      return right;
+    }
+    return phNav;
+  }
+
+  // Sticky / non-sticky PageHeader as a soft modern fallback.
+  const pageHeader = root.querySelector<HTMLElement>('[data-component="PageHeader"]');
+  if (pageHeader) return pageHeader;
+
+  return null;
+}
+
+/**
+ * Last-resort mount point when no GitHub header slot exists (e.g. beta Files UI
+ * that has not yet painted a known header). Creates a fixed host once.
+ */
+export function ensureFallbackHost(doc: Document = document): HTMLElement {
+  const existing = doc.getElementById(FALLBACK_HOST_ID);
+  if (existing instanceof HTMLElement) return existing;
+
+  const host = doc.createElement("div");
+  host.id = FALLBACK_HOST_ID;
+  host.setAttribute(
+    "style",
+    [
+      "position: fixed",
+      "top: 72px",
+      "right: 16px",
+      "z-index: 1000",
+      "display: flex",
+      "align-items: center",
+      "gap: 8px",
+    ].join(";"),
+  );
+  doc.body.appendChild(host);
+  return host;
+}

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -2,6 +2,7 @@ import { createRoot } from "react-dom/client";
 import { parsePRUrl, type PRIdentity } from "../lib/github/diffFetch";
 import { fetchConversationDescription, scrapePRContext } from "../lib/github/prContext";
 import { requestPRDiff, streamReviewPlan } from "../lib/messaging";
+import { ensureFallbackHost, FALLBACK_HOST_ID, findButtonAnchor } from "./buttonAnchor";
 import { Overlay } from "./overlay/Overlay";
 import overlayStyles from "./overlay/styles/overlay.css?inline";
 import { useReviewStore, restoreSession, buildSessionKey } from "./overlay/store";
@@ -31,10 +32,21 @@ function tryInjectButton(): void {
 
   currentPR = pr;
 
-  if (document.getElementById(BUTTON_ID)) return;
+  // Prefer a real header action slot; fall back to a fixed host so the button
+  // still appears on beta / partially-rendered PR shells. If a better anchor
+  // appears later (SPA paint), re-parent the existing button into it.
+  const preferred = findButtonAnchor();
+  const anchor = preferred ?? ensureFallbackHost();
 
-  const anchor = findButtonAnchor();
-  if (!anchor) return;
+  const existing = document.getElementById(BUTTON_ID);
+  if (existing?.isConnected) {
+    if (!anchor.contains(existing)) {
+      anchor.appendChild(existing);
+      removeFallbackHostIfEmpty();
+    }
+    return;
+  }
+  existing?.remove();
 
   const button = document.createElement("button");
   button.id = BUTTON_ID;
@@ -82,25 +94,14 @@ function tryInjectButton(): void {
   button.addEventListener("click", onStartReview);
 
   anchor.appendChild(button);
+  removeFallbackHostIfEmpty();
 }
 
-/**
- * GitHub's PR header markup shifts across redesigns; try a few reasonably
- * stable anchors near the PR title / action bar before giving up for this
- * pass (the mutation observer will retry on the next DOM change).
- */
-function findButtonAnchor(): HTMLElement | null {
-  const candidates = [
-    ".gh-header-actions",
-    ".gh-header-meta",
-    '[data-testid="issue-viewer-header-actions"]',
-    ".gh-header-show",
-  ];
-  for (const selector of candidates) {
-    const el = document.querySelector<HTMLElement>(selector);
-    if (el) return el;
+function removeFallbackHostIfEmpty(): void {
+  const host = document.getElementById(FALLBACK_HOST_ID);
+  if (host && host.childElementCount === 0) {
+    host.remove();
   }
-  return null;
 }
 
 function cancelActiveStream(): void {


### PR DESCRIPTION
## Summary

The "Start Guided Review" button only appeared on the classic Files changed tab because injection looked for `.gh-header-*` anchors that the modern React PR layout does not render.

This change expands header anchor discovery so the button shows on Conversation, Commits, Checks, Files (classic and improved beta), and other `/pull/{id}` subviews.

- Prefer classic `.gh-header-actions` when present
- Support modern PageHeader slots (`PH_Actions`, `PH_Navigation`, tab nav)
- Fall back to a fixed host when no header is ready yet; re-parent into a real slot once GitHub paints
- Add unit + e2e coverage for modern markup and PR tab subpaths

## Test plan

- [x] `npm test` (includes new `buttonAnchor` unit tests)
- [x] `npm run typecheck` / `npm run build`
- [x] `npm run test:e2e` (classic overlay flow + modern header + tab subpaths)
- [ ] Manual: load `dist/` in Chrome, open a PR, confirm button on Conversation / Commits / Checks / Files
- [ ] Manual: if improved Files changed beta is enabled, confirm button appears there too
- [ ] Manual: click Start Guided Review and confirm overlay still streams a plan