### PR TITLE
Add in-overlay draft comments and submit review flow

### DIFF
--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -9,7 +9,10 @@ import overlayStyles from "./overlay/styles/overlay.css?inline";
 import { useReviewStore, restoreSession, buildSessionKey } from "./overlay/store";
 
 const BUTTON_ID = "guided-review-start-btn";
+const BUTTON_STYLE_ID = "guided-review-start-btn-styles";
 const HOST_ID = "guided-review-overlay-host";
+/** Brand accent hover — keep in sync with `--color-gr-accent-hover` in theme.css. */
+const ACCENT_HOVER = "#b6e64e";
 
 let currentPR: PRIdentity | null = null;
 /** Active stream cancel handle so restart / close can abort the worker. */
@@ -17,7 +20,16 @@ let activeStreamCancel: (() => void) | null = null;
 
 init();
 
+function ensureButtonStyles(): void {
+  if (document.getElementById(BUTTON_STYLE_ID)) return;
+  const style = document.createElement("style");
+  style.id = BUTTON_STYLE_ID;
+  style.textContent = `#${BUTTON_ID}:hover{background:${ACCENT_HOVER};border-color:${ACCENT_HOVER}}`;
+  document.documentElement.appendChild(style);
+}
+
 function init(): void {
+  ensureButtonStyles();
   tryInjectButton();
 
   // Toolbar icon click is handled in the background worker; when the active
@@ -76,6 +88,7 @@ function tryInjectButton(): void {
       "font-weight: 600",
       "cursor: pointer",
       "line-height: 1.2",
+      "transition: background 0.12s ease, border-color 0.12s ease",
     ].join(";"),
   );
 

