### PR TITLE
feat(options): add About page linked from settings and popup

### DIFF
--- a/e2e/options.spec.ts
+++ b/e2e/options.spec.ts
@@ -48,4 +48,19 @@ test.describe("Options page", () => {
 
     await expect(page.getByRole("combobox", { name: "Model" })).toContainText("Grok 4");
   });
+
+  test("navigates to About from Settings and back", async ({ context, extensionId }) => {
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/src/options/index.html`);
+
+    await page.getByRole("link", { name: /about guided review/i }).click();
+    await expect(page.getByRole("heading", { name: "What it does" })).toBeVisible();
+    await expect(page).toHaveURL(/#about$/);
+    await expect(page).toHaveTitle(/About/);
+
+    await page.getByRole("link", { name: /settings/i }).click();
+    await expect(page.getByRole("combobox", { name: "Provider" })).toBeVisible();
+    await expect(page).toHaveURL(/#settings$/);
+  });
 });
+

--- a/src/options/About.test.tsx
+++ b/src/options/About.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { About } from "./About";
+
+describe("About", () => {
+  it("explains what the extension does and how a review works", () => {
+    render(<About />);
+
+    expect(screen.getByRole("heading", { name: "Guided Review" })).toBeInTheDocument();
+    expect(screen.getByText(/v0\.1\.0/)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "What it does" })).toBeInTheDocument();
+    expect(
+      screen.getByText(/turns a GitHub pull request diff into an ordered, AI-guided review/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "How a review works" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Privacy" })).toBeInTheDocument();
+    expect(screen.getByText(/no Guided Review backend/i)).toBeInTheDocument();
+  });
+
+  it("links back to settings via hash", () => {
+    render(<About />);
+
+    const link = screen.getByRole("link", { name: /settings/i });
+    expect(link).toHaveAttribute("href", "#settings");
+  });
+});

--- a/src/options/About.tsx
+++ b/src/options/About.tsx
@@ -1,0 +1,78 @@
+import { BrandHeader } from "./BrandHeader";
+
+const sectionTitle = "mb-2 mt-0 text-[13px] font-semibold text-opt-text";
+const bodyText = "m-0 text-[13px] leading-relaxed text-opt-muted";
+
+/**
+ * Explains what Guided Review does, how a walkthrough works, and where data goes.
+ * Linked from the Settings (options) page via `#about`.
+ */
+export function About() {
+  const version = chrome.runtime.getManifest().version;
+
+  return (
+    <div className="mx-auto max-w-[480px] px-6 py-8">
+      <BrandHeader />
+      <p className="mb-6 text-[13px] text-opt-muted">
+        AI-structured walkthroughs for GitHub pull requests
+        {version ? (
+          <>
+            {" "}
+            · <span className="tabular-nums">v{version}</span>
+          </>
+        ) : null}
+      </p>
+
+      <section className="mb-6">
+        <h2 className={sectionTitle}>What it does</h2>
+        <p className={bodyText}>
+          Guided Review turns a GitHub pull request diff into an ordered, AI-guided review.
+          Instead of scrolling a flat file list, you walk through logical units — schema and
+          data-model changes first, then the core logic that depends on them, then call-sites,
+          then tests — with short context and risk flags for each step.
+        </p>
+      </section>
+
+      <section className="mb-6">
+        <h2 className={sectionTitle}>How a review works</h2>
+        <ol className="m-0 list-decimal space-y-2 pl-5 text-[13px] leading-relaxed text-opt-muted">
+          <li>Open a pull request on GitHub.</li>
+          <li>
+            Click <strong className="font-semibold text-opt-text">Start Guided Review</strong> on
+            the PR page (or use the extension icon while a PR tab is active).
+          </li>
+          <li>
+            The extension fetches the PR diff and sends it to the AI provider you configured,
+            which builds a structured review plan.
+          </li>
+          <li>
+            Step through the plan in the overlay: description first, then each review unit with
+            the real diff hunks resolved from the PR — the model plans structure and commentary
+            only; it does not invent the code you see.
+          </li>
+        </ol>
+      </section>
+
+      <section className="mb-6">
+        <h2 className={sectionTitle}>Privacy</h2>
+        <p className={bodyText}>
+          Your API key is stored only in this browser via{" "}
+          <code className="rounded bg-opt-subtle px-1 py-0.5 text-[12px] text-opt-text">
+            chrome.storage.local
+          </code>
+          . Diffs and prompts go only to the provider you choose (Anthropic, OpenAI, or xAI).
+          There is no Guided Review backend in the middle.
+        </p>
+      </section>
+
+      <nav className="mt-8 border-t border-opt-border pt-6">
+        <a
+          href="#settings"
+          className="text-[13px] font-semibold text-opt-muted no-underline hover:text-opt-text hover:underline"
+        >
+          ← Settings
+        </a>
+      </nav>
+    </div>
+  );
+}

--- a/src/options/App.test.tsx
+++ b/src/options/App.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+import { App } from "./App";
+
+afterEach(() => {
+  window.location.hash = "";
+  document.title = "";
+});
+
+describe("App", () => {
+  it("shows settings by default", async () => {
+    render(<App />);
+
+    expect(await screen.findByRole("combobox", { name: /provider/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /about guided review/i })).toHaveAttribute(
+      "href",
+      "#about",
+    );
+    expect(document.title).toBe("Guided Review — Settings");
+  });
+
+  it("shows the about page when the hash is #about", async () => {
+    window.location.hash = "#about";
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "What it does" })).toBeInTheDocument();
+    expect(screen.queryByRole("combobox", { name: /provider/i })).not.toBeInTheDocument();
+    expect(document.title).toBe("Guided Review — About");
+  });
+
+  it("navigates between settings and about via hash links", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByRole("combobox", { name: /provider/i });
+    await user.click(screen.getByRole("link", { name: /about guided review/i }));
+
+    expect(await screen.findByRole("heading", { name: "What it does" })).toBeInTheDocument();
+    await waitFor(() => expect(window.location.hash).toBe("#about"));
+
+    await user.click(screen.getByRole("link", { name: /settings/i }));
+    expect(await screen.findByRole("combobox", { name: /provider/i })).toBeInTheDocument();
+    await waitFor(() => expect(window.location.hash).toBe("#settings"));
+  });
+});

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import { About } from "./About";
+import { Options } from "./Options";
+
+export type OptionsRoute = "settings" | "about";
+
+function parseHash(hash: string): OptionsRoute {
+  const path = hash.replace(/^#\/?/, "").toLowerCase();
+  return path === "about" ? "about" : "settings";
+}
+
+function useHashRoute(): OptionsRoute {
+  const [route, setRoute] = useState<OptionsRoute>(() =>
+    typeof window !== "undefined" ? parseHash(window.location.hash) : "settings",
+  );
+
+  useEffect(() => {
+    const onHashChange = () => setRoute(parseHash(window.location.hash));
+    window.addEventListener("hashchange", onHashChange);
+    return () => window.removeEventListener("hashchange", onHashChange);
+  }, []);
+
+  return route;
+}
+
+const TITLES: Record<OptionsRoute, string> = {
+  settings: "Guided Review — Settings",
+  about: "Guided Review — About",
+};
+
+/**
+ * Options entry shell: Settings (default) and About, switched via URL hash
+ * (`#settings` / `#about`) so each view is linkable without a second HTML entry.
+ */
+export function App() {
+  const route = useHashRoute();
+
+  useEffect(() => {
+    document.title = TITLES[route];
+  }, [route]);
+
+  return route === "about" ? <About /> : <Options />;
+}

--- a/src/options/BrandHeader.tsx
+++ b/src/options/BrandHeader.tsx
@@ -1,0 +1,15 @@
+/** Shared branding block used by Settings and About. */
+export function BrandHeader({ title = "Guided Review" }: { title?: string }) {
+  return (
+    <div className="mb-2 flex items-center gap-3">
+      <img
+        className="h-10 w-10 shrink-0 rounded-lg"
+        src={chrome.runtime.getURL("icon.png")}
+        alt=""
+        width={40}
+        height={40}
+      />
+      <h1 className="m-0 text-lg font-bold">{title}</h1>
+    </div>
+  );
+}

--- a/src/options/Options.test.tsx
+++ b/src/options/Options.test.tsx
@@ -147,4 +147,13 @@ describe("Options", () => {
     expect(within(listbox).getByRole("option", { name: /Claude Sonnet 5/i })).toBeInTheDocument();
     expect(within(listbox).getByRole("option", { name: /Claude Haiku 4\.5/i })).toBeInTheDocument();
   });
+
+  it("links to the about page", async () => {
+    render(<Options />);
+
+    await screen.findByRole("combobox", { name: /provider/i });
+    const about = screen.getByRole("link", { name: /about guided review/i });
+    expect(about).toHaveAttribute("href", "#about");
+  });
 });
