### PR TITLE
Start guided review from toolbar icon

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-"Guided PR Review" is a Chrome Manifest V3 extension (built with `@crxjs/vite-plugin`) that injects a
+"Guided Review" is a Chrome Manifest V3 extension (built with `@crxjs/vite-plugin`) that injects a
 "Start Guided Review" button into GitHub PR pages. It fetches the PR's diff, sends it to an LLM
 (Anthropic/OpenAI/Grok), and turns the raw diff into an ordered sequence of "review units" — logical
 groupings of hunks with inferred context — shown in an overlay so a human can walk through the PR
@@ -81,7 +81,7 @@ calls with typed helpers.
    for tests and non-stream callers.)
 5. The overlay (`src/content/overlay/`, state in `store.ts` via Zustand) renders display units
    (`displayUnits.ts`: synthetic PR description first, then `ReviewPlan.units`) in order, resolving
-   each unit's `fileId`/`hunkId` refs back against the *real* parsed diff — the LLM plans structure
+   each unit's `fileId`/`hunkId` refs back against the _real_ parsed diff — the LLM plans structure
    and commentary only; it never supplies the code shown to the reviewer.
 
 ### Session persistence

--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -3,7 +3,7 @@ import pkg from "./package.json";
 
 export default defineManifest({
   manifest_version: 3,
-  name: "Guided PR Review",
+  name: "Guided Review",
   description:
     "Turns a GitHub pull request diff into a guided, AI-structured review: model changes first, grouped by concern, with context and risk flags.",
   version: pkg.version,
@@ -32,7 +32,11 @@ export default defineManifest({
     },
   ],
   options_page: "src/options/index.html",
-  action: {},
+  action: {
+    // With a popup, chrome.action.onClicked does not fire — the popup handles
+    // icon clicks (start review on PR pages, otherwise show a short message).
+    default_popup: "src/popup/index.html",
+  },
   web_accessible_resources: [
     {
       resources: ["logomark.svg"],

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -21,9 +21,8 @@ import { ProviderError } from "./providers/types";
 
 const ANNOTATE_PORT_NAME = "annotate-review";
 
-chrome.action.onClicked.addListener(() => {
-  chrome.runtime.openOptionsPage();
-});
+// Toolbar icon opens the action popup (`src/popup/`), which starts a guided
+// review on PR pages or explains that the extension only works there.
 
 // Content scripts run in an "untrusted" context and are blocked from
 // chrome.storage.session by default. The overlay persists/restores review

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -2,6 +2,7 @@ import { createRoot } from "react-dom/client";
 import { parsePRUrl, type PRIdentity } from "../lib/github/diffFetch";
 import { fetchConversationDescription, scrapePRContext } from "../lib/github/prContext";
 import { requestPRDiff, streamReviewPlan } from "../lib/messaging";
+import type { ContentRequest } from "../lib/types";
 import { ensureFallbackHost, FALLBACK_HOST_ID, findButtonAnchor } from "./buttonAnchor";
 import { Overlay } from "./overlay/Overlay";
 import overlayStyles from "./overlay/styles/overlay.css?inline";
@@ -18,6 +19,14 @@ init();
 
 function init(): void {
   tryInjectButton();
+
+  // Toolbar icon click is handled in the background worker; when the active
+  // tab is a PR page it forwards START_GUIDED_REVIEW here.
+  chrome.runtime.onMessage.addListener((message: ContentRequest) => {
+    if (message?.type === "START_GUIDED_REVIEW") {
+      void onStartReview();
+    }
+  });
 
   // GitHub is a SPA — the PR page doesn't reload between "Conversation" /
   // "Files changed" / re-renders after data loads, so watch for DOM changes
@@ -112,8 +121,11 @@ function cancelActiveStream(): void {
 }
 
 async function onStartReview(): Promise<void> {
-  if (!currentPR) return;
-  const pr = currentPR;
+  // Prefer the cached identity from button injection; re-parse the URL so a
+  // toolbar-icon click still works if the button hasn't painted yet.
+  const pr = currentPR ?? parsePRUrl(window.location.href);
+  if (!pr) return;
+  currentPR = pr;
   const sessionKey = buildSessionKey(pr);
 
   ensureOverlayMounted();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -143,3 +143,15 @@ export interface FetchDiffError {
 
 /** One-shot request/response messages (annotate uses a port instead). */
 export type BackgroundRequest = TestConnectionRequest | FetchDiffRequest;
+
+// ---- Messaging protocol (background → content) -----------------------------
+
+/**
+ * Toolbar action click on a PR page: content should open the overlay and
+ * start (or resume) the guided review for the current PR.
+ */
+export interface StartGuidedReviewMessage {
+  type: "START_GUIDED_REVIEW";
+}
+
+export type ContentRequest = StartGuidedReviewMessage;

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Guided Review</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  </head>
+  <body>
+    <div id="root" class="popup" hidden>
+      <div class="popup__mark" aria-hidden="true"></div>
+      <p id="message" class="popup__message"></p>
+      <a id="settings" class="popup__link" href="#">Settings</a>
+    </div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/src/popup/main.ts
+++ b/src/popup/main.ts
@@ -1,0 +1,58 @@
+import { parsePRUrl } from "../lib/github/diffFetch";
+import type { StartGuidedReviewMessage } from "../lib/types";
+import "./popup.css";
+
+const NOT_ON_PR =
+  "Guided Review only works on GitHub pull request pages right now.";
+const RELOAD_PR =
+  "Open a GitHub pull request and reload the page, then try again.";
+
+init();
+
+async function init(): Promise<void> {
+  const root = document.getElementById("root");
+  const messageEl = document.getElementById("message");
+  const settingsLink = document.getElementById("settings");
+  if (!(root instanceof HTMLElement) || !(messageEl instanceof HTMLElement))
+    return;
+
+  const markUrl = chrome.runtime.getURL("logomark.svg");
+  root.style.setProperty("--mark-url", `url("${markUrl}")`);
+
+  settingsLink?.addEventListener("click", (event) => {
+    event.preventDefault();
+    chrome.runtime.openOptionsPage();
+  });
+
+  const tab = await getActiveTab();
+  const tabId = tab?.id;
+  const pr = tab?.url ? parsePRUrl(tab.url) : null;
+
+  if (tabId != null && pr) {
+    const message: StartGuidedReviewMessage = { type: "START_GUIDED_REVIEW" };
+    try {
+      await chrome.tabs.sendMessage(tabId, message);
+      window.close();
+      return;
+    } catch {
+      showMessage(root, messageEl, RELOAD_PR);
+      return;
+    }
+  }
+
+  showMessage(root, messageEl, NOT_ON_PR);
+}
+
+function showMessage(
+  root: HTMLElement,
+  messageEl: HTMLElement,
+  text: string,
+): void {
+  messageEl.textContent = text;
+  root.hidden = false;
+}
+
+async function getActiveTab(): Promise<chrome.tabs.Tab | undefined> {
+  const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+  return tabs[0];
+}

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -1,0 +1,65 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Helvetica,
+    Arial,
+    sans-serif;
+  color: #fefefe;
+  background: #110e0b;
+}
+
+.popup {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+  width: 280px;
+  padding: 16px;
+}
+
+.popup[hidden] {
+  display: none;
+}
+
+.popup__mark {
+  width: 28px;
+  height: 14px;
+  flex-shrink: 0;
+  background-color: #caff57;
+  -webkit-mask: var(--mark-url) center / contain no-repeat;
+  mask: var(--mark-url) center / contain no-repeat;
+}
+
+.popup__message {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.45;
+  color: #fefefe;
+}
+
+.popup__link {
+  font-size: 12px;
+  font-weight: 600;
+  color: #caff57;
+  text-decoration: none;
+}
+
+.popup__link:hover {
+  text-decoration: underline;
+}

--- a/src/test/chromeMock.ts
+++ b/src/test/chromeMock.ts
@@ -126,6 +126,10 @@ export function createChromeMock() {
         addListener: vi.fn(),
       },
     },
+    tabs: {
+      sendMessage: vi.fn(async (_tabId: number, _message: unknown) => undefined),
+      query: vi.fn(async (_query: unknown) => []),
+    },
   };
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
     rollupOptions: {
       input: {
         options: path.resolve(__dirname, "src/options/index.html"),
+        popup: path.resolve(__dirname, "src/popup/index.html"),
       },
     },
   },


### PR DESCRIPTION
## Summary
- Clicking the extension toolbar icon on a GitHub PR page starts (or resumes) the guided review, same as the in-page button.
- On any other page, a small action popup explains that Guided Review only works on GitHub pull request pages, with a link to Settings.
- If the content script is not loaded yet (e.g. after install), the popup asks the user to reload the PR page.

## Test plan
- [ ] Reload the unpacked extension from `dist/` after build
- [ ] On a GitHub PR page, click the toolbar icon → review overlay opens / starts
- [ ] On a non-PR page (e.g. google.com or a GitHub issue), click the icon → popup message appears
- [ ] From the popup, open Settings → options page loads
- [ ] After installing/updating without reloading a PR tab, click the icon → reload hint is shown