--- a/src/content/overlay/Overlay.test.tsx
+++ b/src/content/overlay/Overlay.test.tsx
@@ -503,14 +503,14 @@ describe("Overlay", () => {
   });
 
   describe("submit review modal", () => {
-    it("opens from the header Submit review button", () => {
+    it("opens from the header Submit Review button", () => {
       seedReadyReview(0);
       render(<Overlay />);
 
       expect(screen.queryByTestId("submit-review-modal")).not.toBeInTheDocument();
       fireEvent.click(screen.getByTestId("submit-review-button"));
       expect(screen.getByTestId("submit-review-modal")).toBeInTheDocument();
-      expect(screen.getByRole("dialog", { name: "Submit review" })).toBeInTheDocument();
+      expect(screen.getByRole("dialog", { name: "Submit Review" })).toBeInTheDocument();
     });
 
     it("opens with meta+Enter when the modal is closed", () => {

--- a/src/content/overlay/Overlay.test.tsx
+++ b/src/content/overlay/Overlay.test.tsx
@@ -4,6 +4,7 @@ import { Overlay } from "./Overlay";
 import { DEFAULT_DIFF_VIEW_MODE } from "./diffViewMode";
 import { useReviewStore } from "./store";
 import { PR_DESCRIPTION_UNIT_TITLE } from "./displayUnits";
+import { VIEW_CHORD_WINDOW_MS } from "./viewModeChord";
 import type { ParsedDiff, PRContext, ReviewPlan } from "../../lib/types";
 
 function diffFixture(): ParsedDiff {
@@ -70,6 +71,22 @@ function resetStore(): void {
     streamGeneration: 0,
     sessionKey: null,
     diffViewMode: DEFAULT_DIFF_VIEW_MODE,
+    uiMode: "navigate",
+    selectableLines: [],
+    lineSelection: null,
+    composerOpen: false,
+    draftComments: [],
+  });
+}
+
+function seedReadyReview(unitIndex = 1): void {
+  useReviewStore.setState({
+    isOpen: true,
+    status: "ready",
+    diff: diffFixture(),
+    plan: planFixture(),
+    prContext: prContextFixture(),
+    currentUnitIndex: unitIndex,
   });
 }
 
@@ -78,6 +95,8 @@ describe("Overlay", () => {
     resetStore();
     Element.prototype.scrollIntoView = vi.fn();
     Element.prototype.scrollTo = vi.fn();
+    // jsdom does not implement scrollBy; ArrowDown scrolls the code column.
+    Element.prototype.scrollBy = vi.fn();
   });
 
   it("renders nothing when the review isn't open", () => {
@@ -171,7 +190,10 @@ describe("Overlay", () => {
     expect(screen.getByLabelText(/keyboard shortcuts/i)).toBeInTheDocument();
     expect(screen.getByText(/previous \/ next step/i)).toBeInTheDocument();
     expect(screen.getByText(/scroll the code pane/i)).toBeInTheDocument();
-    expect(screen.getByText(/exit the review/i)).toBeInTheDocument();
+    expect(screen.getByText(/^unified view$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^split view$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^enter comment mode$/i)).toBeInTheDocument();
+    expect(screen.getByText(/exit comment mode \/ exit review/i)).toBeInTheDocument();
     expect(screen.queryByText(/building the rest of the walkthrough/i)).not.toBeInTheDocument();
   });
 
@@ -317,6 +339,442 @@ describe("Overlay", () => {
     expect(scrollToMock).toHaveBeenCalledWith({ top: 0 });
     expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: "nearest", behavior: "smooth" });
     expect(screen.getByRole("button", { current: true }).textContent).toMatch(/Update foo/);
+  });
+
+  describe("comment mode keyboard", () => {
+    it("c enters comment mode on a review unit with code", () => {
+      seedReadyReview(1);
+      render(<Overlay />);
+
+      fireEvent.keyDown(window, { key: "c" });
+
+      expect(useReviewStore.getState().uiMode).toBe("comment");
+      expect(useReviewStore.getState().lineSelection).toEqual({
+        anchorIndex: 0,
+        focusIndex: 0,
+      });
+      expect(screen.getByTestId("comment-mode-chip")).toBeInTheDocument();
+      expect(screen.getByTestId("diff-line-focus")).toBeInTheDocument();
+    });
+
+    it("c is a no-op on the description unit", () => {
+      seedReadyReview(0);
+      render(<Overlay />);
+
+      fireEvent.keyDown(window, { key: "c" });
+
+      expect(useReviewStore.getState().uiMode).toBe("navigate");
+    });
+
+    it("ArrowUp/Down move the line cursor instead of scrolling in comment mode", () => {
+      seedReadyReview(1);
+      // Multi-line hunk so cursor can move.
+      useReviewStore.setState({
+        diff: {
+          files: [
+            {
+              path: "src/foo.ts",
+              status: "modified",
+              isBinaryOrElided: false,
+              hunks: [
+                {
+                  id: "src/foo.ts#0",
+                  header: "@@ -1,2 +1,2 @@",
+                  oldStart: 1,
+                  oldLines: 2,
+                  newStart: 1,
+                  newLines: 2,
+                  lines: [
+                    { type: "context", content: "a", oldLine: 1, newLine: 1 },
+                    { type: "add", content: "b", newLine: 2 },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      });
+      render(<Overlay />);
+      fireEvent.keyDown(window, { key: "c" });
+
+      const scrollBy = vi.fn();
+      const codeCol = screen.getByTestId("code-col");
+      codeCol.scrollBy = scrollBy;
+
+      fireEvent.keyDown(window, { key: "ArrowDown" });
+      expect(useReviewStore.getState().lineSelection?.focusIndex).toBe(1);
+      expect(scrollBy).not.toHaveBeenCalled();
+    });
+
+    it("Shift+ArrowDown extends the selection", () => {
+      seedReadyReview(1);
+      useReviewStore.setState({
+        diff: {
+          files: [
+            {
+              path: "src/foo.ts",
+              status: "modified",
+              isBinaryOrElided: false,
+              hunks: [
+                {
+                  id: "src/foo.ts#0",
+                  header: "@@ -1,0 +1,3 @@",
+                  oldStart: 1,
+                  oldLines: 0,
+                  newStart: 1,
+                  newLines: 3,
+                  lines: [
+                    { type: "add", content: "a", newLine: 1 },
+                    { type: "add", content: "b", newLine: 2 },
+                    { type: "add", content: "c", newLine: 3 },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      });
+      render(<Overlay />);
+      fireEvent.keyDown(window, { key: "c" });
+      fireEvent.keyDown(window, { key: "ArrowDown", shiftKey: true });
+      fireEvent.keyDown(window, { key: "ArrowDown", shiftKey: true });
+
+      expect(useReviewStore.getState().lineSelection).toEqual({
+        anchorIndex: 0,
+        focusIndex: 2,
+      });
+    });
+
+    it("Enter opens the composer; Esc exits comment mode", () => {
+      seedReadyReview(1);
+      render(<Overlay />);
+      fireEvent.keyDown(window, { key: "c" });
+      fireEvent.keyDown(window, { key: "Enter" });
+
+      expect(useReviewStore.getState().composerOpen).toBe(true);
+      expect(screen.getByTestId("comment-composer")).toBeInTheDocument();
+
+      fireEvent.keyDown(screen.getByTestId("comment-composer-input"), {
+        key: "Escape",
+      });
+      expect(useReviewStore.getState().composerOpen).toBe(false);
+      expect(useReviewStore.getState().uiMode).toBe("comment");
+
+      fireEvent.keyDown(window, { key: "Escape" });
+      expect(useReviewStore.getState().uiMode).toBe("navigate");
+    });
+
+    it("Ctrl+Enter in the composer saves a draft comment", () => {
+      seedReadyReview(1);
+      render(<Overlay />);
+      fireEvent.keyDown(window, { key: "c" });
+      fireEvent.keyDown(window, { key: "Enter" });
+
+      const input = screen.getByTestId("comment-composer-input");
+      fireEvent.change(input, { target: { value: "Please add a test" } });
+      fireEvent.keyDown(input, { key: "Enter", ctrlKey: true });
+
+      expect(useReviewStore.getState().draftComments).toHaveLength(1);
+      expect(useReviewStore.getState().draftComments[0].body).toBe(
+        "Please add a test",
+      );
+      expect(useReviewStore.getState().composerOpen).toBe(false);
+      expect(screen.getByTestId("draft-comment")).toHaveTextContent(
+        "Please add a test",
+      );
+    });
+
+    it("Ctrl+Enter via window capture saves when the composer textarea is focused", () => {
+      seedReadyReview(1);
+      render(<Overlay />);
+      fireEvent.keyDown(window, { key: "c" });
+      fireEvent.keyDown(window, { key: "Enter" });
+
+      const input = screen.getByTestId("comment-composer-input");
+      fireEvent.change(input, { target: { value: "From window handler" } });
+      input.focus();
+      fireEvent.keyDown(input, { key: "Enter", ctrlKey: true, bubbles: true });
+
+      expect(useReviewStore.getState().draftComments).toHaveLength(1);
+      expect(useReviewStore.getState().draftComments[0].body).toBe(
+        "From window handler",
+      );
+    });
+  });
+
+  describe("submit review modal", () => {
+    it("opens from the header Submit review button", () => {
+      seedReadyReview(0);
+      render(<Overlay />);
+
+      expect(screen.queryByTestId("submit-review-modal")).not.toBeInTheDocument();
+      fireEvent.click(screen.getByTestId("submit-review-button"));
+      expect(screen.getByTestId("submit-review-modal")).toBeInTheDocument();
+      expect(screen.getByRole("dialog", { name: "Submit review" })).toBeInTheDocument();
+    });
+
+    it("opens with meta+Enter when the modal is closed", () => {
+      seedReadyReview(0);
+      render(<Overlay />);
+
+      expect(screen.queryByTestId("submit-review-modal")).not.toBeInTheDocument();
+      fireEvent.keyDown(window, { key: "Enter", metaKey: true });
+      expect(screen.getByTestId("submit-review-modal")).toBeInTheDocument();
+    });
+
+    it("opens with Ctrl+Enter when the modal is closed", () => {
+      seedReadyReview(0);
+      render(<Overlay />);
+
+      fireEvent.keyDown(window, { key: "Enter", ctrlKey: true });
+      expect(screen.getByTestId("submit-review-modal")).toBeInTheDocument();
+    });
+
+    it("opens with meta+Enter from comment mode (without opening the line composer)", () => {
+      seedReadyReview(1);
+      render(<Overlay />);
+
+      fireEvent.keyDown(window, { key: "c" });
+      expect(useReviewStore.getState().uiMode).toBe("comment");
+
+      fireEvent.keyDown(window, { key: "Enter", metaKey: true });
+      expect(screen.getByTestId("submit-review-modal")).toBeInTheDocument();
+      expect(useReviewStore.getState().composerOpen).toBe(false);
+    });
+
+    it("closes on Esc without exiting the overlay", () => {
+      seedReadyReview(0);
+      render(<Overlay />);
+
+      fireEvent.click(screen.getByTestId("submit-review-button"));
+      expect(screen.getByTestId("submit-review-modal")).toBeInTheDocument();
+
+      fireEvent.keyDown(window, { key: "Escape" });
+      expect(screen.queryByTestId("submit-review-modal")).not.toBeInTheDocument();
+      expect(useReviewStore.getState().isOpen).toBe(true);
+    });
+
+    it("exits the overlay on Esc after the modal is closed", () => {
+      seedReadyReview(0);
+      render(<Overlay />);
+
+      fireEvent.click(screen.getByTestId("submit-review-button"));
+      fireEvent.keyDown(window, { key: "Escape" });
+      expect(screen.queryByTestId("submit-review-modal")).not.toBeInTheDocument();
+
+      fireEvent.keyDown(window, { key: "Escape" });
+      expect(useReviewStore.getState().isOpen).toBe(false);
+    });
+
+    it("closes the modal on submit without calling network", () => {
+      seedReadyReview(0);
+      render(<Overlay />);
+
+      fireEvent.click(screen.getByTestId("submit-review-button"));
+      fireEvent.click(screen.getByTestId("submit-review-event-APPROVE"));
+      fireEvent.change(screen.getByTestId("submit-review-body"), {
+        target: { value: "Looks good" },
+      });
+      fireEvent.click(screen.getByTestId("submit-review-confirm"));
+
+      expect(screen.queryByTestId("submit-review-modal")).not.toBeInTheDocument();
+      expect(useReviewStore.getState().isOpen).toBe(true);
+    });
+
+    it("submits with meta+Enter via the window capture handler", () => {
+      seedReadyReview(0);
+      render(<Overlay />);
+
+      fireEvent.click(screen.getByTestId("submit-review-button"));
+      fireEvent.click(screen.getByTestId("submit-review-event-APPROVE"));
+      fireEvent.change(screen.getByTestId("submit-review-body"), {
+        target: { value: "Approved via shortcut" },
+      });
+      fireEvent.keyDown(window, { key: "Enter", metaKey: true });
+
+      expect(screen.queryByTestId("submit-review-modal")).not.toBeInTheDocument();
+      expect(useReviewStore.getState().isOpen).toBe(true);
+    });
+
+    it("submits with Ctrl+Enter via the window capture handler", () => {
+      seedReadyReview(0);
+      render(<Overlay />);
+
+      fireEvent.click(screen.getByTestId("submit-review-button"));
+      fireEvent.click(screen.getByTestId("submit-review-event-COMMENT"));
+      fireEvent.keyDown(window, { key: "Enter", ctrlKey: true });
+
+      expect(screen.queryByTestId("submit-review-modal")).not.toBeInTheDocument();
+      expect(useReviewStore.getState().isOpen).toBe(true);
+    });
+
+    it("ArrowDown and Enter on choose step advance via window capture", () => {
+      seedReadyReview(0);
+      render(<Overlay />);
+
+      fireEvent.click(screen.getByTestId("submit-review-button"));
+      expect(screen.getByTestId("submit-review-modal")).toHaveAttribute(
+        "data-step",
+        "choose",
+      );
+
+      fireEvent.keyDown(window, { key: "ArrowDown" });
+      expect(screen.getByTestId("submit-review-event-APPROVE")).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+
+      fireEvent.keyDown(window, { key: "Enter" });
+      expect(screen.getByTestId("submit-review-modal")).toHaveAttribute(
+        "data-step",
+        "compose",
+      );
+      expect(screen.getByTestId("submit-review-selected-event")).toHaveAttribute(
+        "data-event",
+        "APPROVE",
+      );
+    });
+  });
+
+  describe("view mode keyboard chords", () => {
+    it("v then u switches to unified view", () => {
+      seedReadyReview(1);
+      render(<Overlay />);
+
+      expect(useReviewStore.getState().diffViewMode).toBe("split");
+      expect(screen.getByTestId("diff-view-split")).toBeInTheDocument();
+
+      fireEvent.keyDown(window, { key: "v" });
+      fireEvent.keyDown(window, { key: "u" });
+
+      expect(useReviewStore.getState().diffViewMode).toBe("unified");
+      expect(screen.getByTestId("diff-view-unified")).toBeInTheDocument();
+      expect(screen.queryByTestId("diff-view-split")).not.toBeInTheDocument();
+    });
+
+    it("v then s switches to split view", () => {
+      seedReadyReview(1);
+      useReviewStore.setState({ diffViewMode: "unified" });
+      render(<Overlay />);
+
+      fireEvent.keyDown(window, { key: "v" });
+      fireEvent.keyDown(window, { key: "s" });
+
+      expect(useReviewStore.getState().diffViewMode).toBe("split");
+      expect(screen.getByTestId("diff-view-split")).toBeInTheDocument();
+    });
+
+    it("does not switch when the second key arrives after the chord window", () => {
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date("2020-01-01T00:00:00.000Z"));
+        seedReadyReview(1);
+        render(<Overlay />);
+
+        fireEvent.keyDown(window, { key: "v" });
+        vi.setSystemTime(
+          new Date(Date.parse("2020-01-01T00:00:00.000Z") + VIEW_CHORD_WINDOW_MS + 1),
+        );
+        fireEvent.keyDown(window, { key: "u" });
+
+        expect(useReviewStore.getState().diffViewMode).toBe("split");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("works in comment mode", () => {
+      seedReadyReview(1);
+      render(<Overlay />);
+
+      fireEvent.keyDown(window, { key: "c" });
+      expect(useReviewStore.getState().uiMode).toBe("comment");
+
+      fireEvent.keyDown(window, { key: "v" });
+      fireEvent.keyDown(window, { key: "u" });
+
+      expect(useReviewStore.getState().diffViewMode).toBe("unified");
+      expect(useReviewStore.getState().uiMode).toBe("comment");
+    });
+
+    it("does not change view mode while the composer is open", () => {
+      seedReadyReview(1);
+      render(<Overlay />);
+
+      fireEvent.keyDown(window, { key: "c" });
+      fireEvent.keyDown(window, { key: "Enter" });
+      expect(useReviewStore.getState().composerOpen).toBe(true);
+
+      fireEvent.keyDown(window, { key: "v" });
+      fireEvent.keyDown(window, { key: "u" });
+
+      expect(useReviewStore.getState().diffViewMode).toBe("split");
+    });
+  });
+
+  describe("keyboard isolation from the host page", () => {
+    function dispatchKeyOnWindow(key: string, init: KeyboardEventInit = {}) {
+      const event = new KeyboardEvent("keydown", {
+        key,
+        bubbles: true,
+        cancelable: true,
+        ...init,
+      });
+      const stopSpy = vi.spyOn(event, "stopPropagation");
+      const preventSpy = vi.spyOn(event, "preventDefault");
+      window.dispatchEvent(event);
+      return { event, stopSpy, preventSpy };
+    }
+
+    it("stops propagation for unhandled keys so GitHub shortcuts cannot run", () => {
+      seedReadyReview(0);
+      render(<Overlay />);
+
+      for (const key of ["s", "t", "a", "i", "?", "/"]) {
+        const { stopSpy } = dispatchKeyOnWindow(key);
+        expect(stopSpy).toHaveBeenCalled();
+      }
+      // Overlay stays open; GitHub-style keys did not trigger our exit path.
+      expect(useReviewStore.getState().isOpen).toBe(true);
+    });
+
+    it("stops propagation for GitHub shortcut letters while the composer is open", () => {
+      seedReadyReview(1);
+      render(<Overlay />);
+      fireEvent.keyDown(window, { key: "c" });
+      fireEvent.keyDown(window, { key: "Enter" });
+      expect(useReviewStore.getState().composerOpen).toBe(true);
+
+      for (const key of ["s", "t", "c", "a", "i"]) {
+        const { stopSpy, preventSpy } = dispatchKeyOnWindow(key);
+        expect(stopSpy).toHaveBeenCalled();
+        // Character keys must not be cancelled so the textarea can receive them.
+        expect(preventSpy).not.toHaveBeenCalled();
+      }
+      expect(useReviewStore.getState().composerOpen).toBe(true);
+      expect(useReviewStore.getState().isOpen).toBe(true);
+    });
+
+    it("does not preventDefault for printable keys in the composer (typing allowed)", () => {
+      seedReadyReview(1);
+      render(<Overlay />);
+      fireEvent.keyDown(window, { key: "c" });
+      fireEvent.keyDown(window, { key: "Enter" });
+
+      const input = screen.getByTestId("comment-composer-input");
+      const event = new KeyboardEvent("keydown", {
+        key: "s",
+        bubbles: true,
+        cancelable: true,
+      });
+      const preventSpy = vi.spyOn(event, "preventDefault");
+      const stopSpy = vi.spyOn(event, "stopPropagation");
+      input.dispatchEvent(event);
+
+      expect(stopSpy).toHaveBeenCalled();
+      expect(preventSpy).not.toHaveBeenCalled();
+      expect(useReviewStore.getState().composerOpen).toBe(true);
+    });
   });
 });
 

--- a/src/content/overlay/Overlay.tsx
+++ b/src/content/overlay/Overlay.tsx
@@ -1,17 +1,50 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useReviewStore, persistSession } from "./store";
 import { resolveUnitFiles } from "./selectors";
 import { buildDisplayUnits, displayUnitCount } from "./displayUnits";
+import { buildSelectableLines } from "./buildSelectableLines";
+import {
+  recordViewChordKey,
+  type ViewChordPending,
+} from "./viewModeChord";
+import type { ReviewSubmission } from "./commentTypes";
 import { ProgressHeader } from "./components/ProgressHeader";
 import { Sidebar } from "./components/Sidebar";
 import { DiffPane } from "./components/DiffPane";
 import { DescriptionPane } from "./components/DescriptionPane";
 import { ContextPanel } from "./components/ContextPanel";
 import { FooterNav } from "./components/FooterNav";
+import { SubmitReviewModal } from "./components/SubmitReviewModal";
 
 interface OverlayProps {
   /** Invoked when the user exits so any in-flight stream can be cancelled. */
   onRequestClose?: () => void;
+}
+
+/**
+ * Whether this keydown targets an editable control. Uses composedPath so we
+ * see elements inside the overlay's open shadow root (event.target is retargeted
+ * to the host for listeners outside the shadow tree).
+ */
+function findEditableInPath(event: KeyboardEvent): HTMLElement | null {
+  for (const node of event.composedPath()) {
+    if (!(node instanceof HTMLElement)) continue;
+    const tag = node.tagName;
+    if (tag === "TEXTAREA" || tag === "INPUT" || tag === "SELECT") return node;
+    if (node.isContentEditable) return node;
+  }
+  return null;
+}
+
+function isEditableEvent(event: KeyboardEvent): boolean {
+  return findEditableInPath(event) !== null;
+}
+
+function editableTextValue(el: HTMLElement): string {
+  if (el instanceof HTMLTextAreaElement || el instanceof HTMLInputElement) {
+    return el.value;
+  }
+  return el.innerText ?? "";
 }
 
 export function Overlay({ onRequestClose }: OverlayProps) {
@@ -23,21 +56,39 @@ export function Overlay({ onRequestClose }: OverlayProps) {
   const prContext = useReviewStore((s) => s.prContext);
   const currentUnitIndex = useReviewStore((s) => s.currentUnitIndex);
   const sessionKey = useReviewStore((s) => s.sessionKey);
+  const uiMode = useReviewStore((s) => s.uiMode);
+  const diffViewMode = useReviewStore((s) => s.diffViewMode);
   const close = useReviewStore((s) => s.close);
   const goToUnit = useReviewStore((s) => s.goToUnit);
   const goNext = useReviewStore((s) => s.goNext);
   const goPrev = useReviewStore((s) => s.goPrev);
   const codeColRef = useRef<HTMLElement>(null);
   const contextPaneRef = useRef<HTMLDivElement>(null);
+  /** Pending `v` leader for view-mode chords (`v+u` / `v+s`). */
+  const viewChordRef = useRef<ViewChordPending>(null);
+  const [submitReviewOpen, setSubmitReviewOpen] = useState(false);
+  /** Latest submit action from the open Submit review modal (for ⌘/Ctrl+Enter). */
+  const submitReviewActionRef = useRef<(() => void) | null>(null);
+  /** Choose-step keys (↑/↓/Enter) for the open Submit review modal. */
+  const submitReviewKeyRef = useRef<((e: KeyboardEvent) => boolean) | null>(
+    null,
+  );
 
   const handleExit = () => {
     onRequestClose?.();
     close();
   };
 
+  const handleSubmitReview = (_submission: ReviewSubmission) => {
+    // API integration later — UI only closes the modal for now.
+    setSubmitReviewOpen(false);
+  };
+
+  const draftComments = useReviewStore((s) => s.draftComments);
+
   useEffect(() => {
     if (status === "ready") void persistSession();
-  }, [status, currentUnitIndex, sessionKey]);
+  }, [status, currentUnitIndex, sessionKey, draftComments]);
 
   // When the active unit changes (keyboard ←/→, footer nav, or sidebar click),
   // reset the code and context panes so the new step starts at the top rather
@@ -58,43 +109,203 @@ export function Overlay({ onRequestClose }: OverlayProps) {
     };
   }, [isOpen]);
 
+  const planStillBuilding = status === "loading" || status === "streaming";
+  // Spinner on the description unit only while the plan is still being built.
+  const showBuildingSpinner = planStillBuilding && (!plan || currentUnitIndex === 0);
+  const displayUnits = buildDisplayUnits(plan);
+  const total = displayUnitCount(plan);
+  const currentDisplay = displayUnits[currentUnitIndex] ?? displayUnits[0];
+  const isDescriptionUnit = !currentDisplay || currentDisplay.kind === "pr_description";
+  const currentReviewUnit =
+    currentDisplay?.kind === "review" ? currentDisplay.unit : null;
+
+  const resolvedFiles = useMemo(
+    () =>
+      currentReviewUnit && diff
+        ? resolveUnitFiles(currentReviewUnit, diff)
+        : [],
+    [currentReviewUnit, diff],
+  );
+
+  const selectableForUnit = useMemo(
+    () => buildSelectableLines(resolvedFiles, diffViewMode),
+    [resolvedFiles, diffViewMode],
+  );
+
+  // Keep store selectable lines in sync while in comment mode (e.g. view toggle).
+  useEffect(() => {
+    if (uiMode !== "comment") return;
+    useReviewStore.getState().setSelectableLines(selectableForUnit);
+  }, [uiMode, selectableForUnit]);
+
+  const currentUnitId = currentReviewUnit?.id;
+
   useEffect(() => {
     if (!isOpen) return;
 
     const SCROLL_STEP = 120;
+    viewChordRef.current = null;
 
-    // Listen on window in the capture phase so these shortcuts fire before
-    // any listener GitHub itself has registered (including its own keyboard
-    // shortcut handling), and regardless of which element currently has
-    // focus. stopPropagation/preventDefault keep the keystroke from ever
-    // reaching the underlying GitHub page.
+    // Capture on window so we run before GitHub's document-level shortcuts.
+    // The overlay mounts in an open shadow root; with focus inside it,
+    // document.activeElement is the host — GitHub thinks nothing is focused
+    // and would fire s/t/c/a/i/etc. Always stopPropagation so the page never
+    // sees keys while the overlay is open. Only preventDefault when we consume
+    // the key (so typing into the comment composer still inserts characters).
     function onKeyDown(event: KeyboardEvent): void {
+      event.stopPropagation();
+
+      // Submit-review modal: Esc closes the dialog only (not the whole overlay).
+      // ⌘/Ctrl+Enter submits on the compose step; ↑/↓/Enter drive the choose step.
+      // Handled here because capture stopPropagation blocks element React handlers.
+      if (submitReviewOpen) {
+        viewChordRef.current = null;
+        if (event.key === "Escape") {
+          event.preventDefault();
+          setSubmitReviewOpen(false);
+          return;
+        }
+        if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+          event.preventDefault();
+          submitReviewActionRef.current?.();
+          return;
+        }
+        if (submitReviewKeyRef.current?.(event)) {
+          event.preventDefault();
+        }
+        return;
+      }
+
+      const store = useReviewStore.getState();
+      const editable = isEditableEvent(event);
+
+      // Composer / any editable: let the control own typing. Handle Esc and
+      // ⌘/Ctrl+Enter here because stopPropagation in capture prevents the
+      // textarea's React onKeyDown from running for real keystrokes.
+      if (store.composerOpen || editable) {
+        viewChordRef.current = null;
+        if (event.key === "Escape") {
+          event.preventDefault();
+          if (store.composerOpen) store.closeComposer();
+          return;
+        }
+        if (
+          store.composerOpen &&
+          event.key === "Enter" &&
+          (event.metaKey || event.ctrlKey)
+        ) {
+          event.preventDefault();
+          const el = findEditableInPath(event);
+          const body = el ? editableTextValue(el) : "";
+          store.saveDraftComment(body, currentUnitId);
+          return;
+        }
+        return;
+      }
+
+      // ⌘/Ctrl+Enter opens the Submit review modal (when not typing in a field).
+      if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        viewChordRef.current = null;
+        setSubmitReviewOpen(true);
+        return;
+      }
+
+      // View-mode chords: v+u (unified), v+s (split). Both navigate and comment mode.
+      if (
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.altKey &&
+        !event.shiftKey
+      ) {
+        const { next, mode, consumed } = recordViewChordKey(
+          viewChordRef.current,
+          event.key,
+          Date.now(),
+        );
+        viewChordRef.current = next;
+        if (consumed) {
+          event.preventDefault();
+          if (mode) store.setDiffViewMode(mode);
+          return;
+        }
+      } else {
+        viewChordRef.current = null;
+      }
+
+      if (store.uiMode === "comment") {
+        switch (event.key) {
+          case "Escape":
+            event.preventDefault();
+            viewChordRef.current = null;
+            store.exitCommentMode();
+            return;
+          case "ArrowUp":
+            event.preventDefault();
+            viewChordRef.current = null;
+            store.moveLineCursor(-1, event.shiftKey);
+            return;
+          case "ArrowDown":
+            event.preventDefault();
+            viewChordRef.current = null;
+            store.moveLineCursor(1, event.shiftKey);
+            return;
+          case "Enter":
+            event.preventDefault();
+            viewChordRef.current = null;
+            store.openComposer();
+            return;
+          case "ArrowRight":
+            event.preventDefault();
+            viewChordRef.current = null;
+            store.goNext();
+            return;
+          case "ArrowLeft":
+            event.preventDefault();
+            viewChordRef.current = null;
+            store.goPrev();
+            return;
+          default:
+            return;
+        }
+      }
+
+      // navigate mode
       switch (event.key) {
         case "Escape":
           event.preventDefault();
-          event.stopPropagation();
+          viewChordRef.current = null;
           onRequestClose?.();
-          useReviewStore.getState().close();
+          store.close();
           return;
         case "ArrowRight":
           event.preventDefault();
-          event.stopPropagation();
-          useReviewStore.getState().goNext();
+          viewChordRef.current = null;
+          store.goNext();
           return;
         case "ArrowLeft":
           event.preventDefault();
-          event.stopPropagation();
-          useReviewStore.getState().goPrev();
+          viewChordRef.current = null;
+          store.goPrev();
           return;
         case "ArrowUp":
           event.preventDefault();
-          event.stopPropagation();
+          viewChordRef.current = null;
           codeColRef.current?.scrollBy({ top: -SCROLL_STEP, behavior: "smooth" });
           return;
         case "ArrowDown":
           event.preventDefault();
-          event.stopPropagation();
+          viewChordRef.current = null;
           codeColRef.current?.scrollBy({ top: SCROLL_STEP, behavior: "smooth" });
+          return;
+        case "c":
+        case "C":
+          if (event.metaKey || event.ctrlKey || event.altKey) return;
+          event.preventDefault();
+          viewChordRef.current = null;
+          if (selectableForUnit.length > 0) {
+            store.enterCommentMode(selectableForUnit);
+          }
           return;
         default:
           return;
@@ -103,34 +314,19 @@ export function Overlay({ onRequestClose }: OverlayProps) {
 
     window.addEventListener("keydown", onKeyDown, true);
     return () => window.removeEventListener("keydown", onKeyDown, true);
-  }, [isOpen, onRequestClose]);
+  }, [isOpen, onRequestClose, selectableForUnit, currentUnitId, submitReviewOpen]);
 
   if (!isOpen) return null;
-
-  const planStillBuilding = status === "loading" || status === "streaming";
-  // Spinner on the description unit only while the plan is still being built.
-  const showBuildingSpinner = planStillBuilding && (!plan || currentUnitIndex === 0);
-  const displayUnits = buildDisplayUnits(plan);
-  const total = displayUnitCount(plan);
-  const totalKnown = status === "ready";
-  const currentDisplay = displayUnits[currentUnitIndex] ?? displayUnits[0];
-  const isDescriptionUnit = !currentDisplay || currentDisplay.kind === "pr_description";
-  const currentReviewUnit =
-    currentDisplay?.kind === "review" ? currentDisplay.unit : null;
-  const resolvedFiles =
-    currentReviewUnit && diff ? resolveUnitFiles(currentReviewUnit, diff) : [];
 
   return (
     <div
       className="fixed inset-0 z-[2147483000] flex flex-col bg-gr-bg font-sans text-sm text-gr-text antialiased [color-scheme:dark] [text-rendering:optimizeLegibility]"
     >
       <ProgressHeader
-        currentIndex={currentUnitIndex}
-        total={total}
-        totalKnown={totalKnown}
         prContext={prContext}
         diff={diff}
         onExit={handleExit}
+        onSubmitReview={() => setSubmitReviewOpen(true)}
       />
 
       <div className="flex min-h-0 flex-1">
@@ -145,6 +341,7 @@ export function Overlay({ onRequestClose }: OverlayProps) {
             <DiffPane
               files={resolvedFiles}
               unitTitle={currentReviewUnit?.title ?? ""}
+              unitId={currentReviewUnit?.id}
             />
           )}
         </main>
@@ -179,6 +376,14 @@ export function Overlay({ onRequestClose }: OverlayProps) {
         total={total}
         onPrev={goPrev}
         onNext={goNext}
+      />
+
+      <SubmitReviewModal
+        open={submitReviewOpen}
+        onClose={() => setSubmitReviewOpen(false)}
+        onSubmit={handleSubmitReview}
+        submitActionRef={submitReviewActionRef}
+        keyActionRef={submitReviewKeyRef}
       />
     </div>
   );

--- a/src/content/overlay/Overlay.tsx
+++ b/src/content/overlay/Overlay.tsx
@@ -67,9 +67,9 @@ export function Overlay({ onRequestClose }: OverlayProps) {
   /** Pending `v` leader for view-mode chords (`v+u` / `v+s`). */
   const viewChordRef = useRef<ViewChordPending>(null);
   const [submitReviewOpen, setSubmitReviewOpen] = useState(false);
-  /** Latest submit action from the open Submit review modal (for ⌘/Ctrl+Enter). */
+  /** Latest submit action from the open Submit Review modal (for ⌘/Ctrl+Enter). */
   const submitReviewActionRef = useRef<(() => void) | null>(null);
-  /** Choose-step keys (↑/↓/Enter) for the open Submit review modal. */
+  /** Choose-step keys (↑/↓/Enter) for the open Submit Review modal. */
   const submitReviewKeyRef = useRef<((e: KeyboardEvent) => boolean) | null>(
     null,
   );
@@ -203,7 +203,7 @@ export function Overlay({ onRequestClose }: OverlayProps) {
         return;
       }
 
-      // ⌘/Ctrl+Enter opens the Submit review modal (when not typing in a field).
+      // ⌘/Ctrl+Enter opens the Submit Review modal (when not typing in a field).
       if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
         event.preventDefault();
         viewChordRef.current = null;

--- a/src/content/overlay/buildSelectableLines.test.ts
+++ b/src/content/overlay/buildSelectableLines.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import type { DiffFile, DiffHunk } from "../../lib/types";
+import { buildSelectableLines } from "./buildSelectableLines";
+import type { ResolvedUnitFile } from "./selectors";
+
+function hunkFixture(overrides: Partial<DiffHunk> = {}): DiffHunk {
+  return {
+    id: "src/foo.ts#0",
+    header: "@@ -1,3 +1,4 @@",
+    oldStart: 1,
+    oldLines: 3,
+    newStart: 1,
+    newLines: 4,
+    lines: [
+      { type: "context", content: "const a = 1;", oldLine: 1, newLine: 1 },
+      { type: "del", content: "const b = 2;", oldLine: 2 },
+      { type: "add", content: "const b = 3;", newLine: 2 },
+      { type: "add", content: "const c = 4;", newLine: 3 },
+      { type: "context", content: "export { a, b };", oldLine: 3, newLine: 4 },
+    ],
+    ...overrides,
+  };
+}
+
+function fileFixture(overrides: Partial<DiffFile> = {}): DiffFile {
+  return {
+    path: "src/foo.ts",
+    status: "modified",
+    isBinaryOrElided: false,
+    hunks: [hunkFixture()],
+    ...overrides,
+  };
+}
+
+function resolved(files: DiffFile[] = [fileFixture()]): ResolvedUnitFile[] {
+  return files.map((file) => ({ file, hunks: file.hunks }));
+}
+
+describe("buildSelectableLines", () => {
+  it("returns empty for no files", () => {
+    expect(buildSelectableLines([], "unified")).toEqual([]);
+    expect(buildSelectableLines([], "split")).toEqual([]);
+  });
+
+  it("skips binary/elided files", () => {
+    const files = resolved([
+      fileFixture({ path: "logo.png", isBinaryOrElided: true, hunks: [] }),
+    ]);
+    expect(buildSelectableLines(files, "unified")).toEqual([]);
+  });
+
+  it("unified: one row per line with del→LEFT and add/context→RIGHT", () => {
+    const lines = buildSelectableLines(resolved(), "unified");
+    expect(lines).toHaveLength(5);
+    expect(lines.map((l) => [l.type, l.side, l.id])).toEqual([
+      ["context", "RIGHT", "src/foo.ts#0:0:RIGHT"],
+      ["del", "LEFT", "src/foo.ts#0:1:LEFT"],
+      ["add", "RIGHT", "src/foo.ts#0:2:RIGHT"],
+      ["add", "RIGHT", "src/foo.ts#0:3:RIGHT"],
+      ["context", "RIGHT", "src/foo.ts#0:4:RIGHT"],
+    ]);
+    expect(lines[1].oldLine).toBe(2);
+    expect(lines[2].newLine).toBe(2);
+  });
+
+  it("split: emits only RIGHT content cells per row", () => {
+    const lines = buildSelectableLines(resolved(), "split");
+    // context R, del+add pair: R only, add-only R, context R → 4
+    expect(lines).toHaveLength(4);
+    expect(lines.every((l) => l.side === "RIGHT")).toBe(true);
+    expect(lines.map((l) => [l.type, l.id])).toEqual([
+      ["context", "src/foo.ts#0:0:RIGHT"],
+      ["add", "src/foo.ts#0:2:RIGHT"],
+      ["add", "src/foo.ts#0:3:RIGHT"],
+      ["context", "src/foo.ts#0:4:RIGHT"],
+    ]);
+    expect(lines[2]).toMatchObject({
+      type: "add",
+      side: "RIGHT",
+      newLine: 3,
+      lineIndex: 3,
+    });
+  });
+
+  it("split: pure deletions emit no selectable lines", () => {
+    const files = resolved([
+      fileFixture({
+        path: "gone.ts",
+        hunks: [
+          hunkFixture({
+            id: "gone.ts#0",
+            lines: [
+              { type: "del", content: "a", oldLine: 1 },
+              { type: "del", content: "b", oldLine: 2 },
+            ],
+          }),
+        ],
+      }),
+    ]);
+    const lines = buildSelectableLines(files, "split");
+    expect(lines).toHaveLength(0);
+  });
+
+  it("walks multiple files in order", () => {
+    const files = resolved([
+      fileFixture({ path: "a.ts", hunks: [hunkFixture({ id: "a.ts#0", lines: [
+        { type: "add", content: "x", newLine: 1 },
+      ] })] }),
+      fileFixture({ path: "b.ts", hunks: [hunkFixture({ id: "b.ts#0", lines: [
+        { type: "add", content: "y", newLine: 1 },
+      ] })] }),
+    ]);
+    const lines = buildSelectableLines(files, "unified");
+    expect(lines.map((l) => l.filePath)).toEqual(["a.ts", "b.ts"]);
+  });
+});

--- a/src/content/overlay/buildSelectableLines.ts
+++ b/src/content/overlay/buildSelectableLines.ts
@@ -1,0 +1,82 @@
+import type { DiffLine } from "../../lib/types";
+import { buildSplitRows } from "./buildSplitRows";
+import type { DiffViewMode } from "./diffViewMode";
+import type { DiffSide, SelectableLine } from "./commentTypes";
+import type { ResolvedUnitFile } from "./selectors";
+
+function lineId(hunkId: string, lineIndex: number, side: DiffSide): string {
+  return `${hunkId}:${lineIndex}:${side}`;
+}
+
+function fromDiffLine(
+  filePath: string,
+  hunkId: string,
+  lineIndex: number,
+  line: DiffLine,
+  side: DiffSide,
+): SelectableLine {
+  return {
+    id: lineId(hunkId, lineIndex, side),
+    filePath,
+    hunkId,
+    lineIndex,
+    side,
+    oldLine: line.oldLine,
+    newLine: line.newLine,
+    type: line.type,
+  };
+}
+
+/**
+ * Unified: one selectable row per diff line.
+ * - del → LEFT (old file)
+ * - add → RIGHT (new file)
+ * - context → RIGHT (GitHub-style “comment on new”)
+ */
+function buildUnified(files: ResolvedUnitFile[]): SelectableLine[] {
+  const out: SelectableLine[] = [];
+  for (const { file, hunks } of files) {
+    if (file.isBinaryOrElided) continue;
+    for (const hunk of hunks) {
+      hunk.lines.forEach((line, lineIndex) => {
+        const side: DiffSide = line.type === "del" ? "LEFT" : "RIGHT";
+        out.push(fromDiffLine(file.path, hunk.id, lineIndex, line, side));
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Split: only RIGHT (new-file / changes) cells are commentable, ordered
+ * file → hunk → row → right cell (if any).
+ * Pure deletions have no RIGHT cells — use unified view to comment on them.
+ */
+function buildSplit(files: ResolvedUnitFile[]): SelectableLine[] {
+  const out: SelectableLine[] = [];
+  for (const { file, hunks } of files) {
+    if (file.isBinaryOrElided) continue;
+    for (const hunk of hunks) {
+      const rows = buildSplitRows(hunk.lines);
+      for (const row of rows) {
+        if (row.right.kind === "content") {
+          const line = hunk.lines[row.right.sourceIndex];
+          if (line) {
+            out.push(
+              fromDiffLine(file.path, hunk.id, row.right.sourceIndex, line, "RIGHT"),
+            );
+          }
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/** Flat keyboard-navigable line list for the current unit + diff view mode. */
+export function buildSelectableLines(
+  files: ResolvedUnitFile[],
+  viewMode: DiffViewMode,
+): SelectableLine[] {
+  return viewMode === "split" ? buildSplit(files) : buildUnified(files);
+}

--- a/src/content/overlay/commentTypes.ts
+++ b/src/content/overlay/commentTypes.ts
@@ -1,0 +1,92 @@
+/**
+ * Local draft review-comment types for the overlay.
+ * Kept out of `src/lib/types.ts` until a GitHub post path exists.
+ */
+
+export type DiffSide = "LEFT" | "RIGHT";
+
+/** One keyboard-selectable line anchor in the current unit's code pane. */
+export interface SelectableLine {
+  /** Stable id: `${hunkId}:${lineIndex}:${side}` */
+  id: string;
+  filePath: string;
+  hunkId: string;
+  /** Index into `DiffHunk.lines`. */
+  lineIndex: number;
+  side: DiffSide;
+  oldLine?: number;
+  newLine?: number;
+  type: "add" | "del" | "context";
+}
+
+/** Inclusive range in the flat selectable-line list (anchor + cursor). */
+export interface LineSelection {
+  /** Flat-list index where shift-select started. */
+  anchorIndex: number;
+  /** Flat-list index of the current cursor. */
+  focusIndex: number;
+}
+
+/** A locally saved draft comment (not yet posted to GitHub). */
+export interface DraftComment {
+  id: string;
+  filePath: string;
+  side: DiffSide;
+  /** Inclusive display line numbers on `side` (file coordinates). */
+  startLine: number;
+  endLine: number;
+  /** SelectableLine ids covering the range (for highlight + placement). */
+  lineIds: string[];
+  body: string;
+  /** Review unit id active when the comment was saved, if any. */
+  unitId?: string;
+}
+
+export type UiMode = "navigate" | "comment";
+
+/** GitHub pull request review event (API names; ready for a later post path). */
+export type ReviewEvent = "COMMENT" | "APPROVE" | "REQUEST_CHANGES";
+
+/** Summary body + event chosen in the Submit review modal. */
+export interface ReviewSubmission {
+  body: string;
+  event: ReviewEvent;
+}
+
+/** File-side line number used for labels and future API mapping. */
+export function displayLineNumber(line: SelectableLine): number | undefined {
+  return line.side === "LEFT" ? line.oldLine : line.newLine;
+}
+
+export function selectionBounds(sel: LineSelection): { start: number; end: number } {
+  return {
+    start: Math.min(sel.anchorIndex, sel.focusIndex),
+    end: Math.max(sel.anchorIndex, sel.focusIndex),
+  };
+}
+
+/**
+ * Lines included in the current selection: same file + side as the anchor,
+ * with flat indices between anchor and focus (inclusive).
+ */
+export function linesInSelection(
+  lines: SelectableLine[],
+  sel: LineSelection,
+): SelectableLine[] {
+  if (lines.length === 0) return [];
+  const anchor = lines[sel.anchorIndex];
+  if (!anchor) return [];
+  const { start, end } = selectionBounds(sel);
+  return lines.slice(start, end + 1).filter(
+    (l) => l.filePath === anchor.filePath && l.side === anchor.side,
+  );
+}
+
+export function formatLineRangeLabel(
+  filePath: string,
+  startLine: number,
+  endLine: number,
+): string {
+  if (startLine === endLine) return `${filePath}:L${startLine}`;
+  return `${filePath}:L${startLine}–L${endLine}`;
+}

--- a/src/content/overlay/commentTypes.ts
+++ b/src/content/overlay/commentTypes.ts
@@ -47,7 +47,7 @@ export type UiMode = "navigate" | "comment";
 /** GitHub pull request review event (API names; ready for a later post path). */
 export type ReviewEvent = "COMMENT" | "APPROVE" | "REQUEST_CHANGES";
 
-/** Summary body + event chosen in the Submit review modal. */
+/** Summary body + event chosen in the Submit Review modal. */
 export interface ReviewSubmission {
   body: string;
   event: ReviewEvent;

--- a/src/content/overlay/components/CommentComposer.test.tsx
+++ b/src/content/overlay/components/CommentComposer.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { CommentComposer } from "./CommentComposer";
+
+describe("CommentComposer", () => {
+  it("renders the line range label and autofocuses the textarea", () => {
+    render(
+      <CommentComposer
+        filePath="src/foo.ts"
+        startLine={12}
+        endLine={15}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("comment-composer")).toHaveTextContent(
+      "src/foo.ts:L12–L15",
+    );
+    const input = screen.getByTestId("comment-composer-input");
+    expect(input).toHaveFocus();
+    expect(input.className).toMatch(/font-sans/);
+    expect(input.className).toMatch(/text-\[14px\]/);
+  });
+
+  it("saves with Ctrl+Enter when body is non-empty", () => {
+    const onSave = vi.fn();
+    render(
+      <CommentComposer
+        filePath="a.ts"
+        startLine={1}
+        endLine={1}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByTestId("comment-composer-input");
+    fireEvent.change(input, { target: { value: "needs tests" } });
+    fireEvent.keyDown(input, { key: "Enter", ctrlKey: true });
+    expect(onSave).toHaveBeenCalledWith("needs tests");
+  });
+
+  it("does not save empty body on Ctrl+Enter", () => {
+    const onSave = vi.fn();
+    render(
+      <CommentComposer
+        filePath="a.ts"
+        startLine={1}
+        endLine={1}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByTestId("comment-composer-input"), {
+      key: "Enter",
+      ctrlKey: true,
+    });
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("cancels on Escape", () => {
+    const onCancel = vi.fn();
+    render(
+      <CommentComposer
+        filePath="a.ts"
+        startLine={1}
+        endLine={1}
+        onSave={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByTestId("comment-composer-input"), {
+      key: "Escape",
+    });
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("Enter alone does not save (allows newlines)", () => {
+    const onSave = vi.fn();
+    render(
+      <CommentComposer
+        filePath="a.ts"
+        startLine={1}
+        endLine={1}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByTestId("comment-composer-input");
+    fireEvent.change(input, { target: { value: "line" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});

--- a/src/content/overlay/components/CommentComposer.tsx
+++ b/src/content/overlay/components/CommentComposer.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
+import { formatLineRangeLabel } from "../commentTypes";
+import { Kbd } from "./Kbd";
+
+interface CommentComposerProps {
+  filePath: string;
+  startLine: number;
+  endLine: number;
+  onSave: (body: string) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Inline markdown draft composer. Enter inserts a newline;
+ * ⌘/Ctrl+Enter saves; Esc cancels.
+ */
+export function CommentComposer({
+  filePath,
+  startLine,
+  endLine,
+  onSave,
+  onCancel,
+}: CommentComposerProps) {
+  const [body, setBody] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  const canSave = body.trim().length > 0;
+
+  function handleKeyDown(event: KeyboardEvent<HTMLTextAreaElement>): void {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      onCancel();
+      return;
+    }
+    if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+      event.preventDefault();
+      event.stopPropagation();
+      if (canSave) onSave(body);
+    }
+  }
+
+  return (
+    <div
+      className="border border-gr-border bg-gr-chrome px-3 py-3"
+      data-testid="comment-composer"
+      role="form"
+      aria-label="Draft review comment"
+    >
+      <div className="mb-2 font-mono text-[12px] text-gr-muted">
+        {formatLineRangeLabel(filePath, startLine, endLine)}
+      </div>
+      <textarea
+        ref={textareaRef}
+        className="min-h-[88px] w-full resize-y rounded-md border border-gr-border bg-gr-bg px-3 py-2 font-sans text-[14px] leading-relaxed text-gr-text outline-none placeholder:text-gr-faint focus:border-gr-accent"
+        placeholder="Leave a review comment (markdown supported)…"
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        onKeyDown={handleKeyDown}
+        aria-label="Comment body"
+        data-testid="comment-composer-input"
+      />
+      <div className="mt-2 flex flex-wrap items-center justify-end gap-2">
+        <button
+          type="button"
+          className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-[13px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+          onClick={onCancel}
+        >
+          Cancel
+          <Kbd>Esc</Kbd>
+        </button>
+        <button
+          type="button"
+          className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-[13px] font-medium text-gr-accent-on enabled:hover:border-gr-accent-hover enabled:hover:bg-gr-accent-hover disabled:cursor-not-allowed disabled:opacity-40 [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
+          disabled={!canSave}
+          onClick={() => {
+            if (canSave) onSave(body);
+          }}
+          data-testid="comment-composer-save"
+        >
+          Save draft
+          <Kbd>⌘</Kbd>
+          <span className="text-[11px] opacity-70">/</span>
+          <Kbd>Ctrl</Kbd>
+          <Kbd>Enter</Kbd>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/content/overlay/components/CommentComposer.tsx
+++ b/src/content/overlay/components/CommentComposer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type KeyboardEvent } from "react";
 import { formatLineRangeLabel } from "../commentTypes";
 import { Kbd } from "./Kbd";
+import { ModEnterChord } from "./ShortcutKeys";
 
 interface CommentComposerProps {
   filePath: string;
@@ -82,11 +83,8 @@ export function CommentComposer({
           }}
           data-testid="comment-composer-save"
         >
-          Save draft
-          <Kbd>⌘</Kbd>
-          <span className="text-[11px] opacity-70">/</span>
-          <Kbd>Ctrl</Kbd>
-          <Kbd>Enter</Kbd>
+          Save Draft
+          <ModEnterChord />
         </button>
       </div>
     </div>

--- a/src/content/overlay/components/DiffPane.test.tsx
+++ b/src/content/overlay/components/DiffPane.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { sha256Hex } from "../../../lib/github/prFileDiffUrl";
 import type { DiffFile, DiffHunk, PRContext } from "../../../lib/types";
 import { DEFAULT_DIFF_VIEW_MODE } from "../diffViewMode";
@@ -70,6 +70,11 @@ function resetStore(): void {
     streamGeneration: 0,
     sessionKey: null,
     diffViewMode: DEFAULT_DIFF_VIEW_MODE,
+    uiMode: "navigate",
+    selectableLines: [],
+    lineSelection: null,
+    composerOpen: false,
+    draftComments: [],
   });
 }
 
@@ -90,6 +95,7 @@ describe("DiffPane", () => {
       "Wire up the new auth path",
     );
     expect(screen.getByTestId("diff-view-toggle")).toBeInTheDocument();
+    expect(screen.getByTestId("enter-comment-mode")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Split" })).toHaveAttribute(
       "aria-pressed",
       "true",
@@ -109,6 +115,65 @@ describe("DiffPane", () => {
     await act(async () => {
       await Promise.resolve();
     });
+  });
+
+  it("enters comment mode when Add Comment is pressed", async () => {
+    Element.prototype.scrollIntoView = vi.fn();
+    renderPane();
+
+    const button = screen.getByTestId("enter-comment-mode");
+    expect(button).toHaveTextContent(/add comment/i);
+    expect(button).not.toBeDisabled();
+    expect(screen.queryByTestId("comment-mode-chip")).not.toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(useReviewStore.getState().uiMode).toBe("comment");
+    expect(useReviewStore.getState().lineSelection).toEqual({
+      anchorIndex: 0,
+      focusIndex: 0,
+    });
+    expect(useReviewStore.getState().selectableLines.length).toBeGreaterThan(0);
+    // Button is replaced by the comment-mode label.
+    expect(screen.queryByTestId("enter-comment-mode")).not.toBeInTheDocument();
+    expect(screen.getByTestId("comment-mode-chip")).toBeInTheDocument();
+    expect(screen.getByTestId("comment-mode-chip")).toHaveTextContent(
+      /comment mode/i,
+    );
+  });
+
+  it("disables Add Comment when the unit has no selectable lines", async () => {
+    const file = fileFixture({
+      path: "logo.png",
+      isBinaryOrElided: true,
+      hunks: [],
+    });
+    renderPane([{ file, hunks: [] }]);
+
+    const button = screen.getByTestId("enter-comment-mode");
+    expect(button).toBeDisabled();
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(useReviewStore.getState().uiMode).toBe("navigate");
+  });
+
+  it("shows the comment-mode label to the left of the view toggle", async () => {
+    Element.prototype.scrollIntoView = vi.fn();
+    renderPane();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("enter-comment-mode"));
+    });
+
+    const chip = screen.getByTestId("comment-mode-chip");
+    const toggle = screen.getByTestId("diff-view-toggle");
+    // Chip is a previous sibling of the toggle within the toolbar group.
+    expect(chip.compareDocumentPosition(toggle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it("switches to unified view when Unified is pressed", async () => {
@@ -251,6 +316,108 @@ describe("DiffPane", () => {
     });
   });
 
+  it("focus highlights the line number gutter with brand colors", async () => {
+    Element.prototype.scrollIntoView = vi.fn();
+    useReviewStore.setState({ diffViewMode: "unified" });
+    renderPane();
+
+    const addId = "src/foo.ts#0:2:RIGHT";
+    const delId = "src/foo.ts#0:1:LEFT";
+    await act(async () => {
+      useReviewStore.getState().enterCommentMode([
+        {
+          id: addId,
+          filePath: "src/foo.ts",
+          hunkId: "src/foo.ts#0",
+          lineIndex: 2,
+          side: "RIGHT",
+          newLine: 2,
+          type: "add",
+        },
+        {
+          id: delId,
+          filePath: "src/foo.ts",
+          hunkId: "src/foo.ts#0",
+          lineIndex: 1,
+          side: "LEFT",
+          oldLine: 2,
+          type: "del",
+        },
+      ]);
+    });
+
+    const focus = screen.getByTestId("diff-line-focus");
+    expect(focus).toHaveAttribute("data-line-id", addId);
+    // Row wash + brand line-number gutter both mark focus.
+    expect(focus.className).toMatch(/bg-gr-accent-subtle/);
+    expect(focus.className).not.toMatch(/bg-gr-add-bg/);
+
+    const focusNumbers = screen.getAllByTestId("diff-line-number-highlight");
+    expect(focusNumbers.length).toBeGreaterThan(0);
+    for (const num of focusNumbers) {
+      expect(num.className).toMatch(/bg-gr-accent/);
+      expect(num.className).toMatch(/text-gr-accent-on/);
+    }
+
+    // Unfocused del line still uses del background.
+    const delLine = document.querySelector(`[data-line-id="${delId}"]`);
+    expect(delLine?.className).toMatch(/bg-gr-del-bg/);
+    expect(delLine?.className).not.toMatch(/bg-gr-accent-subtle/);
+  });
+
+  it("highlights line numbers for every line in a multi-line selection", async () => {
+    Element.prototype.scrollIntoView = vi.fn();
+    useReviewStore.setState({ diffViewMode: "unified" });
+    renderPane();
+
+    const firstId = "src/foo.ts#0:2:RIGHT";
+    const secondId = "src/foo.ts#0:3:RIGHT";
+    await act(async () => {
+      useReviewStore.getState().enterCommentMode([
+        {
+          id: firstId,
+          filePath: "src/foo.ts",
+          hunkId: "src/foo.ts#0",
+          lineIndex: 2,
+          side: "RIGHT",
+          newLine: 2,
+          type: "add",
+        },
+        {
+          id: secondId,
+          filePath: "src/foo.ts",
+          hunkId: "src/foo.ts#0",
+          lineIndex: 3,
+          side: "RIGHT",
+          newLine: 3,
+          type: "add",
+        },
+      ]);
+      // Extend selection to cover both lines (anchor 0, focus 1).
+      useReviewStore.setState({
+        lineSelection: { anchorIndex: 0, focusIndex: 1 },
+      });
+    });
+
+    const firstLine = document.querySelector(`[data-line-id="${firstId}"]`);
+    const secondLine = document.querySelector(`[data-line-id="${secondId}"]`);
+    expect(firstLine).not.toBeNull();
+    expect(secondLine).not.toBeNull();
+
+    const firstNums = firstLine!.querySelectorAll(
+      '[data-testid="diff-line-number-highlight"]',
+    );
+    const secondNums = secondLine!.querySelectorAll(
+      '[data-testid="diff-line-number-highlight"]',
+    );
+    expect(firstNums.length).toBeGreaterThan(0);
+    expect(secondNums.length).toBeGreaterThan(0);
+    for (const num of [...firstNums, ...secondNums]) {
+      expect(num.className).toMatch(/bg-gr-accent/);
+      expect(num.className).toMatch(/text-gr-accent-on/);
+    }
+  });
+
   it("soft-wraps long lines in unified view", async () => {
     const longPath =
       'd="M0,0L12.34567890123456789012345678901234567890123456789012345678901234567890123456789z"';
@@ -268,10 +435,92 @@ describe("DiffPane", () => {
 
     const unified = screen.getByTestId("diff-view-unified");
     expect(unified.className).toMatch(/overflow-x-hidden/);
-    const line = unified.firstElementChild;
+    const line = unified.querySelector("[data-line-id]");
     expect(line?.className).toMatch(/whitespace-pre-wrap/);
     expect(line?.className).toMatch(/break-all/);
     expect(line?.textContent).toContain(longPath);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+  });
+
+  it("renders draft comment cards with a dark surface background", async () => {
+    Element.prototype.scrollIntoView = vi.fn();
+    const addId = "src/foo.ts#0:2:RIGHT";
+    useReviewStore.setState({
+      diffViewMode: "unified",
+      uiMode: "comment",
+      selectableLines: [
+        {
+          id: addId,
+          filePath: "src/foo.ts",
+          hunkId: "src/foo.ts#0",
+          lineIndex: 2,
+          side: "RIGHT",
+          newLine: 2,
+          type: "add",
+        },
+      ],
+      lineSelection: { anchorIndex: 0, focusIndex: 0 },
+      draftComments: [
+        {
+          id: "draft-1",
+          filePath: "src/foo.ts",
+          side: "RIGHT",
+          startLine: 2,
+          endLine: 2,
+          lineIds: [addId],
+          body: "Looks good",
+        },
+      ],
+    });
+    renderPane();
+
+    const card = screen.getByTestId("draft-comment");
+    expect(card.className).toMatch(/bg-gr-bg/);
+    expect(card.className).toMatch(/border-gr-border/);
+    expect(card.className).not.toMatch(/bg-gr-accent-subtle/);
+    expect(card).toHaveTextContent("Looks good");
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+  });
+
+  it("pins split-view comment extras to the right column only", async () => {
+    Element.prototype.scrollIntoView = vi.fn();
+    const addId = "src/foo.ts#0:2:RIGHT";
+    useReviewStore.setState({
+      diffViewMode: "split",
+      uiMode: "comment",
+      selectableLines: [
+        {
+          id: addId,
+          filePath: "src/foo.ts",
+          hunkId: "src/foo.ts#0",
+          lineIndex: 2,
+          side: "RIGHT",
+          newLine: 2,
+          type: "add",
+        },
+      ],
+      lineSelection: { anchorIndex: 0, focusIndex: 0 },
+      composerOpen: true,
+    });
+    renderPane();
+
+    const extrasRow = screen.getByTestId("split-line-extras");
+    expect(extrasRow.className).toMatch(/flex/);
+    expect(screen.getByTestId("comment-composer")).toBeInTheDocument();
+    // Composer lives under the right flex-1 column (third child: spacer, divider, right).
+    const children = Array.from(extrasRow.children);
+    expect(children).toHaveLength(3);
+    const rightCol = children[2];
+    expect(rightCol.className).toMatch(/flex-1/);
+    expect(rightCol.querySelector('[data-testid="comment-composer"]')).not.toBeNull();
+    // Left spacer has no comment UI.
+    expect(children[0].querySelector('[data-testid="comment-composer"]')).toBeNull();
 
     await act(async () => {
       await Promise.resolve();

--- a/src/content/overlay/components/DiffPane.tsx
+++ b/src/content/overlay/components/DiffPane.tsx
@@ -19,6 +19,7 @@ import type { ResolvedUnitFile } from "../selectors";
 import { CommentComposer } from "./CommentComposer";
 import { DraftCommentCard } from "./DraftCommentCard";
 import { Kbd } from "./Kbd";
+import { ShortcutKeys } from "./ShortcutKeys";
 
 interface DiffPaneProps {
   files: ResolvedUnitFile[];
@@ -469,8 +470,7 @@ function DiffViewToggle({
           onClick={() => onChange("unified")}
         >
           Unified
-          <Kbd>v</Kbd>
-          <Kbd>u</Kbd>
+          <ShortcutKeys keys={["v", "u"]} join="sequence" />
         </button>
         <button
           type="button"
@@ -485,8 +485,7 @@ function DiffViewToggle({
           onClick={() => onChange("split")}
         >
           Split
-          <Kbd>v</Kbd>
-          <Kbd>s</Kbd>
+          <ShortcutKeys keys={["v", "s"]} join="sequence" />
         </button>
       </div>
     </div>
@@ -523,7 +522,7 @@ function AddCommentButton({
           ? "cursor-not-allowed bg-gr-bg text-gr-faint opacity-60"
           : "cursor-pointer bg-gr-bg text-gr-text hover:bg-gr-subtle",
       )}
-      aria-label="Add comment"
+      aria-label="Add Comment"
       disabled={disabled}
       data-testid="enter-comment-mode"
       onClick={() => {

--- a/src/content/overlay/components/DiffPane.tsx
+++ b/src/content/overlay/components/DiffPane.tsx
@@ -1,18 +1,31 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { buildPRFileDiffUrl } from "../../../lib/github/prFileDiffUrl";
 import { highlightToLines, languageForPath } from "../../../lib/highlight";
 import { cn } from "../../../lib/cn";
 import type { DiffHunk } from "../../../lib/types";
+import { buildSelectableLines } from "../buildSelectableLines";
 import { buildSplitRows, type SplitCell } from "../buildSplitRows";
+import {
+  displayLineNumber,
+  linesInSelection,
+  type DraftComment,
+  type LineSelection,
+  type SelectableLine,
+} from "../commentTypes";
 import type { DiffViewMode } from "../diffViewMode";
 import { hydrateDiffViewMode, useReviewStore } from "../store";
 import type { ResolvedUnitFile } from "../selectors";
+import { CommentComposer } from "./CommentComposer";
+import { DraftCommentCard } from "./DraftCommentCard";
+import { Kbd } from "./Kbd";
 
 interface DiffPaneProps {
   files: ResolvedUnitFile[];
   /** Title of the currently active review unit. */
   unitTitle: string;
+  /** Review unit id for associating saved drafts. */
+  unitId?: string;
 }
 
 /**
@@ -73,12 +86,108 @@ function CodeContent({
 const DIFF_LINE_WRAP =
   "flex min-w-0 whitespace-pre-wrap break-all pr-3";
 
+function selectionClasses(
+  lineId: string | undefined,
+  selectedIds: Set<string>,
+  focusId: string | null,
+): string {
+  if (!lineId) return "";
+  // Focus keeps the row wash; brand line-number gutter is layered on top.
+  if (focusId === lineId) {
+    return "bg-gr-accent-subtle";
+  }
+  if (selectedIds.has(lineId)) {
+    return "bg-gr-accent-subtle/70";
+  }
+  return "";
+}
+
+/**
+ * Brand highlight on gutter numbers for the focused line and every line in the
+ * current multi-line selection.
+ */
+function lineNumberClasses(isHighlighted: boolean): string {
+  return cn(
+    "w-10 shrink-0 select-none pr-3 text-right",
+    isHighlighted
+      ? "bg-gr-accent font-medium text-gr-accent-on"
+      : "text-gr-faint",
+  );
+}
+
+function lineIdFor(
+  hunkId: string,
+  lineIndex: number,
+  side: "LEFT" | "RIGHT",
+): string {
+  return `${hunkId}:${lineIndex}:${side}`;
+}
+
+interface LineExtrasProps {
+  lineId: string;
+  draftsByEndLineId: Map<string, DraftComment[]>;
+  composerPlacementId: string | null;
+  composerRange: { filePath: string; startLine: number; endLine: number } | null;
+  unitId?: string;
+}
+
+function LineExtras({
+  lineId,
+  draftsByEndLineId,
+  composerPlacementId,
+  composerRange,
+  unitId,
+}: LineExtrasProps) {
+  const saveDraftComment = useReviewStore((s) => s.saveDraftComment);
+  const closeComposer = useReviewStore((s) => s.closeComposer);
+  const removeDraftComment = useReviewStore((s) => s.removeDraftComment);
+  const updateDraftComment = useReviewStore((s) => s.updateDraftComment);
+  const drafts = draftsByEndLineId.get(lineId) ?? [];
+  const showComposer = composerPlacementId === lineId && composerRange;
+
+  if (!showComposer && drafts.length === 0) return null;
+
+  return (
+    <div className="font-sans" data-testid={`line-extras-${lineId}`}>
+      {drafts.map((d) => (
+        <DraftCommentCard
+          key={d.id}
+          comment={d}
+          onRemove={removeDraftComment}
+          onUpdate={updateDraftComment}
+        />
+      ))}
+      {showComposer && (
+        <CommentComposer
+          filePath={composerRange.filePath}
+          startLine={composerRange.startLine}
+          endLine={composerRange.endLine}
+          onSave={(body) => saveDraftComment(body, unitId)}
+          onCancel={closeComposer}
+        />
+      )}
+    </div>
+  );
+}
+
 function UnifiedHunk({
   hunk,
   language,
+  selectedIds,
+  focusId,
+  draftsByEndLineId,
+  composerPlacementId,
+  composerRange,
+  unitId,
 }: {
   hunk: DiffHunk;
   language: string | undefined;
+  selectedIds: Set<string>;
+  focusId: string | null;
+  draftsByEndLineId: Map<string, DraftComment[]>;
+  composerPlacementId: string | null;
+  composerRange: { filePath: string; startLine: number; endLine: number } | null;
+  unitId?: string;
 }) {
   const highlighted = useMemo(
     () => highlightHunkLines(hunk, language),
@@ -90,38 +199,68 @@ function UnifiedHunk({
       className="overflow-x-hidden font-mono text-[12px] leading-relaxed"
       data-testid="diff-view-unified"
     >
-      {hunk.lines.map((line, i) => (
-        <div
-          key={i}
-          className={cn(
-            DIFF_LINE_WRAP,
-            line.type === "add" && "bg-gr-add-bg",
-            line.type === "del" && "bg-gr-del-bg",
-          )}
-        >
-          <span className="w-10 shrink-0 select-none pr-3 text-right text-gr-faint">
-            {line.oldLine ?? ""}
-          </span>
-          <span className="w-10 shrink-0 select-none pr-3 text-right text-gr-faint">
-            {line.newLine ?? ""}
-          </span>
-          <span
-            className={cn(
-              "w-4 shrink-0 opacity-70",
-              line.type === "add" && "text-gr-add-text",
-              line.type === "del" && "text-gr-del-text",
-            )}
-          >
-            {line.type === "add" ? "+" : line.type === "del" ? "-" : ""}
-          </span>
-          <span className="min-w-0 flex-1">
-            <CodeContent
-              content={line.content}
-              highlighted={highlighted[i] ?? null}
+      {hunk.lines.map((line, i) => {
+        const side = line.type === "del" ? "LEFT" : "RIGHT";
+        const id = lineIdFor(hunk.id, i, side);
+        const isFocus = focusId === id;
+        const isSelected = selectedIds.has(id);
+        const highlightNumber = isFocus || isSelected;
+        // Selection/focus must win over add/del green/red (Tailwind bg-* conflicts).
+        const showDiffBg = !isFocus && !isSelected;
+        return (
+          <div key={i}>
+            <div
+              data-line-id={id}
+              data-testid={isFocus ? "diff-line-focus" : undefined}
+              className={cn(
+                DIFF_LINE_WRAP,
+                showDiffBg && line.type === "add" && "bg-gr-add-bg",
+                showDiffBg && line.type === "del" && "bg-gr-del-bg",
+                selectionClasses(id, selectedIds, focusId),
+              )}
+            >
+              <span
+                className={lineNumberClasses(highlightNumber)}
+                data-testid={
+                  highlightNumber ? "diff-line-number-highlight" : undefined
+                }
+              >
+                {line.oldLine ?? ""}
+              </span>
+              <span
+                className={lineNumberClasses(highlightNumber)}
+                data-testid={
+                  highlightNumber ? "diff-line-number-highlight" : undefined
+                }
+              >
+                {line.newLine ?? ""}
+              </span>
+              <span
+                className={cn(
+                  "w-4 shrink-0 opacity-70",
+                  line.type === "add" && "text-gr-add-text",
+                  line.type === "del" && "text-gr-del-text",
+                )}
+              >
+                {line.type === "add" ? "+" : line.type === "del" ? "-" : ""}
+              </span>
+              <span className="min-w-0 flex-1">
+                <CodeContent
+                  content={line.content}
+                  highlighted={highlighted[i] ?? null}
+                />
+              </span>
+            </div>
+            <LineExtras
+              lineId={id}
+              draftsByEndLineId={draftsByEndLineId}
+              composerPlacementId={composerPlacementId}
+              composerRange={composerRange}
+              unitId={unitId}
             />
-          </span>
-        </div>
-      ))}
+          </div>
+        );
+      })}
     </div>
   );
 }
@@ -130,31 +269,51 @@ function SplitCellView({
   cell,
   highlighted,
   side,
+  lineId,
+  selectedIds,
+  focusId,
 }: {
   cell: SplitCell;
   highlighted: string | null;
   side: "left" | "right";
+  lineId?: string;
+  selectedIds: Set<string>;
+  focusId: string | null;
 }) {
   if (cell.kind === "empty") {
     return (
       <div className={cn(DIFF_LINE_WRAP, "flex-1 overflow-hidden")}>
-        <span className="w-10 shrink-0 select-none pr-3 text-right text-gr-faint" />
+        <span className={lineNumberClasses(false)} />
         <span className="min-w-0 flex-1" />
       </div>
     );
   }
+
+  const isFocus = lineId != null && focusId === lineId;
+  const isSelected = lineId != null && selectedIds.has(lineId);
+  const highlightNumber = isFocus || isSelected;
+  // Selection/focus must win over add/del green/red (Tailwind bg-* conflicts).
+  const showDiffBg = !isFocus && !isSelected;
 
   return (
     <div
       className={cn(
         DIFF_LINE_WRAP,
         "flex-1 overflow-hidden",
-        cell.type === "del" && "bg-gr-del-bg",
-        cell.type === "add" && "bg-gr-add-bg",
+        showDiffBg && cell.type === "del" && "bg-gr-del-bg",
+        showDiffBg && cell.type === "add" && "bg-gr-add-bg",
+        selectionClasses(lineId, selectedIds, focusId),
       )}
       data-side={side}
+      data-line-id={lineId}
+      data-testid={isFocus ? "diff-line-focus" : undefined}
     >
-      <span className="w-10 shrink-0 select-none pr-3 text-right text-gr-faint">
+      <span
+        className={lineNumberClasses(highlightNumber)}
+        data-testid={
+          highlightNumber ? "diff-line-number-highlight" : undefined
+        }
+      >
         {cell.lineNumber ?? ""}
       </span>
       <span
@@ -176,9 +335,21 @@ function SplitCellView({
 function SplitHunk({
   hunk,
   language,
+  selectedIds,
+  focusId,
+  draftsByEndLineId,
+  composerPlacementId,
+  composerRange,
+  unitId,
 }: {
   hunk: DiffHunk;
   language: string | undefined;
+  selectedIds: Set<string>;
+  focusId: string | null;
+  draftsByEndLineId: Map<string, DraftComment[]>;
+  composerPlacementId: string | null;
+  composerRange: { filePath: string; startLine: number; endLine: number } | null;
+  unitId?: string;
 }) {
   const highlighted = useMemo(
     () => highlightHunkLines(hunk, language),
@@ -191,29 +362,81 @@ function SplitHunk({
       className="overflow-x-hidden font-mono text-[12px] leading-relaxed"
       data-testid="diff-view-split"
     >
-      {rows.map((row, i) => (
-        <div key={i} className="flex min-w-0 border-b border-gr-border-muted last:border-b-0">
-          <SplitCellView
-            cell={row.left}
-            highlighted={
-              row.left.kind === "content"
-                ? (highlighted[row.left.sourceIndex] ?? null)
-                : null
-            }
-            side="left"
-          />
-          <div className="w-px shrink-0 bg-gr-border" aria-hidden="true" />
-          <SplitCellView
-            cell={row.right}
-            highlighted={
-              row.right.kind === "content"
-                ? (highlighted[row.right.sourceIndex] ?? null)
-                : null
-            }
-            side="right"
-          />
-        </div>
-      ))}
+      {rows.map((row, i) => {
+        const leftId =
+          row.left.kind === "content"
+            ? lineIdFor(hunk.id, row.left.sourceIndex, "LEFT")
+            : undefined;
+        const rightId =
+          row.right.kind === "content"
+            ? lineIdFor(hunk.id, row.right.sourceIndex, "RIGHT")
+            : undefined;
+
+        const showLeftExtras =
+          leftId != null &&
+          (composerPlacementId === leftId || draftsByEndLineId.has(leftId));
+        const showRightExtras =
+          rightId != null &&
+          (composerPlacementId === rightId || draftsByEndLineId.has(rightId));
+
+        return (
+          <div key={i}>
+            <div className="flex min-w-0 border-b border-gr-border-muted last:border-b-0">
+              <SplitCellView
+                cell={row.left}
+                highlighted={
+                  row.left.kind === "content"
+                    ? (highlighted[row.left.sourceIndex] ?? null)
+                    : null
+                }
+                side="left"
+                lineId={leftId}
+                selectedIds={selectedIds}
+                focusId={focusId}
+              />
+              <div className="w-px shrink-0 bg-gr-border" aria-hidden="true" />
+              <SplitCellView
+                cell={row.right}
+                highlighted={
+                  row.right.kind === "content"
+                    ? (highlighted[row.right.sourceIndex] ?? null)
+                    : null
+                }
+                side="right"
+                lineId={rightId}
+                selectedIds={selectedIds}
+                focusId={focusId}
+              />
+            </div>
+            {(showLeftExtras || showRightExtras) && (
+              <div className="flex min-w-0" data-testid="split-line-extras">
+                <div className="min-w-0 flex-1" aria-hidden="true" />
+                <div className="w-px shrink-0 bg-gr-border" aria-hidden="true" />
+                <div className="min-w-0 flex-1">
+                  {showLeftExtras && leftId && (
+                    <LineExtras
+                      lineId={leftId}
+                      draftsByEndLineId={draftsByEndLineId}
+                      composerPlacementId={composerPlacementId}
+                      composerRange={composerRange}
+                      unitId={unitId}
+                    />
+                  )}
+                  {showRightExtras && rightId && (
+                    <LineExtras
+                      lineId={rightId}
+                      draftsByEndLineId={draftsByEndLineId}
+                      composerPlacementId={composerPlacementId}
+                      composerRange={composerRange}
+                      unitId={unitId}
+                    />
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }
@@ -232,35 +455,85 @@ function DiffViewToggle({
       aria-label="Diff view"
       data-testid="diff-view-toggle"
     >
-      <div className="inline-flex overflow-hidden rounded-md border border-gr-border">
+      <div className="inline-flex overflow-hidden rounded-md border border-gr-border bg-gr-bg">
         <button
           type="button"
           className={cn(
-            "cursor-pointer px-3 py-1.5 text-[13px] transition-colors",
+            "inline-flex cursor-pointer items-center gap-1.5 px-3 py-1.5 text-[13px] transition-colors",
             mode === "unified"
               ? "bg-gr-subtle text-gr-text"
-              : "bg-gr-bg text-gr-muted hover:bg-gr-subtle hover:text-gr-text",
+              : "bg-transparent text-gr-muted hover:bg-gr-subtle hover:text-gr-text",
           )}
+          aria-label="Unified"
           aria-pressed={mode === "unified"}
           onClick={() => onChange("unified")}
         >
           Unified
+          <Kbd>v</Kbd>
+          <Kbd>u</Kbd>
         </button>
         <button
           type="button"
           className={cn(
-            "cursor-pointer border-l border-gr-border px-3 py-1.5 text-[13px] transition-colors",
+            "inline-flex cursor-pointer items-center gap-1.5 border-l border-gr-border px-3 py-1.5 text-[13px] transition-colors",
             mode === "split"
               ? "bg-gr-subtle text-gr-text"
-              : "bg-gr-bg text-gr-muted hover:bg-gr-subtle hover:text-gr-text",
+              : "bg-transparent text-gr-muted hover:bg-gr-subtle hover:text-gr-text",
           )}
+          aria-label="Split"
           aria-pressed={mode === "split"}
           onClick={() => onChange("split")}
         >
           Split
+          <Kbd>v</Kbd>
+          <Kbd>s</Kbd>
         </button>
       </div>
     </div>
+  );
+}
+
+function CommentModeChip() {
+  return (
+    <span
+      className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-gr-accent/40 bg-gr-accent-subtle px-2.5 py-1 text-[12px] text-gr-accent"
+      data-testid="comment-mode-chip"
+    >
+      Comment mode
+      <span className="inline-flex items-center gap-1 text-gr-muted">
+        · <Kbd>Esc</Kbd> to exit
+      </span>
+    </span>
+  );
+}
+
+function AddCommentButton({
+  disabled,
+  onEnter,
+}: {
+  disabled: boolean;
+  onEnter: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "inline-flex shrink-0 items-center gap-1.5 rounded-md border border-gr-border px-3 py-1.5 text-[13px] transition-colors",
+        disabled
+          ? "cursor-not-allowed bg-gr-bg text-gr-faint opacity-60"
+          : "cursor-pointer bg-gr-bg text-gr-text hover:bg-gr-subtle",
+      )}
+      aria-label="Add comment"
+      disabled={disabled}
+      data-testid="enter-comment-mode"
+      onClick={() => {
+        if (disabled) return;
+        onEnter();
+      }}
+    >
+      Add Comment
+      <Kbd>c</Kbd>
+    </button>
   );
 }
 
@@ -319,16 +592,118 @@ function BinaryElidedEmptyState({ filePath }: { filePath: string }) {
   );
 }
 
-export function DiffPane({ files, unitTitle }: DiffPaneProps) {
+function useSelectionDerived(
+  selectableLines: SelectableLine[],
+  lineSelection: LineSelection | null,
+  composerOpen: boolean,
+  draftComments: DraftComment[],
+  filePaths: Set<string>,
+) {
+  return useMemo(() => {
+    const selected = lineSelection
+      ? linesInSelection(selectableLines, lineSelection)
+      : [];
+    const selectedIds = new Set(selected.map((l) => l.id));
+    const focusId =
+      lineSelection && selectableLines[lineSelection.focusIndex]
+        ? selectableLines[lineSelection.focusIndex].id
+        : null;
+
+    let composerPlacementId: string | null = null;
+    let composerRange: {
+      filePath: string;
+      startLine: number;
+      endLine: number;
+    } | null = null;
+
+    if (composerOpen && selected.length > 0) {
+      const first = selected[0];
+      const last = selected[selected.length - 1];
+      const startNum = displayLineNumber(first);
+      const endNum = displayLineNumber(last);
+      if (startNum !== undefined && endNum !== undefined) {
+        composerPlacementId = last.id;
+        composerRange = {
+          filePath: first.filePath,
+          startLine: Math.min(startNum, endNum),
+          endLine: Math.max(startNum, endNum),
+        };
+      }
+    }
+
+    const draftsByEndLineId = new Map<string, DraftComment[]>();
+    for (const draft of draftComments) {
+      if (!filePaths.has(draft.filePath)) continue;
+      const endId = draft.lineIds[draft.lineIds.length - 1];
+      if (!endId) continue;
+      const list = draftsByEndLineId.get(endId) ?? [];
+      list.push(draft);
+      draftsByEndLineId.set(endId, list);
+    }
+
+    return {
+      selectedIds,
+      focusId,
+      composerPlacementId,
+      composerRange,
+      draftsByEndLineId,
+    };
+  }, [selectableLines, lineSelection, composerOpen, draftComments, filePaths]);
+}
+
+export function DiffPane({ files, unitTitle, unitId }: DiffPaneProps) {
   const diffViewMode = useReviewStore((s) => s.diffViewMode);
   const setDiffViewMode = useReviewStore((s) => s.setDiffViewMode);
+  const uiMode = useReviewStore((s) => s.uiMode);
+  const selectableLines = useReviewStore((s) => s.selectableLines);
+  const lineSelection = useReviewStore((s) => s.lineSelection);
+  const composerOpen = useReviewStore((s) => s.composerOpen);
+  const draftComments = useReviewStore((s) => s.draftComments);
+  const enterCommentMode = useReviewStore((s) => s.enterCommentMode);
+  const rootRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     void hydrateDiffViewMode();
   }, []);
 
+  const unitSelectableLines = useMemo(
+    () => buildSelectableLines(files, diffViewMode),
+    [files, diffViewMode],
+  );
+
+  const filePaths = useMemo(
+    () => new Set(files.map((f) => f.file.path)),
+    [files],
+  );
+
+  const {
+    selectedIds,
+    focusId,
+    composerPlacementId,
+    composerRange,
+    draftsByEndLineId,
+  } = useSelectionDerived(
+    uiMode === "comment" ? selectableLines : [],
+    uiMode === "comment" ? lineSelection : null,
+    composerOpen,
+    draftComments,
+    filePaths,
+  );
+
+  // Scroll the focused line into view when the cursor moves.
+  useEffect(() => {
+    if (uiMode !== "comment" || !focusId || !rootRef.current) return;
+    const el = rootRef.current.querySelector(
+      `[data-line-id="${CSS.escape(focusId)}"]`,
+    );
+    el?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+  }, [uiMode, focusId, lineSelection?.focusIndex]);
+
+  const commentModeActive = uiMode === "comment";
+  const commentModeDisabled = unitSelectableLines.length === 0;
+
   return (
-    <>
+    <div ref={rootRef}>
       <div className="mb-4 flex items-center justify-between gap-4">
         <h2
           className="min-w-0 truncate text-[15px] font-semibold text-gr-text"
@@ -337,7 +712,17 @@ export function DiffPane({ files, unitTitle }: DiffPaneProps) {
         >
           {unitTitle}
         </h2>
-        <DiffViewToggle mode={diffViewMode} onChange={setDiffViewMode} />
+        <div className="flex shrink-0 items-center gap-2">
+          {commentModeActive ? (
+            <CommentModeChip />
+          ) : (
+            <AddCommentButton
+              disabled={commentModeDisabled}
+              onEnter={() => enterCommentMode(unitSelectableLines)}
+            />
+          )}
+          <DiffViewToggle mode={diffViewMode} onChange={setDiffViewMode} />
+        </div>
       </div>
       {files.map(({ file, hunks }) => {
         const language = languageForPath(file.path);
@@ -366,15 +751,35 @@ export function DiffPane({ files, unitTitle }: DiffPaneProps) {
             ) : (
               hunks.map((hunk) =>
                 diffViewMode === "split" ? (
-                  <SplitHunk hunk={hunk} language={language} key={hunk.id} />
+                  <SplitHunk
+                    hunk={hunk}
+                    language={language}
+                    key={hunk.id}
+                    selectedIds={selectedIds}
+                    focusId={focusId}
+                    draftsByEndLineId={draftsByEndLineId}
+                    composerPlacementId={composerPlacementId}
+                    composerRange={composerRange}
+                    unitId={unitId}
+                  />
                 ) : (
-                  <UnifiedHunk hunk={hunk} language={language} key={hunk.id} />
+                  <UnifiedHunk
+                    hunk={hunk}
+                    language={language}
+                    key={hunk.id}
+                    selectedIds={selectedIds}
+                    focusId={focusId}
+                    draftsByEndLineId={draftsByEndLineId}
+                    composerPlacementId={composerPlacementId}
+                    composerRange={composerRange}
+                    unitId={unitId}
+                  />
                 ),
               )
             )}
           </div>
         );
       })}
-    </>
+    </div>
   );
 }

--- a/src/content/overlay/components/DraftCommentCard.test.tsx
+++ b/src/content/overlay/components/DraftCommentCard.test.tsx
@@ -1,0 +1,128 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { DraftComment } from "../commentTypes";
+import { DraftCommentCard } from "./DraftCommentCard";
+
+const draft: DraftComment = {
+  id: "draft-1",
+  filePath: "src/foo.ts",
+  side: "RIGHT",
+  startLine: 2,
+  endLine: 4,
+  lineIds: ["a", "b"],
+  body: "Looks good",
+};
+
+describe("DraftCommentCard", () => {
+  it("renders the body in sans 14px and shows Edit / Remove", () => {
+    render(
+      <DraftCommentCard comment={draft} onRemove={vi.fn()} onUpdate={vi.fn()} />,
+    );
+
+    const body = screen.getByTestId("draft-comment-body");
+    expect(body).toHaveTextContent("Looks good");
+    expect(body.className).toMatch(/font-sans/);
+    expect(body.className).toMatch(/text-\[14px\]/);
+    expect(screen.getByTestId("draft-comment-edit")).toBeInTheDocument();
+    expect(screen.getByTestId("draft-comment-remove")).toBeInTheDocument();
+  });
+
+  it("enters edit mode from the Edit button", () => {
+    render(
+      <DraftCommentCard comment={draft} onRemove={vi.fn()} onUpdate={vi.fn()} />,
+    );
+
+    fireEvent.click(screen.getByTestId("draft-comment-edit"));
+    const input = screen.getByTestId("draft-comment-edit-input");
+    expect(input).toHaveValue("Looks good");
+    expect(input).toHaveFocus();
+    expect(input.className).toMatch(/font-sans/);
+    expect(input.className).toMatch(/text-\[14px\]/);
+    expect(screen.queryByTestId("draft-comment-edit")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("draft-comment-body")).not.toBeInTheDocument();
+  });
+
+  it("saves edits via Save button and Ctrl+Enter", () => {
+    const onUpdate = vi.fn();
+    const { rerender } = render(
+      <DraftCommentCard comment={draft} onRemove={vi.fn()} onUpdate={onUpdate} />,
+    );
+
+    fireEvent.click(screen.getByTestId("draft-comment-edit"));
+    fireEvent.change(screen.getByTestId("draft-comment-edit-input"), {
+      target: { value: "  Needs a test  " },
+    });
+    fireEvent.click(screen.getByTestId("draft-comment-edit-save"));
+    expect(onUpdate).toHaveBeenCalledWith("draft-1", "  Needs a test  ");
+
+    onUpdate.mockClear();
+    rerender(
+      <DraftCommentCard
+        comment={{ ...draft, body: "Needs a test" }}
+        onRemove={vi.fn()}
+        onUpdate={onUpdate}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("draft-comment-edit"));
+    fireEvent.change(screen.getByTestId("draft-comment-edit-input"), {
+      target: { value: "revised" },
+    });
+    fireEvent.keyDown(screen.getByTestId("draft-comment-edit-input"), {
+      key: "Enter",
+      ctrlKey: true,
+    });
+    expect(onUpdate).toHaveBeenCalledWith("draft-1", "revised");
+  });
+
+  it("does not save empty body", () => {
+    const onUpdate = vi.fn();
+    render(
+      <DraftCommentCard comment={draft} onRemove={vi.fn()} onUpdate={onUpdate} />,
+    );
+
+    fireEvent.click(screen.getByTestId("draft-comment-edit"));
+    fireEvent.change(screen.getByTestId("draft-comment-edit-input"), {
+      target: { value: "   " },
+    });
+    expect(screen.getByTestId("draft-comment-edit-save")).toBeDisabled();
+    fireEvent.keyDown(screen.getByTestId("draft-comment-edit-input"), {
+      key: "Enter",
+      ctrlKey: true,
+    });
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it("cancels edit with Esc or Cancel without calling onUpdate", () => {
+    const onUpdate = vi.fn();
+    render(
+      <DraftCommentCard comment={draft} onRemove={vi.fn()} onUpdate={onUpdate} />,
+    );
+
+    fireEvent.click(screen.getByTestId("draft-comment-edit"));
+    fireEvent.change(screen.getByTestId("draft-comment-edit-input"), {
+      target: { value: "changed" },
+    });
+    fireEvent.keyDown(screen.getByTestId("draft-comment-edit-input"), {
+      key: "Escape",
+    });
+    expect(onUpdate).not.toHaveBeenCalled();
+    expect(screen.getByTestId("draft-comment-body")).toHaveTextContent("Looks good");
+
+    fireEvent.click(screen.getByTestId("draft-comment-edit"));
+    fireEvent.change(screen.getByTestId("draft-comment-edit-input"), {
+      target: { value: "again" },
+    });
+    fireEvent.click(screen.getByTestId("draft-comment-edit-cancel"));
+    expect(onUpdate).not.toHaveBeenCalled();
+    expect(screen.getByTestId("draft-comment-body")).toHaveTextContent("Looks good");
+  });
+
+  it("calls onRemove when Remove is clicked", () => {
+    const onRemove = vi.fn();
+    render(
+      <DraftCommentCard comment={draft} onRemove={onRemove} onUpdate={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByTestId("draft-comment-remove"));
+    expect(onRemove).toHaveBeenCalledWith("draft-1");
+  });
+});

--- a/src/content/overlay/components/DraftCommentCard.tsx
+++ b/src/content/overlay/components/DraftCommentCard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type KeyboardEvent } from "react";
 import { formatLineRangeLabel, type DraftComment } from "../commentTypes";
 import { Kbd } from "./Kbd";
+import { ModEnterChord } from "./ShortcutKeys";
 
 interface DraftCommentCardProps {
   comment: DraftComment;
@@ -119,10 +120,7 @@ export function DraftCommentCard({
               data-testid="draft-comment-edit-save"
             >
               Save
-              <Kbd>⌘</Kbd>
-              <span className="text-[11px] opacity-70">/</span>
-              <Kbd>Ctrl</Kbd>
-              <Kbd>Enter</Kbd>
+              <ModEnterChord />
             </button>
           </div>
         </>

--- a/src/content/overlay/components/DraftCommentCard.tsx
+++ b/src/content/overlay/components/DraftCommentCard.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
+import { formatLineRangeLabel, type DraftComment } from "../commentTypes";
+import { Kbd } from "./Kbd";
+
+interface DraftCommentCardProps {
+  comment: DraftComment;
+  onRemove: (id: string) => void;
+  onUpdate: (id: string, body: string) => void;
+}
+
+/** Compact local draft shown under the commented line range. */
+export function DraftCommentCard({
+  comment,
+  onRemove,
+  onUpdate,
+}: DraftCommentCardProps) {
+  const [editing, setEditing] = useState(false);
+  const [body, setBody] = useState(comment.body);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (!editing) return;
+    setBody(comment.body);
+    textareaRef.current?.focus();
+    // Move caret to end so the user can keep typing.
+    const el = textareaRef.current;
+    if (el) {
+      const len = el.value.length;
+      el.setSelectionRange(len, len);
+    }
+  }, [editing, comment.body]);
+
+  const canSave = body.trim().length > 0;
+
+  function exitEdit(): void {
+    setEditing(false);
+    setBody(comment.body);
+  }
+
+  function saveEdit(): void {
+    if (!canSave) return;
+    onUpdate(comment.id, body);
+    setEditing(false);
+  }
+
+  function handleKeyDown(event: KeyboardEvent<HTMLTextAreaElement>): void {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      exitEdit();
+      return;
+    }
+    if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+      event.preventDefault();
+      event.stopPropagation();
+      if (canSave) saveEdit();
+    }
+  }
+
+  return (
+    <div
+      className="border-y border-gr-border bg-gr-bg px-3 py-2.5"
+      data-testid="draft-comment"
+      data-draft-id={comment.id}
+    >
+      <div className="mb-1.5 flex items-center justify-between gap-2">
+        <span className="font-mono text-[11px] text-gr-muted">
+          Draft · {formatLineRangeLabel(comment.filePath, comment.startLine, comment.endLine)}
+        </span>
+        <div className="flex items-center gap-1">
+          {!editing && (
+            <button
+              type="button"
+              className="cursor-pointer rounded px-1.5 py-0.5 text-[12px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+              onClick={() => setEditing(true)}
+              aria-label="Edit draft comment"
+              data-testid="draft-comment-edit"
+            >
+              Edit
+            </button>
+          )}
+          <button
+            type="button"
+            className="cursor-pointer rounded px-1.5 py-0.5 text-[12px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+            onClick={() => onRemove(comment.id)}
+            aria-label="Remove draft comment"
+            data-testid="draft-comment-remove"
+          >
+            Remove
+          </button>
+        </div>
+      </div>
+      {editing ? (
+        <>
+          <textarea
+            ref={textareaRef}
+            className="min-h-[88px] w-full resize-y rounded-md border border-gr-border bg-gr-chrome px-3 py-2 font-sans text-[14px] leading-relaxed text-gr-text outline-none placeholder:text-gr-faint focus:border-gr-accent"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            onKeyDown={handleKeyDown}
+            aria-label="Edit comment body"
+            data-testid="draft-comment-edit-input"
+          />
+          <div className="mt-2 flex flex-wrap items-center justify-end gap-2">
+            <button
+              type="button"
+              className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-chrome px-3 py-1.5 text-[13px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+              onClick={exitEdit}
+              data-testid="draft-comment-edit-cancel"
+            >
+              Cancel
+              <Kbd>Esc</Kbd>
+            </button>
+            <button
+              type="button"
+              className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-[13px] font-medium text-gr-accent-on enabled:hover:border-gr-accent-hover enabled:hover:bg-gr-accent-hover disabled:cursor-not-allowed disabled:opacity-40 [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
+              disabled={!canSave}
+              onClick={saveEdit}
+              data-testid="draft-comment-edit-save"
+            >
+              Save
+              <Kbd>⌘</Kbd>
+              <span className="text-[11px] opacity-70">/</span>
+              <Kbd>Ctrl</Kbd>
+              <Kbd>Enter</Kbd>
+            </button>
+          </div>
+        </>
+      ) : (
+        <div
+          className="whitespace-pre-wrap font-sans text-[14px] leading-relaxed text-gr-text"
+          data-testid="draft-comment-body"
+        >
+          {comment.body}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/content/overlay/components/FooterNav.tsx
+++ b/src/content/overlay/components/FooterNav.tsx
@@ -32,6 +32,7 @@ export function FooterNav({ currentIndex, total, onPrev, onNext }: FooterNavProp
         className={cn(
           navBtnBase,
           "border-gr-accent bg-gr-accent text-gr-accent-on",
+          "enabled:hover:border-gr-accent-hover enabled:hover:bg-gr-accent-hover",
           "[&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
         )}
         onClick={onNext}

--- a/src/content/overlay/components/KeyboardShortcuts.tsx
+++ b/src/content/overlay/components/KeyboardShortcuts.tsx
@@ -1,17 +1,59 @@
-import { Kbd } from "./Kbd";
+import { ShortcutKeys, type ShortcutJoin } from "./ShortcutKeys";
 
-const SHORTCUTS = [
-  { keys: ["←", "→"], description: "Previous / next step" },
-  { keys: ["↑", "↓"], description: "Scroll the code pane" },
-  { keys: ["v", "u"], description: "Unified view" },
-  { keys: ["v", "s"], description: "Split view" },
-  { keys: ["c"], description: "Enter comment mode" },
-  { keys: ["↑", "↓"], description: "Select lines (in comment mode)" },
-  { keys: ["⇧", "↑", "↓"], description: "Multi-line select (comment mode)" },
-  { keys: ["Enter"], description: "Open comment on selection" },
-  { keys: ["⌘", "Enter"], description: "Open / submit review (save draft in composer)" },
-  { keys: ["Esc"], description: "Exit comment mode / exit review" },
-] as const;
+/**
+ * Nested key groups for mixed joins (e.g. ⇧ + ↑ ↓ for multi-line select).
+ * Flat `keys` + `join` covers the common cases.
+ */
+type ShortcutRow =
+  | {
+      description: string;
+      keys: readonly string[];
+      join?: ShortcutJoin;
+    }
+  | {
+      description: string;
+      /** Chord of a modifier plus an alternative pair (no + between the pair). */
+      chordWithAlternatives: {
+        modifier: string;
+        alternatives: readonly string[];
+      };
+    };
+
+const SHORTCUTS: readonly ShortcutRow[] = [
+  { keys: ["←", "→"], join: "none", description: "Previous / next step" },
+  { keys: ["↑", "↓"], join: "none", description: "Scroll the code pane" },
+  { keys: ["v", "u"], join: "sequence", description: "Unified view" },
+  { keys: ["v", "s"], join: "sequence", description: "Split view" },
+  { keys: ["c"], join: "none", description: "Enter comment mode" },
+  { keys: ["↑", "↓"], join: "none", description: "Select lines (in comment mode)" },
+  {
+    description: "Multi-line select (comment mode)",
+    chordWithAlternatives: { modifier: "⇧", alternatives: ["↑", "↓"] },
+  },
+  { keys: ["Enter"], join: "none", description: "Open comment on selection" },
+  {
+    keys: ["mod", "Enter"],
+    join: "chord",
+    description: "Open / submit review (save draft in composer)",
+  },
+  { keys: ["Esc"], join: "none", description: "Exit comment mode / exit review" },
+];
+
+function ShortcutRowKeys({ row }: { row: ShortcutRow }) {
+  if ("chordWithAlternatives" in row) {
+    const { modifier, alternatives } = row.chordWithAlternatives;
+    return (
+      <span className="inline-flex items-center gap-1">
+        <ShortcutKeys keys={[modifier]} join="none" />
+        <span className="text-[11px] opacity-70" aria-hidden="true">
+          +
+        </span>
+        <ShortcutKeys keys={alternatives} join="none" />
+      </span>
+    );
+  }
+  return <ShortcutKeys keys={row.keys} join={row.join} />;
+}
 
 export function KeyboardShortcuts() {
   return (
@@ -20,14 +62,12 @@ export function KeyboardShortcuts() {
         Keyboard shortcuts
       </div>
       <ul className="m-0 flex list-none flex-col gap-2 p-0">
-        {SHORTCUTS.map(({ keys, description }) => (
-          <li key={description} className="flex items-center gap-3 text-[13px] text-gr-muted">
+        {SHORTCUTS.map((row) => (
+          <li key={row.description} className="flex items-center gap-3 text-[13px] text-gr-muted">
             <span className="inline-flex min-w-[72px] shrink-0 items-center gap-1">
-              {keys.map((key, i) => (
-                <Kbd key={`${description}-${key}-${i}`}>{key}</Kbd>
-              ))}
+              <ShortcutRowKeys row={row} />
             </span>
-            <span>{description}</span>
+            <span>{row.description}</span>
           </li>
         ))}
       </ul>

--- a/src/content/overlay/components/KeyboardShortcuts.tsx
+++ b/src/content/overlay/components/KeyboardShortcuts.tsx
@@ -3,7 +3,14 @@ import { Kbd } from "./Kbd";
 const SHORTCUTS = [
   { keys: ["←", "→"], description: "Previous / next step" },
   { keys: ["↑", "↓"], description: "Scroll the code pane" },
-  { keys: ["Esc"], description: "Exit the review" },
+  { keys: ["v", "u"], description: "Unified view" },
+  { keys: ["v", "s"], description: "Split view" },
+  { keys: ["c"], description: "Enter comment mode" },
+  { keys: ["↑", "↓"], description: "Select lines (in comment mode)" },
+  { keys: ["⇧", "↑", "↓"], description: "Multi-line select (comment mode)" },
+  { keys: ["Enter"], description: "Open comment on selection" },
+  { keys: ["⌘", "Enter"], description: "Open / submit review (save draft in composer)" },
+  { keys: ["Esc"], description: "Exit comment mode / exit review" },
 ] as const;
 
 export function KeyboardShortcuts() {
@@ -15,9 +22,9 @@ export function KeyboardShortcuts() {
       <ul className="m-0 flex list-none flex-col gap-2 p-0">
         {SHORTCUTS.map(({ keys, description }) => (
           <li key={description} className="flex items-center gap-3 text-[13px] text-gr-muted">
-            <span className="inline-flex min-w-[52px] shrink-0 items-center gap-1">
-              {keys.map((key) => (
-                <Kbd key={key}>{key}</Kbd>
+            <span className="inline-flex min-w-[72px] shrink-0 items-center gap-1">
+              {keys.map((key, i) => (
+                <Kbd key={`${description}-${key}-${i}`}>{key}</Kbd>
               ))}
             </span>
             <span>{description}</span>

--- a/src/content/overlay/components/ProgressHeader.tsx
+++ b/src/content/overlay/components/ProgressHeader.tsx
@@ -3,22 +3,18 @@ import { summarizeDiff } from "../../../lib/github/diffSummary";
 import { Kbd } from "./Kbd";
 
 interface ProgressHeaderProps {
-  currentIndex: number;
-  total: number;
-  /** When false, only show "Step N" without a known total (plan still loading). */
-  totalKnown: boolean;
   prContext: PRContext | null;
   diff: ParsedDiff | null;
   onExit: () => void;
+  /** Opens the Submit review modal. */
+  onSubmitReview: () => void;
 }
 
 export function ProgressHeader({
-  currentIndex,
-  total,
-  totalKnown,
   prContext,
   diff,
   onExit,
+  onSubmitReview,
 }: ProgressHeaderProps) {
   const stats = diff ? summarizeDiff(diff) : null;
   const logomarkUrl = chrome.runtime.getURL("logomark.svg");
@@ -64,13 +60,18 @@ export function ProgressHeader({
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-3">
-          {totalKnown && total > 0 ? (
-            <span className="text-[13px] text-gr-muted">
-              Step {currentIndex + 1} of {total}
-            </span>
-          ) : (
-            <span className="text-[13px] text-gr-muted">Step {currentIndex + 1}</span>
-          )}
+          <button
+            type="button"
+            className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-[13px] font-medium text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
+            onClick={onSubmitReview}
+            data-testid="submit-review-button"
+          >
+            Submit review
+            <Kbd>⌘</Kbd>
+            <span className="text-[11px] opacity-70">/</span>
+            <Kbd>Ctrl</Kbd>
+            <Kbd>Enter</Kbd>
+          </button>
           <button
             type="button"
             className="inline-flex cursor-pointer items-center gap-2 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-[13px] text-gr-text hover:bg-gr-subtle"

--- a/src/content/overlay/components/ProgressHeader.tsx
+++ b/src/content/overlay/components/ProgressHeader.tsx
@@ -1,12 +1,13 @@
 import type { ParsedDiff, PRContext } from "../../../lib/types";
 import { summarizeDiff } from "../../../lib/github/diffSummary";
 import { Kbd } from "./Kbd";
+import { ModEnterChord } from "./ShortcutKeys";
 
 interface ProgressHeaderProps {
   prContext: PRContext | null;
   diff: ParsedDiff | null;
   onExit: () => void;
-  /** Opens the Submit review modal. */
+  /** Opens the Submit Review modal. */
   onSubmitReview: () => void;
 }
 
@@ -66,11 +67,8 @@ export function ProgressHeader({
             onClick={onSubmitReview}
             data-testid="submit-review-button"
           >
-            Submit review
-            <Kbd>⌘</Kbd>
-            <span className="text-[11px] opacity-70">/</span>
-            <Kbd>Ctrl</Kbd>
-            <Kbd>Enter</Kbd>
+            Submit Review
+            <ModEnterChord />
           </button>
           <button
             type="button"

--- a/src/content/overlay/components/ShortcutKeys.test.tsx
+++ b/src/content/overlay/components/ShortcutKeys.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ModEnterChord, ShortcutKeys } from "./ShortcutKeys";
+
+function mockPlatform(platform: string) {
+  vi.stubGlobal("navigator", {
+    platform,
+    userAgent: "",
+  });
+}
+
+describe("ShortcutKeys", () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("renders sequence keys without a + separator", () => {
+    render(<ShortcutKeys keys={["v", "u"]} join="sequence" />);
+    expect(screen.getByText("v")).toBeInTheDocument();
+    expect(screen.getByText("u")).toBeInTheDocument();
+    expect(screen.queryByText("+")).not.toBeInTheDocument();
+  });
+
+  it("renders chord keys with + between badges", () => {
+    mockPlatform("Win32");
+    render(<ShortcutKeys keys={["mod", "Enter"]} join="chord" />);
+    expect(screen.getByText("Ctrl")).toBeInTheDocument();
+    expect(screen.getByText("Enter")).toBeInTheDocument();
+    expect(screen.getByText("+")).toBeInTheDocument();
+  });
+
+  it("resolves mod to ⌘ on macOS", () => {
+    mockPlatform("MacIntel");
+    render(<ShortcutKeys keys={["mod", "Enter"]} join="chord" />);
+    expect(screen.getByText("⌘")).toBeInTheDocument();
+    expect(screen.queryByText("Ctrl")).not.toBeInTheDocument();
+  });
+
+  it("resolves mod to Ctrl on non-macOS", () => {
+    mockPlatform("Linux x86_64");
+    render(<ShortcutKeys keys={["mod"]} join="none" />);
+    expect(screen.getByText("Ctrl")).toBeInTheDocument();
+    expect(screen.queryByText("⌘")).not.toBeInTheDocument();
+  });
+
+  it("renders alternatives without +", () => {
+    render(<ShortcutKeys keys={["←", "→"]} join="none" />);
+    expect(screen.getByText("←")).toBeInTheDocument();
+    expect(screen.getByText("→")).toBeInTheDocument();
+    expect(screen.queryByText("+")).not.toBeInTheDocument();
+  });
+});
+
+describe("ModEnterChord", () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("shows a single OS modifier with Enter", () => {
+    mockPlatform("Win32");
+    render(<ModEnterChord />);
+    expect(screen.getByText("Ctrl")).toBeInTheDocument();
+    expect(screen.getByText("Enter")).toBeInTheDocument();
+    expect(screen.getByText("+")).toBeInTheDocument();
+    expect(screen.queryByText("⌘")).not.toBeInTheDocument();
+  });
+});

--- a/src/content/overlay/components/ShortcutKeys.tsx
+++ b/src/content/overlay/components/ShortcutKeys.tsx
@@ -1,0 +1,64 @@
+import { Fragment } from "react";
+import { modKeyLabel } from "../platform";
+import { Kbd } from "./Kbd";
+
+/**
+ * Token for a key badge. Pass `"mod"` for the OS-aware primary modifier
+ * (⌘ on macOS, Ctrl elsewhere).
+ */
+export type ShortcutKey = string;
+
+export type ShortcutJoin = "none" | "sequence" | "chord";
+
+interface ShortcutKeysProps {
+  keys: readonly ShortcutKey[];
+  /**
+   * - `none` / `sequence`: adjacent key badges (sequential presses or alternatives).
+   * - `chord`: badges joined with `+` (keys held together).
+   */
+  join?: ShortcutJoin;
+  className?: string;
+}
+
+function resolveKey(key: ShortcutKey): string {
+  return key === "mod" ? modKeyLabel() : key;
+}
+
+/**
+ * Renders a keyboard shortcut hint: sequence (`v` `u`) vs chord (`Ctrl` + `Enter`).
+ */
+export function ShortcutKeys({
+  keys,
+  join = "none",
+  className,
+}: ShortcutKeysProps) {
+  if (keys.length === 0) return null;
+
+  const showPlus = join === "chord";
+
+  return (
+    <span
+      className={
+        className ?? "inline-flex items-center gap-1"
+      }
+    >
+      {keys.map((key, i) => (
+        <Fragment key={`${key}-${i}`}>
+          {showPlus && i > 0 ? (
+            <span className="text-[11px] opacity-70" aria-hidden="true">
+              +
+            </span>
+          ) : null}
+          <Kbd>{resolveKey(key)}</Kbd>
+        </Fragment>
+      ))}
+    </span>
+  );
+}
+
+/** ⌘/Ctrl + Enter chord, resolved for the current OS. */
+export function ModEnterChord({ className }: { className?: string }) {
+  return (
+    <ShortcutKeys keys={["mod", "Enter"]} join="chord" className={className} />
+  );
+}

--- a/src/content/overlay/components/SubmitReviewModal.test.tsx
+++ b/src/content/overlay/components/SubmitReviewModal.test.tsx
@@ -23,7 +23,7 @@ describe("SubmitReviewModal", () => {
       "data-step",
       "choose",
     );
-    expect(screen.getByRole("dialog", { name: "Submit review" })).toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: "Submit Review" })).toBeInTheDocument();
     expect(screen.queryByTestId("submit-review-body")).not.toBeInTheDocument();
     expect(screen.getByText("What would you like to do?")).toBeInTheDocument();
     expect(screen.getByText("Comment")).toBeInTheDocument();
@@ -34,7 +34,7 @@ describe("SubmitReviewModal", () => {
     expect(
       screen.getByText("Submit feedback and approve merging these changes."),
     ).toBeInTheDocument();
-    expect(screen.getByText("Request changes")).toBeInTheDocument();
+    expect(screen.getByText("Request Changes")).toBeInTheDocument();
     expect(
       screen.getByText("Submit feedback that must be addressed before merging."),
     ).toBeInTheDocument();

--- a/src/content/overlay/components/SubmitReviewModal.test.tsx
+++ b/src/content/overlay/components/SubmitReviewModal.test.tsx
@@ -1,0 +1,352 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SubmitReviewModal } from "./SubmitReviewModal";
+
+/** Advance from choose step to compose by clicking Comment (default option). */
+function selectCommentAndCompose(): void {
+  fireEvent.click(screen.getByTestId("submit-review-event-COMMENT"));
+}
+
+describe("SubmitReviewModal", () => {
+  it("renders nothing when closed", () => {
+    const { container } = render(
+      <SubmitReviewModal open={false} onClose={vi.fn()} onSubmit={vi.fn()} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("opens on the choose step with the three review modes", () => {
+    render(<SubmitReviewModal open onClose={vi.fn()} onSubmit={vi.fn()} />);
+
+    expect(screen.getByTestId("submit-review-modal")).toBeInTheDocument();
+    expect(screen.getByTestId("submit-review-modal")).toHaveAttribute(
+      "data-step",
+      "choose",
+    );
+    expect(screen.getByRole("dialog", { name: "Submit review" })).toBeInTheDocument();
+    expect(screen.queryByTestId("submit-review-body")).not.toBeInTheDocument();
+    expect(screen.getByText("What would you like to do?")).toBeInTheDocument();
+    expect(screen.getByText("Comment")).toBeInTheDocument();
+    expect(
+      screen.getByText("Submit general feedback without explicit approval."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Approve")).toBeInTheDocument();
+    expect(
+      screen.getByText("Submit feedback and approve merging these changes."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Request changes")).toBeInTheDocument();
+    expect(
+      screen.getByText("Submit feedback that must be addressed before merging."),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("submit-review-confirm")).not.toBeInTheDocument();
+  });
+
+  it("highlights Comment by default and focuses the listbox", () => {
+    render(<SubmitReviewModal open onClose={vi.fn()} onSubmit={vi.fn()} />);
+
+    expect(screen.getByTestId("submit-review-event-COMMENT")).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByTestId("submit-review-event-APPROVE")).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+    expect(screen.getByTestId("submit-review-event-list")).toHaveFocus();
+  });
+
+  it("moves highlight with ArrowDown and ArrowUp", () => {
+    render(<SubmitReviewModal open onClose={vi.fn()} onSubmit={vi.fn()} />);
+
+    const list = screen.getByTestId("submit-review-event-list");
+    fireEvent.keyDown(list, { key: "ArrowDown" });
+    expect(screen.getByTestId("submit-review-event-APPROVE")).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    fireEvent.keyDown(list, { key: "ArrowDown" });
+    expect(
+      screen.getByTestId("submit-review-event-REQUEST_CHANGES"),
+    ).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.keyDown(list, { key: "ArrowDown" });
+    expect(screen.getByTestId("submit-review-event-COMMENT")).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    fireEvent.keyDown(list, { key: "ArrowUp" });
+    expect(
+      screen.getByTestId("submit-review-event-REQUEST_CHANGES"),
+    ).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("advances to compose on Enter with the highlighted mode", () => {
+    render(<SubmitReviewModal open onClose={vi.fn()} onSubmit={vi.fn()} />);
+
+    const list = screen.getByTestId("submit-review-event-list");
+    fireEvent.keyDown(list, { key: "ArrowDown" });
+    fireEvent.keyDown(list, { key: "Enter" });
+
+    expect(screen.getByTestId("submit-review-modal")).toHaveAttribute(
+      "data-step",
+      "compose",
+    );
+    expect(screen.getByTestId("submit-review-body")).toBeInTheDocument();
+    expect(screen.getByTestId("submit-review-body")).toHaveFocus();
+    expect(screen.getByTestId("submit-review-selected-event")).toHaveAttribute(
+      "data-event",
+      "APPROVE",
+    );
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("advances to compose when clicking a mode option", () => {
+    render(<SubmitReviewModal open onClose={vi.fn()} onSubmit={vi.fn()} />);
+
+    fireEvent.click(screen.getByTestId("submit-review-event-REQUEST_CHANGES"));
+
+    expect(screen.getByTestId("submit-review-selected-event")).toHaveAttribute(
+      "data-event",
+      "REQUEST_CHANGES",
+    );
+    expect(screen.getByTestId("submit-review-body")).toBeInTheDocument();
+  });
+
+  it("submits body and selected event from compose", () => {
+    const onSubmit = vi.fn();
+    render(<SubmitReviewModal open onClose={vi.fn()} onSubmit={onSubmit} />);
+
+    fireEvent.click(screen.getByTestId("submit-review-event-APPROVE"));
+    fireEvent.change(screen.getByTestId("submit-review-body"), {
+      target: { value: "LGTM with nits" },
+    });
+    fireEvent.click(screen.getByTestId("submit-review-confirm"));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      body: "LGTM with nits",
+      event: "APPROVE",
+    });
+  });
+
+  it("allows empty body on submit (GitHub behavior)", () => {
+    const onSubmit = vi.fn();
+    render(<SubmitReviewModal open onClose={vi.fn()} onSubmit={onSubmit} />);
+
+    selectCommentAndCompose();
+    fireEvent.click(screen.getByTestId("submit-review-confirm"));
+    expect(onSubmit).toHaveBeenCalledWith({ body: "", event: "COMMENT" });
+  });
+
+  it("Back returns to choose, keeps body, and restores highlight", () => {
+    render(<SubmitReviewModal open onClose={vi.fn()} onSubmit={vi.fn()} />);
+
+    fireEvent.click(screen.getByTestId("submit-review-event-APPROVE"));
+    fireEvent.change(screen.getByTestId("submit-review-body"), {
+      target: { value: "draft notes" },
+    });
+    fireEvent.click(screen.getByTestId("submit-review-back"));
+
+    expect(screen.getByTestId("submit-review-modal")).toHaveAttribute(
+      "data-step",
+      "choose",
+    );
+    expect(screen.getByTestId("submit-review-event-APPROVE")).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.queryByTestId("submit-review-body")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("submit-review-event-APPROVE"));
+    expect(screen.getByTestId("submit-review-body")).toHaveValue("draft notes");
+  });
+
+  it("can change mode after going back", () => {
+    const onSubmit = vi.fn();
+    render(<SubmitReviewModal open onClose={vi.fn()} onSubmit={onSubmit} />);
+
+    fireEvent.click(screen.getByTestId("submit-review-event-APPROVE"));
+    fireEvent.click(screen.getByTestId("submit-review-back"));
+    fireEvent.click(screen.getByTestId("submit-review-event-REQUEST_CHANGES"));
+    fireEvent.click(screen.getByTestId("submit-review-confirm"));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      body: "",
+      event: "REQUEST_CHANGES",
+    });
+  });
+
+  it("calls onClose from Cancel on choose step", () => {
+    const onClose = vi.fn();
+    render(<SubmitReviewModal open onClose={onClose} onSubmit={vi.fn()} />);
+
+    fireEvent.click(screen.getByTestId("submit-review-cancel"));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("calls onClose from Cancel on compose step", () => {
+    const onClose = vi.fn();
+    render(<SubmitReviewModal open onClose={onClose} onSubmit={vi.fn()} />);
+
+    selectCommentAndCompose();
+    fireEvent.click(screen.getByTestId("submit-review-cancel"));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("calls onClose when clicking the scrim", () => {
+    const onClose = vi.fn();
+    render(<SubmitReviewModal open onClose={onClose} onSubmit={vi.fn()} />);
+
+    fireEvent.click(screen.getByTestId("submit-review-scrim"));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("does not close when clicking inside the dialog", () => {
+    const onClose = vi.fn();
+    render(<SubmitReviewModal open onClose={onClose} onSubmit={vi.fn()} />);
+
+    fireEvent.click(screen.getByTestId("submit-review-modal"));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("calls onClose on Escape from the listbox", () => {
+    const onClose = vi.fn();
+    render(<SubmitReviewModal open onClose={onClose} onSubmit={vi.fn()} />);
+
+    fireEvent.keyDown(screen.getByTestId("submit-review-event-list"), {
+      key: "Escape",
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("calls onClose on Escape from the textarea", () => {
+    const onClose = vi.fn();
+    render(<SubmitReviewModal open onClose={onClose} onSubmit={vi.fn()} />);
+
+    selectCommentAndCompose();
+    fireEvent.keyDown(screen.getByTestId("submit-review-body"), { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("submits with Ctrl+Enter from the textarea", () => {
+    const onSubmit = vi.fn();
+    render(<SubmitReviewModal open onClose={vi.fn()} onSubmit={onSubmit} />);
+
+    fireEvent.click(screen.getByTestId("submit-review-event-APPROVE"));
+    fireEvent.change(screen.getByTestId("submit-review-body"), {
+      target: { value: "Ship it" },
+    });
+    fireEvent.keyDown(screen.getByTestId("submit-review-body"), {
+      key: "Enter",
+      ctrlKey: true,
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      body: "Ship it",
+      event: "APPROVE",
+    });
+  });
+
+  it("submits with meta+Enter from the textarea", () => {
+    const onSubmit = vi.fn();
+    render(<SubmitReviewModal open onClose={vi.fn()} onSubmit={onSubmit} />);
+
+    selectCommentAndCompose();
+    fireEvent.keyDown(screen.getByTestId("submit-review-body"), {
+      key: "Enter",
+      metaKey: true,
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith({ body: "", event: "COMMENT" });
+  });
+
+  it("does not use radio inputs for review modes", () => {
+    render(<SubmitReviewModal open onClose={vi.fn()} onSubmit={vi.fn()} />);
+
+    expect(
+      screen.getByTestId("submit-review-event-COMMENT").querySelector("input"),
+    ).toBeNull();
+    expect(screen.queryByRole("radio")).not.toBeInTheDocument();
+  });
+
+  it("resets to choose step when reopened", () => {
+    const { rerender } = render(
+      <SubmitReviewModal open onClose={vi.fn()} onSubmit={vi.fn()} />,
+    );
+
+    fireEvent.click(screen.getByTestId("submit-review-event-REQUEST_CHANGES"));
+    fireEvent.change(screen.getByTestId("submit-review-body"), {
+      target: { value: "draft notes" },
+    });
+
+    rerender(<SubmitReviewModal open={false} onClose={vi.fn()} onSubmit={vi.fn()} />);
+    rerender(<SubmitReviewModal open onClose={vi.fn()} onSubmit={vi.fn()} />);
+
+    expect(screen.getByTestId("submit-review-modal")).toHaveAttribute(
+      "data-step",
+      "choose",
+    );
+    expect(screen.getByTestId("submit-review-event-COMMENT")).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.queryByTestId("submit-review-body")).not.toBeInTheDocument();
+  });
+
+  it("registers keyActionRef for choose-step capture handling", () => {
+    const keyActionRef = { current: null as ((e: KeyboardEvent) => boolean) | null };
+    render(
+      <SubmitReviewModal
+        open
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+        keyActionRef={keyActionRef}
+      />,
+    );
+
+    expect(keyActionRef.current).not.toBeNull();
+    act(() => {
+      expect(
+        keyActionRef.current!(
+          new KeyboardEvent("keydown", { key: "ArrowDown" }),
+        ),
+      ).toBe(true);
+    });
+    expect(screen.getByTestId("submit-review-event-APPROVE")).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    act(() => {
+      expect(
+        keyActionRef.current!(new KeyboardEvent("keydown", { key: "Enter" })),
+      ).toBe(true);
+    });
+    expect(screen.getByTestId("submit-review-modal")).toHaveAttribute(
+      "data-step",
+      "compose",
+    );
+    expect(keyActionRef.current).toBeNull();
+  });
+
+  it("only sets submitActionRef on the compose step", () => {
+    const submitActionRef = { current: null as (() => void) | null };
+    const onSubmit = vi.fn();
+    render(
+      <SubmitReviewModal
+        open
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+        submitActionRef={submitActionRef}
+      />,
+    );
+
+    expect(submitActionRef.current).toBeNull();
+
+    selectCommentAndCompose();
+    expect(submitActionRef.current).not.toBeNull();
+    submitActionRef.current!();
+    expect(onSubmit).toHaveBeenCalledWith({ body: "", event: "COMMENT" });
+  });
+});

--- a/src/content/overlay/components/SubmitReviewModal.tsx
+++ b/src/content/overlay/components/SubmitReviewModal.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import type { ReviewEvent, ReviewSubmission } from "../commentTypes";
 import { Kbd } from "./Kbd";
+import { ModEnterChord } from "./ShortcutKeys";
 
 interface SubmitReviewModalProps {
   open: boolean;
@@ -43,7 +44,7 @@ const REVIEW_EVENTS: {
   },
   {
     value: "REQUEST_CHANGES",
-    label: "Request changes",
+    label: "Request Changes",
     description: "Submit feedback that must be addressed before merging.",
   },
 ];
@@ -232,7 +233,7 @@ export function SubmitReviewModal({
       >
         <div className="flex items-center justify-between gap-3 border-b border-gr-border px-4 py-3">
           <h2 id={titleId} className="m-0 text-[15px] font-semibold text-gr-text">
-            Submit review
+            Submit Review
           </h2>
           <button
             type="button"
@@ -377,11 +378,8 @@ export function SubmitReviewModal({
                   onClick={handleSubmit}
                   data-testid="submit-review-confirm"
                 >
-                  Submit review
-                  <Kbd>⌘</Kbd>
-                  <span className="text-[11px] opacity-70">/</span>
-                  <Kbd>Ctrl</Kbd>
-                  <Kbd>Enter</Kbd>
+                  Submit Review
+                  <ModEnterChord />
                 </button>
               </div>
             </div>

--- a/src/content/overlay/components/SubmitReviewModal.tsx
+++ b/src/content/overlay/components/SubmitReviewModal.tsx
@@ -1,0 +1,393 @@
+import {
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MutableRefObject,
+} from "react";
+import type { ReviewEvent, ReviewSubmission } from "../commentTypes";
+import { Kbd } from "./Kbd";
+
+interface SubmitReviewModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (submission: ReviewSubmission) => void;
+  /**
+   * Bound to the latest submit action so the overlay capture keydown can
+   * fire ⌘/Ctrl+Enter (React handlers on the textarea do not see real keys
+   * after the window capture stopPropagation).
+   */
+  submitActionRef?: MutableRefObject<(() => void) | null>;
+  /**
+   * Choose-step key handler for the overlay capture path (↑/↓/Enter).
+   * Returns true when the key was handled (caller should preventDefault).
+   */
+  keyActionRef?: MutableRefObject<((e: KeyboardEvent) => boolean) | null>;
+}
+
+const REVIEW_EVENTS: {
+  value: ReviewEvent;
+  label: string;
+  description: string;
+}[] = [
+  {
+    value: "COMMENT",
+    label: "Comment",
+    description: "Submit general feedback without explicit approval.",
+  },
+  {
+    value: "APPROVE",
+    label: "Approve",
+    description: "Submit feedback and approve merging these changes.",
+  },
+  {
+    value: "REQUEST_CHANGES",
+    label: "Request changes",
+    description: "Submit feedback that must be addressed before merging.",
+  },
+];
+
+type ModalStep = "choose" | "compose";
+
+function eventIndex(event: ReviewEvent): number {
+  const i = REVIEW_EVENTS.findIndex((o) => o.value === event);
+  return i >= 0 ? i : 0;
+}
+
+/**
+ * GitHub-style submit-review dialog: pick event type, then summary comment.
+ * UI only — parent decides what to do with the submission (API later).
+ */
+export function SubmitReviewModal({
+  open,
+  onClose,
+  onSubmit,
+  submitActionRef,
+  keyActionRef,
+}: SubmitReviewModalProps) {
+  const titleId = useId();
+  const listboxId = useId();
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const listboxRef = useRef<HTMLDivElement>(null);
+  const [step, setStep] = useState<ModalStep>("choose");
+  const [highlightIndex, setHighlightIndex] = useState(0);
+  const highlightIndexRef = useRef(0);
+  const [body, setBody] = useState("");
+  const [event, setEvent] = useState<ReviewEvent>("COMMENT");
+
+  function setHighlight(index: number): void {
+    highlightIndexRef.current = index;
+    setHighlightIndex(index);
+  }
+
+  function confirmMode(index: number): void {
+    const opt = REVIEW_EVENTS[index] ?? REVIEW_EVENTS[0];
+    setEvent(opt.value);
+    setHighlight(index);
+    setStep("compose");
+  }
+
+  function goBack(): void {
+    setHighlight(eventIndex(event));
+    setStep("choose");
+  }
+
+  // Reset form when opened.
+  useEffect(() => {
+    if (!open) return;
+    setStep("choose");
+    setHighlight(0);
+    setBody("");
+    setEvent("COMMENT");
+  }, [open]);
+
+  // Focus listbox on choose step; textarea on compose.
+  useEffect(() => {
+    if (!open) return;
+    if (step === "choose") {
+      listboxRef.current?.focus();
+    } else {
+      textareaRef.current?.focus();
+    }
+  }, [open, step]);
+
+  // Keep the overlay capture path pointed at the current form values.
+  // Submit only available on the compose step.
+  useEffect(() => {
+    if (!submitActionRef) return;
+    if (!open || step !== "compose") {
+      submitActionRef.current = null;
+      return;
+    }
+    submitActionRef.current = () => onSubmit({ body, event });
+    return () => {
+      submitActionRef.current = null;
+    };
+  }, [open, step, body, event, onSubmit, submitActionRef]);
+
+  // Choose-step keys via overlay capture (real keystrokes never reach React handlers).
+  // highlightIndexRef keeps Enter accurate across sequential keys before re-render.
+  useEffect(() => {
+    if (!keyActionRef) return;
+    if (!open || step !== "choose") {
+      keyActionRef.current = null;
+      return;
+    }
+    keyActionRef.current = (e: KeyboardEvent) => {
+      if (e.metaKey || e.ctrlKey || e.altKey) return false;
+      if (e.key === "ArrowDown") {
+        setHighlight((highlightIndexRef.current + 1) % REVIEW_EVENTS.length);
+        return true;
+      }
+      if (e.key === "ArrowUp") {
+        setHighlight(
+          (highlightIndexRef.current - 1 + REVIEW_EVENTS.length) %
+            REVIEW_EVENTS.length,
+        );
+        return true;
+      }
+      if (e.key === "Enter") {
+        confirmMode(highlightIndexRef.current);
+        return true;
+      }
+      return false;
+    };
+    return () => {
+      keyActionRef.current = null;
+    };
+  }, [open, step, keyActionRef]);
+
+  if (!open) return null;
+
+  function handleSubmit(): void {
+    onSubmit({ body, event });
+  }
+
+  function handleTextareaKeyDown(e: ReactKeyboardEvent<HTMLTextAreaElement>): void {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      e.stopPropagation();
+      onClose();
+      return;
+    }
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      e.stopPropagation();
+      handleSubmit();
+    }
+  }
+
+  /** Element-level keys for tests / when focus is on the listbox without capture. */
+  function handleListboxKeyDown(e: ReactKeyboardEvent<HTMLDivElement>): void {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      e.stopPropagation();
+      onClose();
+      return;
+    }
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      e.stopPropagation();
+      setHighlight((highlightIndexRef.current + 1) % REVIEW_EVENTS.length);
+      return;
+    }
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      e.stopPropagation();
+      setHighlight(
+        (highlightIndexRef.current - 1 + REVIEW_EVENTS.length) %
+          REVIEW_EVENTS.length,
+      );
+      return;
+    }
+    if (e.key === "Enter") {
+      e.preventDefault();
+      e.stopPropagation();
+      confirmMode(highlightIndexRef.current);
+    }
+  }
+
+  const selectedOpt =
+    REVIEW_EVENTS.find((o) => o.value === event) ?? REVIEW_EVENTS[0];
+  const activeOptionId = `${listboxId}-option-${highlightIndex}`;
+
+  return (
+    <div
+      className="absolute inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      data-testid="submit-review-scrim"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        data-testid="submit-review-modal"
+        data-step={step}
+        className="flex w-full max-w-[480px] flex-col rounded-lg border border-gr-border bg-gr-chrome shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between gap-3 border-b border-gr-border px-4 py-3">
+          <h2 id={titleId} className="m-0 text-[15px] font-semibold text-gr-text">
+            Submit review
+          </h2>
+          <button
+            type="button"
+            className="inline-flex cursor-pointer items-center justify-center rounded-md border border-gr-border bg-gr-bg p-1.5 text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+            onClick={onClose}
+            aria-label="Close"
+            data-testid="submit-review-close"
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 16 16"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+            >
+              <path
+                d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {step === "choose" ? (
+          <>
+            <div className="flex flex-col gap-3 px-4 py-4">
+              <p className="m-0 text-[13px] text-gr-muted">
+                What would you like to do?
+              </p>
+              <div
+                ref={listboxRef}
+                role="listbox"
+                id={listboxId}
+                tabIndex={0}
+                aria-label="Review type"
+                aria-activedescendant={activeOptionId}
+                data-testid="submit-review-event-list"
+                className="flex flex-col gap-2 outline-none"
+                onKeyDown={handleListboxKeyDown}
+              >
+                {REVIEW_EVENTS.map((opt, index) => {
+                  const highlighted = highlightIndex === index;
+                  return (
+                    <div
+                      key={opt.value}
+                      id={`${listboxId}-option-${index}`}
+                      role="option"
+                      aria-selected={highlighted}
+                      data-testid={`submit-review-event-${opt.value}`}
+                      className={[
+                        "cursor-pointer rounded-md border px-3 py-2.5 transition-colors",
+                        highlighted
+                          ? "border-gr-accent bg-gr-subtle"
+                          : "border-gr-border bg-gr-bg hover:bg-gr-subtle",
+                      ].join(" ")}
+                      onClick={() => confirmMode(index)}
+                      onMouseEnter={() => setHighlight(index)}
+                    >
+                      <div className="text-[13px] font-semibold text-gr-text">
+                        {opt.label}
+                      </div>
+                      <div className="mt-0.5 text-[12.5px] leading-snug text-gr-muted">
+                        {opt.description}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+              <div className="flex items-center gap-2 text-[12px] text-gr-faint">
+                <Kbd>↑</Kbd>
+                <Kbd>↓</Kbd>
+                <span>to choose</span>
+                <span className="opacity-50">·</span>
+                <Kbd>Enter</Kbd>
+                <span>to continue</span>
+              </div>
+            </div>
+
+            <div className="flex items-center justify-end gap-2 border-t border-gr-border px-4 py-3">
+              <button
+                type="button"
+                className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-[13px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+                onClick={onClose}
+                data-testid="submit-review-cancel"
+              >
+                Cancel
+                <Kbd>Esc</Kbd>
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="flex flex-col gap-4 px-4 py-4">
+              <textarea
+                ref={textareaRef}
+                className="min-h-[100px] w-full resize-y rounded-md border border-gr-border bg-gr-bg px-3 py-2 font-sans text-[14px] leading-relaxed text-gr-text outline-none placeholder:text-gr-faint focus:border-gr-accent"
+                placeholder="Leave a comment"
+                value={body}
+                onChange={(e) => setBody(e.target.value)}
+                onKeyDown={handleTextareaKeyDown}
+                aria-label="Review comment"
+                data-testid="submit-review-body"
+              />
+
+              <div
+                className="rounded-md border border-gr-border bg-gr-bg px-3 py-2.5"
+                data-testid="submit-review-selected-event"
+                data-event={selectedOpt.value}
+              >
+                <div className="text-[13px] font-semibold text-gr-text">
+                  {selectedOpt.label}
+                </div>
+                <div className="mt-0.5 text-[12.5px] leading-snug text-gr-muted">
+                  {selectedOpt.description}
+                </div>
+              </div>
+            </div>
+
+            <div className="flex items-center justify-between gap-2 border-t border-gr-border px-4 py-3">
+              <button
+                type="button"
+                className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-[13px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+                onClick={goBack}
+                data-testid="submit-review-back"
+              >
+                Back
+              </button>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-[13px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+                  onClick={onClose}
+                  data-testid="submit-review-cancel"
+                >
+                  Cancel
+                  <Kbd>Esc</Kbd>
+                </button>
+                <button
+                  type="button"
+                  className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-[13px] font-medium text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
+                  onClick={handleSubmit}
+                  data-testid="submit-review-confirm"
+                >
+                  Submit review
+                  <Kbd>⌘</Kbd>
+                  <span className="text-[11px] opacity-70">/</span>
+                  <Kbd>Ctrl</Kbd>
+                  <Kbd>Enter</Kbd>
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/content/overlay/platform.test.ts
+++ b/src/content/overlay/platform.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isMacPlatform, modKeyLabel } from "./platform";
+
+function mockNavigator(partial: {
+  platform?: string;
+  userAgent?: string;
+  userAgentData?: { platform?: string };
+}) {
+  vi.stubGlobal("navigator", {
+    platform: partial.platform ?? "",
+    userAgent: partial.userAgent ?? "",
+    userAgentData: partial.userAgentData,
+  });
+}
+
+describe("isMacPlatform", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("detects macOS from navigator.platform", () => {
+    mockNavigator({ platform: "MacIntel" });
+    expect(isMacPlatform()).toBe(true);
+  });
+
+  it("detects macOS from userAgentData.platform", () => {
+    mockNavigator({ platform: "Win32", userAgentData: { platform: "macOS" } });
+    expect(isMacPlatform()).toBe(true);
+  });
+
+  it("detects macOS from userAgent fallback", () => {
+    mockNavigator({
+      platform: "",
+      userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+    });
+    expect(isMacPlatform()).toBe(true);
+  });
+
+  it("returns false for Windows", () => {
+    mockNavigator({ platform: "Win32", userAgent: "Windows NT 10.0" });
+    expect(isMacPlatform()).toBe(false);
+  });
+
+  it("returns false for Linux", () => {
+    mockNavigator({ platform: "Linux x86_64", userAgent: "X11; Linux x86_64" });
+    expect(isMacPlatform()).toBe(false);
+  });
+});
+
+describe("modKeyLabel", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns ⌘ on macOS", () => {
+    mockNavigator({ platform: "MacIntel" });
+    expect(modKeyLabel()).toBe("⌘");
+  });
+
+  it("returns Ctrl on non-macOS", () => {
+    mockNavigator({ platform: "Win32" });
+    expect(modKeyLabel()).toBe("Ctrl");
+  });
+});

--- a/src/content/overlay/platform.ts
+++ b/src/content/overlay/platform.ts
@@ -1,0 +1,20 @@
+/**
+ * OS detection for keyboard-shortcut labels (⌘ vs Ctrl).
+ * Content-script safe — reads navigator only at call time.
+ */
+
+export function isMacPlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+
+  const nav = navigator as Navigator & {
+    userAgentData?: { platform?: string };
+  };
+  const platform = nav.userAgentData?.platform ?? nav.platform ?? "";
+  if (/Mac|iPhone|iPod|iPad/i.test(platform)) return true;
+  return /Mac OS X|Macintosh/i.test(nav.userAgent ?? "");
+}
+
+/** Primary modifier label for this OS: ⌘ on Apple platforms, Ctrl elsewhere. */
+export function modKeyLabel(): "⌘" | "Ctrl" {
+  return isMacPlatform() ? "⌘" : "Ctrl";
+}

--- a/src/content/overlay/store.test.ts
+++ b/src/content/overlay/store.test.ts
@@ -53,7 +53,24 @@ function resetStore(): void {
     streamGeneration: 0,
     sessionKey: null,
     diffViewMode: DEFAULT_DIFF_VIEW_MODE,
+    uiMode: "navigate",
+    selectableLines: [],
+    lineSelection: null,
+    composerOpen: false,
+    draftComments: [],
   });
+}
+
+function selectableFixture(count = 3) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `src/foo.ts#0:${i}:RIGHT`,
+    filePath: "src/foo.ts",
+    hunkId: "src/foo.ts#0",
+    lineIndex: i,
+    side: "RIGHT" as const,
+    newLine: i + 1,
+    type: "add" as const,
+  }));
 }
 
 describe("buildSessionKey", () => {
@@ -316,6 +333,229 @@ describe("useReviewStore", () => {
       );
       expect(restored).toBe(false);
       expect(useReviewStore.getState().status).toBe("idle");
+    });
+
+    it("persistSession / restoreSession round-trips draft comments", async () => {
+      resetStore();
+      const lines = selectableFixture(2);
+      useReviewStore.getState().startLoading(SESSION_KEY);
+      useReviewStore.getState().setReady(diffFixture(), planFixture(1));
+      useReviewStore.getState().enterCommentMode(lines);
+      useReviewStore.getState().saveDraftComment("Looks good");
+
+      await persistSession();
+      resetStore();
+      await restoreSession(SESSION_KEY);
+
+      const drafts = useReviewStore.getState().draftComments;
+      expect(drafts).toHaveLength(1);
+      expect(drafts[0].body).toBe("Looks good");
+      expect(useReviewStore.getState().uiMode).toBe("navigate");
+    });
+  });
+
+  describe("comment mode", () => {
+    it("enterCommentMode selects the first line; empty list is a no-op", () => {
+      resetStore();
+      useReviewStore.getState().enterCommentMode([]);
+      expect(useReviewStore.getState().uiMode).toBe("navigate");
+
+      useReviewStore.getState().enterCommentMode(selectableFixture(3));
+      const state = useReviewStore.getState();
+      expect(state.uiMode).toBe("comment");
+      expect(state.lineSelection).toEqual({ anchorIndex: 0, focusIndex: 0 });
+      expect(state.selectableLines).toHaveLength(3);
+    });
+
+    it("moveLineCursor moves focus; without shift resets anchor", () => {
+      resetStore();
+      useReviewStore.getState().enterCommentMode(selectableFixture(4));
+      useReviewStore.getState().moveLineCursor(1, false);
+      expect(useReviewStore.getState().lineSelection).toEqual({
+        anchorIndex: 1,
+        focusIndex: 1,
+      });
+      useReviewStore.getState().moveLineCursor(1, false);
+      expect(useReviewStore.getState().lineSelection).toEqual({
+        anchorIndex: 2,
+        focusIndex: 2,
+      });
+    });
+
+    it("moveLineCursor with extend grows a multi-line range on the same side", () => {
+      resetStore();
+      useReviewStore.getState().enterCommentMode(selectableFixture(4));
+      useReviewStore.getState().moveLineCursor(1, true);
+      useReviewStore.getState().moveLineCursor(1, true);
+      expect(useReviewStore.getState().lineSelection).toEqual({
+        anchorIndex: 0,
+        focusIndex: 2,
+      });
+    });
+
+    it("moveLineCursor with extend skips lines on a different side", () => {
+      resetStore();
+      const lines = [
+        {
+          id: "f#0:0:LEFT",
+          filePath: "f.ts",
+          hunkId: "f#0",
+          lineIndex: 0,
+          side: "LEFT" as const,
+          oldLine: 1,
+          type: "del" as const,
+        },
+        {
+          id: "f#0:1:RIGHT",
+          filePath: "f.ts",
+          hunkId: "f#0",
+          lineIndex: 1,
+          side: "RIGHT" as const,
+          newLine: 1,
+          type: "add" as const,
+        },
+        {
+          id: "f#0:2:LEFT",
+          filePath: "f.ts",
+          hunkId: "f#0",
+          lineIndex: 2,
+          side: "LEFT" as const,
+          oldLine: 2,
+          type: "del" as const,
+        },
+      ];
+      useReviewStore.getState().enterCommentMode(lines);
+      useReviewStore.getState().moveLineCursor(1, true);
+      // Skips RIGHT, lands on second LEFT
+      expect(useReviewStore.getState().lineSelection).toEqual({
+        anchorIndex: 0,
+        focusIndex: 2,
+      });
+    });
+
+    it("openComposer / saveDraftComment / updateDraftComment / removeDraftComment", () => {
+      resetStore();
+      useReviewStore.getState().enterCommentMode(selectableFixture(3));
+      useReviewStore.getState().moveLineCursor(1, true);
+      useReviewStore.getState().openComposer();
+      expect(useReviewStore.getState().composerOpen).toBe(true);
+
+      useReviewStore.getState().saveDraftComment("   ");
+      expect(useReviewStore.getState().draftComments).toHaveLength(0);
+      expect(useReviewStore.getState().composerOpen).toBe(true);
+
+      useReviewStore.getState().saveDraftComment("  Needs a test  ", "u0");
+      const drafts = useReviewStore.getState().draftComments;
+      expect(drafts).toHaveLength(1);
+      expect(drafts[0]).toMatchObject({
+        body: "Needs a test",
+        filePath: "src/foo.ts",
+        side: "RIGHT",
+        startLine: 1,
+        endLine: 2,
+        unitId: "u0",
+      });
+      expect(useReviewStore.getState().composerOpen).toBe(false);
+
+      useReviewStore.getState().updateDraftComment(drafts[0].id, "  Revised  ");
+      expect(useReviewStore.getState().draftComments[0].body).toBe("Revised");
+
+      useReviewStore.getState().updateDraftComment(drafts[0].id, "   ");
+      expect(useReviewStore.getState().draftComments[0].body).toBe("Revised");
+
+      useReviewStore.getState().removeDraftComment(drafts[0].id);
+      expect(useReviewStore.getState().draftComments).toHaveLength(0);
+    });
+
+    it("goNext / goToUnit exit comment mode but keep drafts", () => {
+      resetStore();
+      useReviewStore.getState().setReady(diffFixture(), planFixture(2));
+      useReviewStore.getState().enterCommentMode(selectableFixture(2));
+      useReviewStore.getState().saveDraftComment("keep me");
+
+      useReviewStore.getState().goNext();
+      expect(useReviewStore.getState().uiMode).toBe("navigate");
+      expect(useReviewStore.getState().lineSelection).toBeNull();
+      expect(useReviewStore.getState().draftComments).toHaveLength(1);
+    });
+
+    it("exitCommentMode clears selection without dropping drafts", () => {
+      resetStore();
+      useReviewStore.getState().enterCommentMode(selectableFixture(2));
+      useReviewStore.getState().saveDraftComment("draft");
+      useReviewStore.getState().exitCommentMode();
+      expect(useReviewStore.getState().uiMode).toBe("navigate");
+      expect(useReviewStore.getState().draftComments).toHaveLength(1);
+    });
+
+    it("setSelectableLines rematches focus/anchor by line id", () => {
+      resetStore();
+      const bothSides = [
+        {
+          id: "f#0:0:LEFT",
+          filePath: "f.ts",
+          hunkId: "f#0",
+          lineIndex: 0,
+          side: "LEFT" as const,
+          oldLine: 1,
+          type: "del" as const,
+        },
+        {
+          id: "f#0:1:RIGHT",
+          filePath: "f.ts",
+          hunkId: "f#0",
+          lineIndex: 1,
+          side: "RIGHT" as const,
+          newLine: 1,
+          type: "add" as const,
+        },
+        {
+          id: "f#0:2:RIGHT",
+          filePath: "f.ts",
+          hunkId: "f#0",
+          lineIndex: 2,
+          side: "RIGHT" as const,
+          newLine: 2,
+          type: "add" as const,
+        },
+      ];
+      useReviewStore.getState().enterCommentMode(bothSides);
+      useReviewStore.getState().moveLineCursor(2, false); // focus RIGHT line 2
+      expect(useReviewStore.getState().lineSelection).toEqual({
+        anchorIndex: 2,
+        focusIndex: 2,
+      });
+
+      // Simulate split → RIGHT-only (drop LEFT); same id should stay focused.
+      const rightOnly = bothSides.filter((l) => l.side === "RIGHT");
+      useReviewStore.getState().setSelectableLines(rightOnly);
+      expect(useReviewStore.getState().selectableLines).toHaveLength(2);
+      expect(useReviewStore.getState().lineSelection).toEqual({
+        anchorIndex: 1,
+        focusIndex: 1,
+      });
+      expect(useReviewStore.getState().selectableLines[1].id).toBe(
+        "f#0:2:RIGHT",
+      );
+    });
+
+    it("setSelectableLines resets when prior focus id is gone", () => {
+      resetStore();
+      useReviewStore.getState().enterCommentMode(selectableFixture(3));
+      useReviewStore.getState().moveLineCursor(2, false);
+      useReviewStore.getState().setSelectableLines(selectableFixture(2));
+      expect(useReviewStore.getState().lineSelection).toEqual({
+        anchorIndex: 0,
+        focusIndex: 0,
+      });
+    });
+
+    it("setSelectableLines with empty list exits comment mode", () => {
+      resetStore();
+      useReviewStore.getState().enterCommentMode(selectableFixture(2));
+      useReviewStore.getState().setSelectableLines([]);
+      expect(useReviewStore.getState().uiMode).toBe("navigate");
+      expect(useReviewStore.getState().lineSelection).toBeNull();
     });
   });
 });

--- a/src/content/overlay/store.ts
+++ b/src/content/overlay/store.ts
@@ -1,5 +1,13 @@
 import { create } from "zustand";
 import type { ParsedDiff, PRContext, ReviewPlan, ReviewUnit } from "../../lib/types";
+import {
+  displayLineNumber,
+  linesInSelection,
+  type DraftComment,
+  type LineSelection,
+  type SelectableLine,
+  type UiMode,
+} from "./commentTypes";
 import { displayUnitCount } from "./displayUnits";
 import {
   DEFAULT_DIFF_VIEW_MODE,
@@ -24,7 +32,16 @@ interface PersistedSession {
   prContext: PRContext | null;
   /** Index into the display unit list (0 = PR description, then plan units). */
   currentUnitIndex: number;
+  /** Local draft comments (session-scoped; not posted to GitHub). */
+  draftComments?: DraftComment[];
 }
+
+const COMMENT_UI_RESET = {
+  uiMode: "navigate" as UiMode,
+  lineSelection: null as LineSelection | null,
+  composerOpen: false,
+  selectableLines: [] as SelectableLine[],
+};
 
 interface ReviewState {
   isOpen: boolean;
@@ -48,6 +65,14 @@ interface ReviewState {
   /** Unified vs side-by-side code view (UI preference, not session data). */
   diffViewMode: DiffViewMode;
 
+  /** navigate = unit walkthrough; comment = line selection for drafts. */
+  uiMode: UiMode;
+  /** Flat selectable lines for the current unit (set when entering comment mode). */
+  selectableLines: SelectableLine[];
+  lineSelection: LineSelection | null;
+  composerOpen: boolean;
+  draftComments: DraftComment[];
+
   open: () => void;
   close: () => void;
   startLoading: (sessionKey: string) => void;
@@ -61,6 +86,20 @@ interface ReviewState {
   goNext: () => void;
   goPrev: () => void;
   setDiffViewMode: (mode: DiffViewMode) => void;
+
+  enterCommentMode: (lines: SelectableLine[]) => void;
+  exitCommentMode: () => void;
+  /**
+   * Replace the selectable-line list (e.g. after split/unified toggle).
+   * Rematches anchor/focus by line id when possible; otherwise resets to the first line.
+   */
+  setSelectableLines: (lines: SelectableLine[]) => void;
+  moveLineCursor: (delta: number, extend: boolean) => void;
+  openComposer: () => void;
+  closeComposer: () => void;
+  saveDraftComment: (body: string, unitId?: string) => void;
+  updateDraftComment: (id: string, body: string) => void;
+  removeDraftComment: (id: string) => void;
 }
 
 /**
@@ -75,6 +114,17 @@ function storageKey(sessionKey: string): string {
   return `guidedReview.session.${sessionKey}`;
 }
 
+function newDraftId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `draft-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+function clearCommentUi(): typeof COMMENT_UI_RESET {
+  return { ...COMMENT_UI_RESET };
+}
+
 export const useReviewStore = create<ReviewState>((set, get) => ({
   isOpen: false,
   status: "idle",
@@ -86,9 +136,14 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   streamGeneration: 0,
   sessionKey: null,
   diffViewMode: DEFAULT_DIFF_VIEW_MODE,
+  uiMode: "navigate",
+  selectableLines: [],
+  lineSelection: null,
+  composerOpen: false,
+  draftComments: [],
 
   open: () => set({ isOpen: true }),
-  close: () => set({ isOpen: false }),
+  close: () => set({ isOpen: false, ...clearCommentUi() }),
 
   startLoading: (sessionKey) =>
     set((state) => ({
@@ -99,6 +154,8 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
       diff: null,
       sessionKey,
       streamGeneration: state.streamGeneration + 1,
+      draftComments: [],
+      ...clearCommentUi(),
     })),
 
   setPRContext: (prContext) => set({ prContext }),
@@ -142,20 +199,22 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   goToUnit: (index) => {
     const total = displayUnitCount(get().plan);
     if (index < 0 || index >= total) return;
-    set({ currentUnitIndex: index });
+    set({ currentUnitIndex: index, ...clearCommentUi() });
   },
 
   goNext: () => {
     const { currentUnitIndex, plan } = get();
     const total = displayUnitCount(plan);
     if (currentUnitIndex < total - 1) {
-      set({ currentUnitIndex: currentUnitIndex + 1 });
+      set({ currentUnitIndex: currentUnitIndex + 1, ...clearCommentUi() });
     }
   },
 
   goPrev: () => {
     const { currentUnitIndex } = get();
-    if (currentUnitIndex > 0) set({ currentUnitIndex: currentUnitIndex - 1 });
+    if (currentUnitIndex > 0) {
+      set({ currentUnitIndex: currentUnitIndex - 1, ...clearCommentUi() });
+    }
   },
 
   setDiffViewMode: (mode) => {
@@ -164,6 +223,152 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
     diffViewModeHydrated = true;
     set({ diffViewMode: mode });
     void setStoredDiffViewMode(mode);
+  },
+
+  enterCommentMode: (lines) => {
+    if (lines.length === 0) return;
+    set({
+      uiMode: "comment",
+      selectableLines: lines,
+      lineSelection: { anchorIndex: 0, focusIndex: 0 },
+      composerOpen: false,
+    });
+  },
+
+  exitCommentMode: () => set(clearCommentUi()),
+
+  setSelectableLines: (lines) => {
+    const { uiMode, lineSelection, selectableLines: prevLines } = get();
+    if (uiMode !== "comment") {
+      set({ selectableLines: lines });
+      return;
+    }
+    if (lines.length === 0) {
+      set(clearCommentUi());
+      return;
+    }
+
+    // Rematch by stable line id so split↔unified (or RIGHT-only) toggles
+    // keep the cursor on the same logical line when it still exists.
+    let nextSelection: LineSelection = { anchorIndex: 0, focusIndex: 0 };
+    let selectionPreserved = false;
+    if (lineSelection) {
+      const prevFocus = prevLines[lineSelection.focusIndex];
+      const prevAnchor = prevLines[lineSelection.anchorIndex];
+      const focusIdx = prevFocus
+        ? lines.findIndex((l) => l.id === prevFocus.id)
+        : -1;
+      const anchorIdx = prevAnchor
+        ? lines.findIndex((l) => l.id === prevAnchor.id)
+        : -1;
+      if (focusIdx >= 0) {
+        nextSelection = {
+          focusIndex: focusIdx,
+          anchorIndex: anchorIdx >= 0 ? anchorIdx : focusIdx,
+        };
+        selectionPreserved = true;
+      }
+    }
+
+    set({
+      selectableLines: lines,
+      lineSelection: nextSelection,
+      composerOpen: selectionPreserved ? get().composerOpen : false,
+    });
+  },
+
+  moveLineCursor: (delta, extend) => {
+    const { uiMode, lineSelection, selectableLines, composerOpen } = get();
+    if (uiMode !== "comment" || composerOpen || !lineSelection) return;
+    if (selectableLines.length === 0) return;
+
+    if (!extend) {
+      const next = lineSelection.focusIndex + delta;
+      if (next < 0 || next >= selectableLines.length) return;
+      set({
+        lineSelection: { anchorIndex: next, focusIndex: next },
+      });
+      return;
+    }
+
+    // Shift+arrow: jump to the next line that shares the anchor's file + side.
+    const anchor = selectableLines[lineSelection.anchorIndex];
+    if (!anchor) return;
+    let i = lineSelection.focusIndex + delta;
+    while (i >= 0 && i < selectableLines.length) {
+      const candidate = selectableLines[i];
+      if (
+        candidate.filePath === anchor.filePath &&
+        candidate.side === anchor.side
+      ) {
+        set({
+          lineSelection: {
+            anchorIndex: lineSelection.anchorIndex,
+            focusIndex: i,
+          },
+        });
+        return;
+      }
+      i += delta;
+    }
+  },
+
+  openComposer: () => {
+    const { uiMode, lineSelection, selectableLines } = get();
+    if (uiMode !== "comment" || !lineSelection) return;
+    if (linesInSelection(selectableLines, lineSelection).length === 0) return;
+    set({ composerOpen: true });
+  },
+
+  closeComposer: () => set({ composerOpen: false }),
+
+  saveDraftComment: (body, unitId) => {
+    const trimmed = body.trim();
+    if (!trimmed) return;
+
+    const { uiMode, lineSelection, selectableLines, draftComments } = get();
+    if (uiMode !== "comment" || !lineSelection) return;
+
+    const selected = linesInSelection(selectableLines, lineSelection);
+    if (selected.length === 0) return;
+
+    const first = selected[0];
+    const last = selected[selected.length - 1];
+    const startNum = displayLineNumber(first);
+    const endNum = displayLineNumber(last);
+    if (startNum === undefined || endNum === undefined) return;
+
+    const draft: DraftComment = {
+      id: newDraftId(),
+      filePath: first.filePath,
+      side: first.side,
+      startLine: Math.min(startNum, endNum),
+      endLine: Math.max(startNum, endNum),
+      lineIds: selected.map((l) => l.id),
+      body: trimmed,
+      unitId,
+    };
+
+    set({
+      draftComments: [...draftComments, draft],
+      composerOpen: false,
+    });
+  },
+
+  updateDraftComment: (id, body) => {
+    const trimmed = body.trim();
+    if (!trimmed) return;
+    set((state) => ({
+      draftComments: state.draftComments.map((d) =>
+        d.id === id ? { ...d, body: trimmed } : d,
+      ),
+    }));
+  },
+
+  removeDraftComment: (id) => {
+    set((state) => ({
+      draftComments: state.draftComments.filter((d) => d.id !== id),
+    }));
   },
 }));
 
@@ -210,10 +415,24 @@ export function resetDiffViewModeHydrationForTests(): void {
  * review flow.
  */
 export async function persistSession(): Promise<void> {
-  const { status, diff, plan, prContext, currentUnitIndex, sessionKey } = useReviewStore.getState();
+  const {
+    status,
+    diff,
+    plan,
+    prContext,
+    currentUnitIndex,
+    sessionKey,
+    draftComments,
+  } = useReviewStore.getState();
   if (status !== "ready" || !diff || !plan || !sessionKey) return;
 
-  const payload: PersistedSession = { diff, plan, prContext, currentUnitIndex };
+  const payload: PersistedSession = {
+    diff,
+    plan,
+    prContext,
+    currentUnitIndex,
+    draftComments,
+  };
   try {
     await chrome.storage.session.set({ [storageKey(sessionKey)]: payload });
   } catch (error) {
@@ -248,6 +467,8 @@ export async function restoreSession(sessionKey: string): Promise<boolean> {
     currentUnitIndex,
     sessionKey,
     error: null,
+    draftComments: saved.draftComments ?? [],
+    ...clearCommentUi(),
   });
   return true;
 }

--- a/src/content/overlay/styles/overlay.css
+++ b/src/content/overlay/styles/overlay.css
@@ -7,6 +7,14 @@
  * not clobber Tailwind design tokens (unlayered rules beat @layer theme).
  * Host reset is pure CSS in this file (not SCSS): Sass was dropping nested
  * @layer contents when the reset lived only in a partial.
+ *
+ * Tailwind v4 border/outline/ring/shadow utilities resolve style via CSS
+ * variables whose defaults come from `@property { initial-value }`. Browsers
+ * ignore `@property` when the rule lives only in a Shadow DOM stylesheet
+ * (tailwindlabs/tailwindcss#15005, #16025), so e.g. `--tw-border-style` is
+ * undefined and `border-style: var(--tw-border-style)` computes to `none` —
+ * 1px borders never paint. Mirror Tailwind's pre-@property `@layer properties`
+ * fallback on every element so those utilities work inside the overlay host.
  */
 @layer reset, theme, base, components, utilities;
 
@@ -19,6 +27,19 @@
   *::before,
   *::after {
     box-sizing: border-box;
+    --tw-border-style: solid;
+    --tw-outline-style: solid;
+    --tw-space-y-reverse: 0;
+    --tw-shadow: 0 0 #0000;
+    --tw-shadow-alpha: 100%;
+    --tw-inset-shadow: 0 0 #0000;
+    --tw-inset-shadow-alpha: 100%;
+    --tw-ring-shadow: 0 0 #0000;
+    --tw-inset-ring-shadow: 0 0 #0000;
+    --tw-ring-offset-width: 0px;
+    --tw-ring-offset-color: #fff;
+    --tw-ring-offset-shadow: 0 0 #0000;
+    --tw-drop-shadow-alpha: 100%;
   }
 }
 

--- a/src/content/overlay/viewModeChord.test.ts
+++ b/src/content/overlay/viewModeChord.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  recordViewChordKey,
+  VIEW_CHORD_WINDOW_MS,
+  type ViewChordPending,
+} from "./viewModeChord";
+
+describe("recordViewChordKey", () => {
+  it("arms on v and completes unified on u", () => {
+    const armed = recordViewChordKey(null, "v", 1000);
+    expect(armed).toEqual({
+      next: { armedAt: 1000 },
+      mode: null,
+      consumed: true,
+    });
+
+    const done = recordViewChordKey(armed.next, "u", 1100);
+    expect(done).toEqual({
+      next: null,
+      mode: "unified",
+      consumed: true,
+    });
+  });
+
+  it("completes split on s after v", () => {
+    let pending: ViewChordPending = null;
+    pending = recordViewChordKey(pending, "v", 1000).next;
+    const done = recordViewChordKey(pending, "s", 1500);
+    expect(done).toEqual({ next: null, mode: "split", consumed: true });
+  });
+
+  it("is case-insensitive", () => {
+    const armed = recordViewChordKey(null, "V", 1000);
+    expect(armed.consumed).toBe(true);
+    expect(recordViewChordKey(armed.next, "U", 1100).mode).toBe("unified");
+    expect(recordViewChordKey(armed.next, "S", 1100).mode).toBe("split");
+  });
+
+  it("re-arms when v is pressed again", () => {
+    let pending = recordViewChordKey(null, "v", 1000).next;
+    const rearm = recordViewChordKey(pending, "v", 1500);
+    expect(rearm).toEqual({
+      next: { armedAt: 1500 },
+      mode: null,
+      consumed: true,
+    });
+    expect(recordViewChordKey(rearm.next, "u", 1600).mode).toBe("unified");
+  });
+
+  it("does not complete after the window expires", () => {
+    const armed = recordViewChordKey(null, "v", 1000);
+    const late = recordViewChordKey(
+      armed.next,
+      "u",
+      1000 + VIEW_CHORD_WINDOW_MS + 1,
+    );
+    expect(late).toEqual({ next: null, mode: null, consumed: false });
+  });
+
+  it("clears pending and does not consume unrelated keys", () => {
+    const armed = recordViewChordKey(null, "v", 1000);
+    const other = recordViewChordKey(armed.next, "c", 1100);
+    expect(other).toEqual({ next: null, mode: null, consumed: false });
+
+    // Subsequent u without a fresh arm does nothing.
+    expect(recordViewChordKey(other.next, "u", 1200)).toEqual({
+      next: null,
+      mode: null,
+      consumed: false,
+    });
+  });
+
+  it("does not treat multi-character keys as v/u/s", () => {
+    expect(recordViewChordKey(null, "ArrowDown", 1000).consumed).toBe(false);
+    const armed = recordViewChordKey(null, "v", 1000);
+    expect(recordViewChordKey(armed.next, "Escape", 1100).consumed).toBe(false);
+  });
+});

--- a/src/content/overlay/viewModeChord.ts
+++ b/src/content/overlay/viewModeChord.ts
@@ -1,0 +1,45 @@
+import type { DiffViewMode } from "./diffViewMode";
+
+/** Max span (ms) from arming `v` to the second key (`u` / `s`). */
+export const VIEW_CHORD_WINDOW_MS = 1000;
+
+export type ViewChordPending = { armedAt: number } | null;
+
+export interface ViewChordResult {
+  next: ViewChordPending;
+  /** Non-null when the chord completed and a mode should be applied. */
+  mode: DiffViewMode | null;
+  /** True when this key was part of the chord (armed `v`, or completing `u`/`s`). */
+  consumed: boolean;
+}
+
+/**
+ * Two-key view-mode chord: `v` then `u` → unified, `v` then `s` → split.
+ * Caller must filter modifiers; this only interprets the key sequence.
+ */
+export function recordViewChordKey(
+  pending: ViewChordPending,
+  key: string,
+  now: number,
+  windowMs = VIEW_CHORD_WINDOW_MS,
+): ViewChordResult {
+  const k = key.length === 1 ? key.toLowerCase() : key;
+
+  if (k === "v") {
+    return { next: { armedAt: now }, mode: null, consumed: true };
+  }
+
+  const armed =
+    pending !== null && now - pending.armedAt <= windowMs ? pending : null;
+
+  if (armed) {
+    if (k === "u") {
+      return { next: null, mode: "unified", consumed: true };
+    }
+    if (k === "s") {
+      return { next: null, mode: "split", consumed: true };
+    }
+  }
+
+  return { next: null, mode: null, consumed: false };
+}

--- a/src/lib/github/prContext.test.ts
+++ b/src/lib/github/prContext.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { scrapePRContext } from "./prContext";
+import type { PRIdentity } from "./diffFetch";
+
+const pr: PRIdentity = { owner: "acme", repo: "app", number: 42 };
+
+function setBody(html: string, title = "Fix bug · Pull Request #42 · acme/app"): void {
+  document.title = title;
+  document.body.innerHTML = html;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  document.title = "";
+});
+
+describe("scrapePRContext branch refs", () => {
+  it("reads classic labeled base-ref / head-ref titles (open Files tab)", () => {
+    setBody(`
+      <span title="acme/app:main" class="commit-ref base-ref">
+        <a title="acme/app:main">main</a>
+      </span>
+      <span title="alice/app:feature-x" class="commit-ref head-ref">
+        <a title="alice/app:feature-x">feature-x</a>
+      </span>
+    `);
+
+    const ctx = scrapePRContext(pr);
+    expect(ctx.baseRef).toBe("main");
+    expect(ctx.headRef).toBe("feature-x");
+  });
+
+  it("reads base from unlabeled commit-ref title when base-ref class is missing (merged Files tab)", () => {
+    // After merge GitHub drops the `base-ref` class (retargeting disabled) but
+    // keeps the title attribute. Head still has `head-ref`.
+    setBody(`
+      <span title="acme/app:main" class="commit-ref css-truncate user-select-contain expandable ">
+        <a title="acme/app:main" href="/acme/app/tree/main">main</a>
+      </span>
+      <span title="acme/app:feature-x" class="commit-ref css-truncate user-select-contain expandable head-ref">
+        <a title="acme/app:feature-x" href="/acme/app/tree/feature-x">feature-x</a>
+      </span>
+    `);
+
+    const ctx = scrapePRContext(pr);
+    expect(ctx.baseRef).toBe("main");
+    expect(ctx.headRef).toBe("feature-x");
+  });
+
+  it("reads nested base-ref text from the merge timeline (merged Conversation)", () => {
+    setBody(`
+      <span class="commit-ref user-select-contain">
+        <span class="base-ref">
+          <span class="css-truncate-target">main</span>
+        </span>
+      </span>
+    `);
+
+    const ctx = scrapePRContext(pr);
+    expect(ctx.baseRef).toBe("main");
+    expect(ctx.headRef).toBe("");
+  });
+
+  it("reads React Conversation BranchName chips (into base, from head)", () => {
+    setBody(`
+      <span>wants to merge 1 commit into</span>
+      <a href="/acme/app/tree/main" data-component="BranchName">acme:main</a>
+      <span>from</span>
+      <a href="/alice/app/tree/feature-x" data-component="BranchName">alice:feature-x</a>
+      <!-- duplicate chips elsewhere on the page should not change the pair -->
+      <a href="/acme/app/tree/main" data-component="BranchName">acme:main</a>
+      <a href="/alice/app/tree/feature-x" data-component="BranchName">alice:feature-x</a>
+    `);
+
+    const ctx = scrapePRContext(pr);
+    expect(ctx.baseRef).toBe("main");
+    expect(ctx.headRef).toBe("feature-x");
+  });
+
+  it("returns empty strings when no branch markup is present", () => {
+    setBody(`<h1 class="gh-header-title"><bdi class="js-issue-title">Fix bug</bdi></h1>`);
+
+    const ctx = scrapePRContext(pr);
+    expect(ctx.baseRef).toBe("");
+    expect(ctx.headRef).toBe("");
+    expect(ctx.title).toBe("Fix bug");
+  });
+
+  it("prefers labeled base-ref over a later unlabeled commit-ref title", () => {
+    setBody(`
+      <span title="acme/app:develop" class="commit-ref base-ref">develop</span>
+      <span title="acme/app:main" class="commit-ref">main</span>
+      <span title="acme/app:feature-x" class="commit-ref head-ref">feature-x</span>
+    `);
+
+    const ctx = scrapePRContext(pr);
+    expect(ctx.baseRef).toBe("develop");
+    expect(ctx.headRef).toBe("feature-x");
+  });
+});

--- a/src/lib/github/prContext.ts
+++ b/src/lib/github/prContext.ts
@@ -43,13 +43,7 @@ export function scrapePRContext(pr: PRIdentity): PRContext {
     'a[data-hovercard-type="user"].author',
   ]);
 
-  const baseRef =
-    firstAttr(['.commit-ref.base-ref[title]', '.base-ref[title]'], "title") ||
-    firstText([".commit-ref.base-ref", ".base-ref"]);
-
-  const headRef =
-    firstAttr(['.commit-ref.head-ref[title]', '.head-ref[title]'], "title") ||
-    firstText([".commit-ref.head-ref", ".head-ref"]);
+  const { baseRef, headRef } = scrapeBranchRefs(document);
 
   // Prefer a scraped title; fall back to document.title only when it looks like
   // a real PR title (GitHub's pattern is "Title · Pull Request #N · owner/repo").
@@ -65,9 +59,110 @@ export function scrapePRContext(pr: PRIdentity): PRContext {
     description: description ?? "",
     descriptionHtml: descriptionHtml ?? "",
     author: author ?? "",
+    baseRef,
+    headRef,
+  };
+}
+
+/**
+ * Resolve base/head branch names from GitHub's PR header DOM. GitHub uses
+ * several layouts depending on open vs merged and Conversation vs Files:
+ *
+ * 1. Classic labeled `.commit-ref.base-ref` / `.head-ref` (open Files tab)
+ * 2. Unlabeled `.commit-ref[title]` for base after merge (merged Files tab
+ *    drops the `base-ref` class because retargeting is disabled)
+ * 3. React Conversation chips: `a[data-component="BranchName"]` in
+ *    into-base / from-head order
+ *
+ * Each strategy only fills gaps left by earlier ones; missing refs stay "".
+ */
+function scrapeBranchRefs(root: ParentNode): { baseRef: string; headRef: string } {
+  let baseRef =
+    firstAttrIn(root, [".commit-ref.base-ref[title]", ".base-ref[title]"], "title") ||
+    firstTextIn(root, [".commit-ref.base-ref", ".base-ref"]);
+
+  let headRef =
+    firstAttrIn(root, [".commit-ref.head-ref[title]", ".head-ref[title]"], "title") ||
+    firstTextIn(root, [".commit-ref.head-ref", ".head-ref"]);
+
+  if (!baseRef || !headRef) {
+    const fromTitles = branchRefsFromCommitRefTitles(root);
+    baseRef = baseRef || fromTitles.baseRef;
+    headRef = headRef || fromTitles.headRef;
+  }
+
+  if (!baseRef || !headRef) {
+    const fromChips = branchRefsFromBranchNameChips(root);
+    baseRef = baseRef || fromChips.baseRef;
+    headRef = headRef || fromChips.headRef;
+  }
+
+  return {
     baseRef: normalizeRef(baseRef) ?? "",
     headRef: normalizeRef(headRef) ?? "",
   };
+}
+
+/**
+ * On merged PRs' Files tab, the base branch is still a `.commit-ref` with a
+ * `title="owner/repo:branch"` attribute, but without the `base-ref` class.
+ * Head usually still has `.head-ref`. Collect titled commit-refs and assign
+ * by class when present, otherwise treat the non-head one as base.
+ */
+function branchRefsFromCommitRefTitles(root: ParentNode): {
+  baseRef?: string;
+  headRef?: string;
+} {
+  const entries: { title: string; isBase: boolean; isHead: boolean }[] = [];
+  for (const el of root.querySelectorAll(".commit-ref[title]")) {
+    const title = el.getAttribute("title")?.trim();
+    if (!title) continue;
+    entries.push({
+      title,
+      isBase: el.classList.contains("base-ref"),
+      isHead: el.classList.contains("head-ref"),
+    });
+  }
+  if (entries.length === 0) return {};
+
+  const labeledBase = entries.find((e) => e.isBase)?.title;
+  const labeledHead = entries.find((e) => e.isHead)?.title;
+  const unlabeled = entries.filter((e) => !e.isBase && !e.isHead);
+
+  let baseRef = labeledBase;
+  let headRef = labeledHead;
+
+  // Merged Files: base lost its class but head kept `head-ref`.
+  if (!baseRef) {
+    baseRef = unlabeled[0]?.title;
+  }
+  if (!headRef) {
+    headRef =
+      unlabeled.find((e) => e.title !== baseRef)?.title ??
+      entries.find((e) => e.title !== baseRef)?.title;
+  }
+
+  return { baseRef, headRef };
+}
+
+/**
+ * New Conversation-tab header renders "into &lt;base&gt; from &lt;head&gt;" as
+ * Primer BranchName links. Take the first two unique chip texts.
+ */
+function branchRefsFromBranchNameChips(root: ParentNode): {
+  baseRef?: string;
+  headRef?: string;
+} {
+  const texts: string[] = [];
+  for (const el of root.querySelectorAll('a[data-component="BranchName"]')) {
+    const text = el.textContent?.trim();
+    if (!text) continue;
+    if (texts.includes(text)) continue;
+    texts.push(text);
+    if (texts.length >= 2) break;
+  }
+  if (texts.length === 0) return {};
+  return { baseRef: texts[0], headRef: texts[1] };
 }
 
 /**
@@ -82,8 +177,12 @@ function prTitleFromDocumentTitle(docTitle: string): string | undefined {
 }
 
 function firstText(selectors: string[]): string | undefined {
+  return firstTextIn(document, selectors);
+}
+
+function firstTextIn(root: ParentNode, selectors: string[]): string | undefined {
   for (const selector of selectors) {
-    const el = document.querySelector(selector);
+    const el = root.querySelector(selector);
     const text = el?.textContent?.trim();
     if (text) return text;
   }
@@ -145,9 +244,13 @@ export async function fetchConversationDescription(
   return { text: el.textContent?.trim() ?? "", html: DOMPurify.sanitize(el.innerHTML) };
 }
 
-function firstAttr(selectors: string[], attr: string): string | undefined {
+function firstAttrIn(
+  root: ParentNode,
+  selectors: string[],
+  attr: string
+): string | undefined {
   for (const selector of selectors) {
-    const el = document.querySelector(selector);
+    const el = root.querySelector(selector);
     const value = el?.getAttribute(attr)?.trim();
     if (value) return value;
   }

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -184,6 +184,7 @@ export function Options() {
           type="button"
           className={cn(
             "inline-flex cursor-pointer items-center gap-2 rounded-md border border-opt-accent bg-opt-accent px-4 py-2 text-[13px] font-semibold text-opt-accent-on",
+            "enabled:hover:border-opt-accent-hover enabled:hover:bg-opt-accent-hover",
             "disabled:cursor-default disabled:opacity-60",
           )}
           onClick={onSave}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -11,12 +11,13 @@
   --color-gr-bg: #110e0b;
   --color-gr-canvas: #16120f;
   --color-gr-subtle: #1c1814;
-  --color-gr-border: #2a2420;
-  --color-gr-border-muted: #211c18;
+  --color-gr-border: #3a342e;
+  --color-gr-border-muted: #2a2420;
   --color-gr-text: #fefefe;
   --color-gr-muted: #8b949e;
   --color-gr-faint: #6e7781;
   --color-gr-accent: #caff57;
+  --color-gr-accent-hover: #b6e64e;
   --color-gr-accent-on: #0d0806;
   --color-gr-accent-subtle: #1a2408;
   --color-gr-danger: #ff7b72;
@@ -46,6 +47,7 @@
   --color-opt-text: var(--opt-text);
   --color-opt-muted: var(--opt-muted);
   --color-opt-accent: var(--opt-accent);
+  --color-opt-accent-hover: var(--opt-accent-hover);
   --color-opt-accent-on: var(--opt-accent-on);
   --color-opt-ok: var(--opt-ok);
   --color-opt-error: var(--opt-error);
@@ -84,6 +86,7 @@
   --opt-text: #0d0806;
   --opt-muted: #59636e;
   --opt-accent: #caff57;
+  --opt-accent-hover: #b6e64e;
   --opt-accent-on: #0d0806;
   --opt-ok: #1a7f37;
   --opt-error: #cf222e;
@@ -93,10 +96,11 @@
   :root {
     --opt-bg: #0d0806;
     --opt-subtle: #16120f;
-    --opt-border: #2a2420;
+    --opt-border: #3a342e;
     --opt-text: #fefefe;
     --opt-muted: #8b949e;
     --opt-accent: #caff57;
+    --opt-accent-hover: #b6e64e;
     --opt-accent-on: #0d0806;
     --opt-ok: #3fb950;
     --opt-error: #ff7b72;


### PR DESCRIPTION
## Summary
- Add keyboard-driven line selection, draft comments, and a comment composer in the guided review overlay.
- Add a GitHub-style submit review modal (Comment / Approve / Request Changes) so reviewers can assemble a review from the overlay.
- Fix keyboard shortcut display on review actions for clearer shortcut affordances.

Draft comments and the submit modal are UI/local state for now; posting to the GitHub review API is left for a follow-up.

## Test plan
- [ ] Load the built extension on a real GitHub PR and start a guided review
- [ ] Select lines in the diff pane, compose a draft comment, and verify it appears on the correct range
- [ ] Open submit review, choose event type, write a summary, and confirm the flow completes in the UI
- [ ] Verify keyboard shortcuts match the displayed chords (including platform-specific modifiers)
- [ ] Run `npm test` and `npm run build`