+

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -11,6 +11,7 @@ import { testConnection } from "../lib/messaging";
 import { Select, type SelectOption } from "./components/Select";
 import { ProviderIcon } from "./components/ProviderIcon";
 import { ActionSpinner } from "./components/ActionSpinner";
+import { BrandHeader } from "./BrandHeader";
 import { cn } from "../lib/cn";
 
 type ActionStatus =
@@ -125,16 +126,7 @@ export function Options() {
 
   return (
     <div className="mx-auto max-w-[480px] px-6 py-8">
-      <div className="mb-2 flex items-center gap-3">
-        <img
-          className="h-10 w-10 shrink-0 rounded-lg"
-          src={chrome.runtime.getURL("icon.png")}
-          alt=""
-          width={40}
-          height={40}
-        />
-        <h1 className="m-0 text-lg font-bold">Guided Review</h1>
-      </div>
+      <BrandHeader />
       <p className="mb-6 text-[13px] text-opt-muted">
         Choose an AI provider and paste your own API key. The key is stored only in this
         browser and is used solely to annotate PR diffs you open.
@@ -226,6 +218,15 @@ export function Options() {
           </span>
         )}
       </div>
+
+      <nav className="mt-8 border-t border-opt-border pt-6">
+        <a
+          href="#about"
+          className="text-[13px] font-semibold text-opt-muted no-underline hover:text-opt-text hover:underline"
+        >
+          About Guided Review
+        </a>
+      </nav>
     </div>
   );
 }

--- a/src/options/main.tsx
+++ b/src/options/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { Options } from "./Options";
+import { App } from "./App";
 import "../styles/theme.css";
 import "./options.scss";
 
@@ -9,6 +9,6 @@ if (!root) throw new Error("Options page is missing its #root element.");
 
 createRoot(root).render(
   <StrictMode>
-    <Options />
+    <App />
   </StrictMode>,
 );

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -9,7 +9,10 @@
     <div id="root" class="popup" hidden>
       <div class="popup__mark" aria-hidden="true"></div>
       <p id="message" class="popup__message"></p>
-      <a id="settings" class="popup__link" href="#">Settings</a>
+      <nav class="popup__links" aria-label="Extension pages">
+        <a id="settings" class="popup__link" href="#">Settings</a>
+        <a id="about" class="popup__link" href="#">About</a>
+      </nav>
     </div>
     <script type="module" src="./main.ts"></script>
   </body>

--- a/src/popup/main.ts
+++ b/src/popup/main.ts
@@ -7,12 +7,16 @@ const NOT_ON_PR =
 const RELOAD_PR =
   "Open a GitHub pull request and reload the page, then try again.";
 
+/** Path registered as `options_page` in the manifest (stable across builds). */
+const OPTIONS_PAGE = "src/options/index.html";
+
 init();
 
 async function init(): Promise<void> {
   const root = document.getElementById("root");
   const messageEl = document.getElementById("message");
   const settingsLink = document.getElementById("settings");
+  const aboutLink = document.getElementById("about");
   if (!(root instanceof HTMLElement) || !(messageEl instanceof HTMLElement))
     return;
 
@@ -22,6 +26,14 @@ async function init(): Promise<void> {
   settingsLink?.addEventListener("click", (event) => {
     event.preventDefault();
     chrome.runtime.openOptionsPage();
+  });
+
+  // openOptionsPage() cannot take a hash; open the options URL with #about.
+  aboutLink?.addEventListener("click", (event) => {
+    event.preventDefault();
+    void chrome.tabs.create({
+      url: chrome.runtime.getURL(`${OPTIONS_PAGE}#about`),
+    });
   });
 
   const tab = await getActiveTab();

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -53,6 +53,13 @@ body {
   color: #fefefe;
 }
 
+.popup__links {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
 .popup__link {
   font-size: 12px;
   font-weight: 600;

--- a/src/test/chromeMock.ts
+++ b/src/test/chromeMock.ts
@@ -100,6 +100,11 @@ export function createChromeMock() {
         return port;
       }),
       getURL: vi.fn((path: string) => path),
+      getManifest: vi.fn(() => ({
+        manifest_version: 3,
+        name: "Guided Review",
+        version: "0.1.0",
+      })),
       openOptionsPage: vi.fn(),
       lastError: undefined as { message?: string } | undefined,
       onMessage: {
@@ -129,6 +134,7 @@ export function createChromeMock() {
     tabs: {
       sendMessage: vi.fn(async (_tabId: number, _message: unknown) => undefined),
       query: vi.fn(async (_query: unknown) => []),
+      create: vi.fn(async (_createProperties: unknown) => ({ id: 1 })),
     },
   };
 }


### PR DESCRIPTION
## Summary
- Adds a hash-routed **About** view (`#about`) on the options page that explains what Guided Review does, how a review works, and privacy (local API key, no middleman backend).
- Links About from the Settings footer and from the toolbar popup unsupported-page banner (opens options with `#about`).
- Shares a small `BrandHeader` between Settings and About; covers navigation with unit and e2e tests.

## Test plan
- [ ] Open extension options → click **About Guided Review** → content and version render; **← Settings** returns to the form
- [ ] Open toolbar popup on a non-PR page → **About** opens options at `#about`
- [ ] `npm test -- src/options` and `npm run build` pass