### PR TITLE
Improve LLM/provider error handling

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -6,6 +6,7 @@ import type {
   FetchDiffError,
   FetchDiffRequest,
   FetchDiffResponse,
+  ReviewErrorInfo,
   ReviewPlan,
   ReviewUnit,
   TestConnectionRequest,
@@ -36,7 +37,7 @@ chrome.runtime.onMessage.addListener((message: BackgroundRequest, _sender, sendR
     handleTestConnection(message)
       .then(sendResponse)
       .catch((error: unknown) => {
-        const response: TestConnectionResponse = { ok: false, error: describeError(error) };
+        const response: TestConnectionResponse = { ok: false, error: describeErrorMessage(error) };
         sendResponse(response);
       });
     return true;
@@ -46,7 +47,7 @@ chrome.runtime.onMessage.addListener((message: BackgroundRequest, _sender, sendR
     handleFetchDiff(message)
       .then(sendResponse)
       .catch((error: unknown) => {
-        const response: FetchDiffError = { ok: false, error: describeError(error) };
+        const response: FetchDiffError = { ok: false, error: describeErrorMessage(error) };
         sendResponse(response);
       });
     return true;
@@ -91,7 +92,9 @@ async function handleAnnotateReviewStream(
   if (!settings.apiKey) {
     postEvent(port, {
       type: "ERROR",
-      error: "No API key configured. Open the extension settings to add one.",
+      error: {
+        message: "No API key configured. Open the extension settings to add one.",
+      },
     });
     return;
   }
@@ -183,11 +186,22 @@ async function handleFetchDiff(request: FetchDiffRequest): Promise<FetchDiffResp
   return { ok: true, diff };
 }
 
-function describeError(error: unknown): string {
-  if (error instanceof ProviderError) return error.message;
-  if (error instanceof DOMException && error.name === "AbortError") {
-    return "Review annotation was cancelled.";
+function describeError(error: unknown): ReviewErrorInfo {
+  if (error instanceof ProviderError) {
+    return {
+      message: error.message,
+      ...(error.statusCode !== undefined ? { statusCode: error.statusCode } : {}),
+      ...(error.code !== undefined ? { code: error.code } : {}),
+    };
   }
-  if (error instanceof Error) return error.message;
-  return "Something went wrong talking to the AI provider.";
+  if (error instanceof DOMException && error.name === "AbortError") {
+    return { message: "Review annotation was cancelled." };
+  }
+  if (error instanceof Error) return { message: error.message };
+  return { message: "Something went wrong talking to the AI provider." };
+}
+
+/** Flatten structured errors for one-shot message responses that still use a string. */
+function describeErrorMessage(error: unknown): string {
+  return describeError(error).message;
 }

--- a/src/background/providers/anthropic.ts
+++ b/src/background/providers/anthropic.ts
@@ -1,7 +1,7 @@
 import type { ProviderSettings } from "../../lib/types";
 import { buildUserPrompt, SYSTEM_PROMPT } from "../../lib/review/buildPrompt";
 import { REVIEW_PLAN_JSON_SCHEMA } from "../../lib/review/reviewSchema";
-import { isAbortError, safeErrorDetail } from "./http";
+import { isAbortError, parseProviderHttpError } from "./http";
 import { readSseJsonStream } from "./sse";
 import type { AnnotateReviewInput, AnnotateStreamEvent, ProviderClient } from "./types";
 import { ProviderError } from "./types";
@@ -54,8 +54,11 @@ export const anthropicProvider: ProviderClient = {
     }
 
     if (!response.ok) {
-      const detail = await safeErrorDetail(response);
-      throw new ProviderError(`Claude API error (${response.status}): ${detail}`);
+      const detail = await parseProviderHttpError(response);
+      throw new ProviderError(detail.message, {
+        statusCode: response.status,
+        code: detail.code,
+      });
     }
 
     if (!response.body) {
@@ -69,11 +72,13 @@ export const anthropicProvider: ProviderClient = {
       const ev = event as {
         type?: string;
         delta?: { type?: string; text?: string; stop_reason?: string };
-        error?: { message?: string };
+        error?: { message?: string; type?: string };
       };
 
       if (ev.type === "error") {
-        throw new ProviderError(ev.error?.message ?? "Claude stream error.");
+        throw new ProviderError(ev.error?.message ?? "Claude stream error.", {
+          code: ev.error?.type,
+        });
       }
 
       if (ev.type === "content_block_delta" && ev.delta?.type === "text_delta" && ev.delta.text) {
@@ -110,8 +115,11 @@ export const anthropicProvider: ProviderClient = {
     });
 
     if (!response.ok) {
-      const detail = await safeErrorDetail(response);
-      throw new ProviderError(`Claude API error (${response.status}): ${detail}`);
+      const detail = await parseProviderHttpError(response);
+      throw new ProviderError(detail.message, {
+        statusCode: response.status,
+        code: detail.code,
+      });
     }
   },
 };

--- a/src/background/providers/http.test.ts
+++ b/src/background/providers/http.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { parseProviderHttpError } from "./http";
+
+function jsonResponse(status: number, body: unknown, statusText = "Error"): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    statusText,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("parseProviderHttpError", () => {
+  it("parses OpenAI-compatible error bodies", async () => {
+    const detail = await parseProviderHttpError(
+      jsonResponse(401, {
+        error: {
+          message: "Incorrect API key provided",
+          type: "invalid_request_error",
+          code: "invalid_api_key",
+        },
+      }),
+    );
+    expect(detail).toEqual({
+      message: "Incorrect API key provided",
+      code: "invalid_api_key",
+    });
+  });
+
+  it("falls back to error.type when code is missing (Anthropic-style)", async () => {
+    const detail = await parseProviderHttpError(
+      jsonResponse(401, {
+        type: "error",
+        error: {
+          type: "authentication_error",
+          message: "invalid x-api-key",
+        },
+      }),
+    );
+    expect(detail).toEqual({
+      message: "invalid x-api-key",
+      code: "authentication_error",
+    });
+  });
+
+  it("uses statusText when the body is not JSON", async () => {
+    const response = new Response("not json", {
+      status: 502,
+      statusText: "Bad Gateway",
+    });
+    const detail = await parseProviderHttpError(response);
+    expect(detail).toEqual({ message: "Bad Gateway" });
+  });
+
+  it("uses a status fallback when body and statusText are empty", async () => {
+    const response = new Response(null, { status: 500, statusText: "" });
+    const detail = await parseProviderHttpError(response);
+    expect(detail.message).toMatch(/500|HTTP/);
+  });
+});

--- a/src/background/providers/http.ts
+++ b/src/background/providers/http.ts
@@ -2,14 +2,55 @@
  * Shared fetch/error helpers for provider HTTP clients.
  */
 
-/** Extract a user-safe error message from a failed provider HTTP response. */
-export async function safeErrorDetail(response: Response): Promise<string> {
+export interface ProviderHttpErrorDetail {
+  /** Exact provider message when present; otherwise statusText or a fallback. */
+  message: string;
+  /** Provider error code/type when present (e.g. invalid_api_key, authentication_error). */
+  code?: string;
+}
+
+/**
+ * Extract a user-safe message and optional provider error code from a failed
+ * provider HTTP response. Supports OpenAI-compatible and Anthropic error shapes.
+ */
+export async function parseProviderHttpError(response: Response): Promise<ProviderHttpErrorDetail> {
   try {
-    const data = await response.json();
-    return data?.error?.message ?? response.statusText;
+    const data = (await response.json()) as unknown;
+    if (!data || typeof data !== "object") {
+      return { message: response.statusText || `HTTP ${response.status}` };
+    }
+
+    const root = data as Record<string, unknown>;
+    const nested =
+      root.error && typeof root.error === "object"
+        ? (root.error as Record<string, unknown>)
+        : null;
+
+    // OpenAI / Grok: { error: { message, code?, type? } }
+    // Anthropic:     { error: { type, message } } or { type: "error", error: { ... } }
+    const messageSource = nested ?? root;
+    const message =
+      typeof messageSource.message === "string" && messageSource.message.trim()
+        ? messageSource.message
+        : response.statusText || `HTTP ${response.status}`;
+
+    const code =
+      (typeof nested?.code === "string" && nested.code) ||
+      (typeof nested?.type === "string" && nested.type) ||
+      (typeof root.code === "string" && root.code) ||
+      (typeof root.type === "string" && root.type !== "error" ? root.type : undefined) ||
+      undefined;
+
+    return code ? { message, code } : { message };
   } catch {
-    return response.statusText;
+    return { message: response.statusText || `HTTP ${response.status}` };
   }
+}
+
+/** @deprecated Prefer parseProviderHttpError — kept for any residual callers. */
+export async function safeErrorDetail(response: Response): Promise<string> {
+  const detail = await parseProviderHttpError(response);
+  return detail.message;
 }
 
 export function isAbortError(error: unknown): boolean {

--- a/src/background/providers/openaiCompatible.ts
+++ b/src/background/providers/openaiCompatible.ts
@@ -1,7 +1,7 @@
 import type { ProviderSettings } from "../../lib/types";
 import { buildUserPrompt, SYSTEM_PROMPT } from "../../lib/review/buildPrompt";
 import { REVIEW_PLAN_JSON_SCHEMA } from "../../lib/review/reviewSchema";
-import { isAbortError, safeErrorDetail } from "./http";
+import { isAbortError, parseProviderHttpError } from "./http";
 import { readSseJsonStream } from "./sse";
 import type { AnnotateReviewInput, AnnotateStreamEvent, ProviderClient } from "./types";
 import { ProviderError } from "./types";
@@ -57,8 +57,11 @@ export function createOpenAICompatibleProvider(baseUrl: string, displayName: str
       }
 
       if (!response.ok) {
-        const detail = await safeErrorDetail(response);
-        throw new ProviderError(`${displayName} API error (${response.status}): ${detail}`);
+        const detail = await parseProviderHttpError(response);
+        throw new ProviderError(detail.message, {
+          statusCode: response.status,
+          code: detail.code,
+        });
       }
 
       if (!response.body) {
@@ -71,11 +74,13 @@ export function createOpenAICompatibleProvider(baseUrl: string, displayName: str
         if (!event || typeof event !== "object") continue;
         const data = event as {
           choices?: Array<{ delta?: { content?: string | null }; finish_reason?: string | null }>;
-          error?: { message?: string };
+          error?: { message?: string; code?: string; type?: string };
         };
 
         if (data.error?.message) {
-          throw new ProviderError(data.error.message);
+          throw new ProviderError(data.error.message, {
+            code: data.error.code ?? data.error.type,
+          });
         }
 
         const content = data.choices?.[0]?.delta?.content;
@@ -107,8 +112,11 @@ export function createOpenAICompatibleProvider(baseUrl: string, displayName: str
       });
 
       if (!response.ok) {
-        const detail = await safeErrorDetail(response);
-        throw new ProviderError(`${displayName} API error (${response.status}): ${detail}`);
+        const detail = await parseProviderHttpError(response);
+        throw new ProviderError(detail.message, {
+          statusCode: response.status,
+          code: detail.code,
+        });
       }
     },
   };

--- a/src/background/providers/types.ts
+++ b/src/background/providers/types.ts
@@ -24,5 +24,20 @@ export interface ProviderClient {
   testConnection(settings: ProviderSettings): Promise<void>;
 }
 
-/** Thrown for any provider-side failure; message is safe to show to the user. */
-export class ProviderError extends Error {}
+/**
+ * Thrown for any provider-side failure. `message` is safe to show to the user
+ * and should be the exact provider message when one was returned. Optional
+ * `statusCode` / `code` carry HTTP status and provider error codes.
+ */
+export class ProviderError extends Error {
+  readonly statusCode?: number;
+  /** Provider-specific code, e.g. `invalid_api_key` or `authentication_error`. */
+  readonly code?: string;
+
+  constructor(message: string, options?: { statusCode?: number; code?: string }) {
+    super(message);
+    this.name = "ProviderError";
+    this.statusCode = options?.statusCode;
+    this.code = options?.code;
+  }
+}

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -2,7 +2,7 @@ import { createRoot } from "react-dom/client";
 import { parsePRUrl, type PRIdentity } from "../lib/github/diffFetch";
 import { fetchConversationDescription, scrapePRContext } from "../lib/github/prContext";
 import { requestPRDiff, streamReviewPlan } from "../lib/messaging";
-import type { ContentRequest } from "../lib/types";
+import type { ContentRequest, ParsedDiff, PRContext } from "../lib/types";
 import { ensureFallbackHost, FALLBACK_HOST_ID, findButtonAnchor } from "./buttonAnchor";
 import { Overlay } from "./overlay/Overlay";
 import overlayStyles from "./overlay/styles/overlay.css?inline";
@@ -133,6 +133,40 @@ function cancelActiveStream(): void {
   }
 }
 
+function startAnnotationStream(
+  diff: ParsedDiff,
+  prContext: PRContext,
+  streamGeneration: number,
+): void {
+  const { cancel } = streamReviewPlan(diff, prContext, {
+    onUnit: (unit) => useReviewStore.getState().appendUnit(unit, streamGeneration),
+    onDone: (plan) => {
+      activeStreamCancel = null;
+      useReviewStore.getState().setReady(diff, plan, streamGeneration);
+    },
+    onError: (error) => {
+      activeStreamCancel = null;
+      useReviewStore.getState().setError(error, streamGeneration);
+    },
+  });
+  activeStreamCancel = cancel;
+}
+
+/**
+ * Retry after a failure. If the diff was already fetched, re-run only the LLM
+ * annotate call; otherwise restart the full review flow (diff fetch + annotate).
+ */
+function retryAnnotation(): void {
+  const { diff, prContext } = useReviewStore.getState();
+  if (diff && prContext) {
+    cancelActiveStream();
+    const generation = useReviewStore.getState().beginRetry();
+    startAnnotationStream(diff, prContext, generation);
+    return;
+  }
+  void onStartReview();
+}
+
 async function onStartReview(): Promise<void> {
   // Prefer the cached identity from button injection; re-parse the URL so a
   // toolbar-icon click still works if the button hasn't painted yet.
@@ -186,18 +220,7 @@ async function onStartReview(): Promise<void> {
     useReviewStore.getState().beginStreaming(streamGeneration);
 
     const latestContext = useReviewStore.getState().prContext ?? prContext;
-    const { cancel } = streamReviewPlan(diff, latestContext, {
-      onUnit: (unit) => useReviewStore.getState().appendUnit(unit, streamGeneration),
-      onDone: (plan) => {
-        activeStreamCancel = null;
-        useReviewStore.getState().setReady(diff, plan, streamGeneration);
-      },
-      onError: (error) => {
-        activeStreamCancel = null;
-        useReviewStore.getState().setError(error, streamGeneration);
-      },
-    });
-    activeStreamCancel = cancel;
+    startAnnotationStream(diff, latestContext, streamGeneration);
   } catch (error) {
     const message = error instanceof Error ? error.message : "Failed to build the guided review.";
     useReviewStore.getState().setError(message, streamGeneration);
@@ -225,5 +248,7 @@ function ensureOverlayMounted(): void {
 
   // Overlay reads the active session key from the store, so SPA navigation to
   // another PR never leaves a stale prUrl prop from the first mount.
-  createRoot(appRoot).render(<Overlay onRequestClose={cancelActiveStream} />);
+  createRoot(appRoot).render(
+    <Overlay onRequestClose={cancelActiveStream} onRetry={retryAnnotation} />,
+  );
 }

--- a/src/content/overlay/Overlay.test.tsx
+++ b/src/content/overlay/Overlay.test.tsx
@@ -201,15 +201,25 @@ describe("Overlay", () => {
     useReviewStore.setState({
       isOpen: true,
       status: "error",
-      error: "Network error",
+      error: {
+        message: "Invalid API key",
+        statusCode: 401,
+        code: "authentication_error",
+      },
       prContext: prContextFixture(),
       currentUnitIndex: 0,
     });
-    render(<Overlay />);
+    const onRetry = vi.fn();
+    render(<Overlay onRetry={onRetry} />);
     expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
-    expect(screen.getByText("Network error")).toBeInTheDocument();
+    expect(screen.getByTestId("error-message")).toHaveTextContent("Invalid API key");
+    expect(screen.getByTestId("error-status-code")).toHaveTextContent("401");
+    expect(screen.getByTestId("error-code")).toHaveTextContent("authentication_error");
     expect(screen.getAllByText(PR_DESCRIPTION_UNIT_TITLE).length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("This PR adds a feature.")).toBeInTheDocument();
+
+    screen.getByRole("button", { name: /retry building the guided review/i }).click();
+    expect(onRetry).toHaveBeenCalledTimes(1);
   });
 
   it("still shows the PR description unit when the plan has no code units", () => {

--- a/src/content/overlay/Overlay.tsx
+++ b/src/content/overlay/Overlay.tsx
@@ -3,10 +3,7 @@ import { useReviewStore, persistSession } from "./store";
 import { resolveUnitFiles } from "./selectors";
 import { buildDisplayUnits, displayUnitCount } from "./displayUnits";
 import { buildSelectableLines } from "./buildSelectableLines";
-import {
-  recordViewChordKey,
-  type ViewChordPending,
-} from "./viewModeChord";
+import { recordViewChordKey, type ViewChordPending } from "./viewModeChord";
 import type { ReviewSubmission } from "./commentTypes";
 import { ProgressHeader } from "./components/ProgressHeader";
 import { Sidebar } from "./components/Sidebar";
@@ -19,6 +16,8 @@ import { SubmitReviewModal } from "./components/SubmitReviewModal";
 interface OverlayProps {
   /** Invoked when the user exits so any in-flight stream can be cancelled. */
   onRequestClose?: () => void;
+  /** Retry a failed annotate / review-build step. */
+  onRetry?: () => void;
 }
 
 /**
@@ -47,7 +46,7 @@ function editableTextValue(el: HTMLElement): string {
   return el.innerText ?? "";
 }
 
-export function Overlay({ onRequestClose }: OverlayProps) {
+export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
   const isOpen = useReviewStore((s) => s.isOpen);
   const status = useReviewStore((s) => s.status);
   const error = useReviewStore((s) => s.error);
@@ -111,11 +110,13 @@ export function Overlay({ onRequestClose }: OverlayProps) {
 
   const planStillBuilding = status === "loading" || status === "streaming";
   // Spinner on the description unit only while the plan is still being built.
-  const showBuildingSpinner = planStillBuilding && (!plan || currentUnitIndex === 0);
+  const showBuildingSpinner =
+    planStillBuilding && (!plan || currentUnitIndex === 0);
   const displayUnits = buildDisplayUnits(plan);
   const total = displayUnitCount(plan);
   const currentDisplay = displayUnits[currentUnitIndex] ?? displayUnits[0];
-  const isDescriptionUnit = !currentDisplay || currentDisplay.kind === "pr_description";
+  const isDescriptionUnit =
+    !currentDisplay || currentDisplay.kind === "pr_description";
   const currentReviewUnit =
     currentDisplay?.kind === "review" ? currentDisplay.unit : null;
 
@@ -290,13 +291,19 @@ export function Overlay({ onRequestClose }: OverlayProps) {
           return;
         case "ArrowUp":
           event.preventDefault();
-          viewChordRef.current = null;
-          codeColRef.current?.scrollBy({ top: -SCROLL_STEP, behavior: "smooth" });
+          event.stopPropagation();
+          codeColRef.current?.scrollBy({
+            top: -SCROLL_STEP,
+            behavior: "smooth",
+          });
           return;
         case "ArrowDown":
           event.preventDefault();
-          viewChordRef.current = null;
-          codeColRef.current?.scrollBy({ top: SCROLL_STEP, behavior: "smooth" });
+          event.stopPropagation();
+          codeColRef.current?.scrollBy({
+            top: SCROLL_STEP,
+            behavior: "smooth",
+          });
           return;
         case "c":
         case "C":
@@ -314,14 +321,33 @@ export function Overlay({ onRequestClose }: OverlayProps) {
 
     window.addEventListener("keydown", onKeyDown, true);
     return () => window.removeEventListener("keydown", onKeyDown, true);
-  }, [isOpen, onRequestClose, selectableForUnit, currentUnitId, submitReviewOpen]);
+  }, [
+    isOpen,
+    onRequestClose,
+    selectableForUnit,
+    currentUnitId,
+    submitReviewOpen,
+  ]);
 
   if (!isOpen) return null;
 
+  const planStillBuilding = status === "loading" || status === "streaming";
+  // Spinner on the description unit only while the plan is still being built.
+  const showBuildingSpinner =
+    planStillBuilding && (!plan || currentUnitIndex === 0);
+  const displayUnits = buildDisplayUnits(plan);
+  const total = displayUnitCount(plan);
+  const totalKnown = status === "ready";
+  const currentDisplay = displayUnits[currentUnitIndex] ?? displayUnits[0];
+  const isDescriptionUnit =
+    !currentDisplay || currentDisplay.kind === "pr_description";
+  const currentReviewUnit =
+    currentDisplay?.kind === "review" ? currentDisplay.unit : null;
+  const resolvedFiles =
+    currentReviewUnit && diff ? resolveUnitFiles(currentReviewUnit, diff) : [];
+
   return (
-    <div
-      className="fixed inset-0 z-[2147483000] flex flex-col bg-gr-bg font-sans text-sm text-gr-text antialiased [color-scheme:dark] [text-rendering:optimizeLegibility]"
-    >
+    <div className="fixed inset-0 z-[2147483000] flex flex-col bg-gr-bg font-sans text-sm text-gr-text antialiased [color-scheme:dark] [text-rendering:optimizeLegibility]">
       <ProgressHeader
         prContext={prContext}
         diff={diff}
@@ -356,10 +382,12 @@ export function Overlay({ onRequestClose }: OverlayProps) {
               unit={currentReviewUnit}
               hasTitle={Boolean(prContext?.title?.trim())}
               hasDescription={Boolean(
-                prContext?.description?.trim() || prContext?.descriptionHtml?.trim()
+                prContext?.description?.trim() ||
+                prContext?.descriptionHtml?.trim(),
               )}
               error={status === "error" ? error : null}
               loading={showBuildingSpinner && isDescriptionUnit}
+              onRetry={status === "error" ? onRetry : undefined}
             />
           </div>
           <Sidebar

--- a/src/content/overlay/Overlay.tsx
+++ b/src/content/overlay/Overlay.tsx
@@ -331,21 +331,6 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
 
   if (!isOpen) return null;
 
-  const planStillBuilding = status === "loading" || status === "streaming";
-  // Spinner on the description unit only while the plan is still being built.
-  const showBuildingSpinner =
-    planStillBuilding && (!plan || currentUnitIndex === 0);
-  const displayUnits = buildDisplayUnits(plan);
-  const total = displayUnitCount(plan);
-  const totalKnown = status === "ready";
-  const currentDisplay = displayUnits[currentUnitIndex] ?? displayUnits[0];
-  const isDescriptionUnit =
-    !currentDisplay || currentDisplay.kind === "pr_description";
-  const currentReviewUnit =
-    currentDisplay?.kind === "review" ? currentDisplay.unit : null;
-  const resolvedFiles =
-    currentReviewUnit && diff ? resolveUnitFiles(currentReviewUnit, diff) : [];
-
   return (
     <div className="fixed inset-0 z-[2147483000] flex flex-col bg-gr-bg font-sans text-sm text-gr-text antialiased [color-scheme:dark] [text-rendering:optimizeLegibility]">
       <ProgressHeader

--- a/src/content/overlay/components/ContextPanel.test.tsx
+++ b/src/content/overlay/components/ContextPanel.test.tsx
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { missingMetadataHint } from "./ContextPanel";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ContextPanel, missingMetadataHint } from "./ContextPanel";
 
 describe("missingMetadataHint", () => {
   it("mentions both title and description when neither is present", () => {
@@ -18,5 +19,39 @@ describe("missingMetadataHint", () => {
     const hint = missingMetadataHint(false, true);
     expect(hint).toMatch(/title/i);
     expect(hint).toMatch(/AI/i);
+  });
+});
+
+describe("ContextPanel error state", () => {
+  it("renders status code, error code, message, and retry", () => {
+    const onRetry = vi.fn();
+    render(
+      <ContextPanel
+        unit={null}
+        error={{
+          message: "Rate limit exceeded",
+          statusCode: 429,
+          code: "rate_limit_error",
+        }}
+        onRetry={onRetry}
+      />,
+    );
+
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+    expect(screen.getByTestId("error-status-code")).toHaveTextContent("429");
+    expect(screen.getByTestId("error-code")).toHaveTextContent("rate_limit_error");
+    expect(screen.getByTestId("error-message")).toHaveTextContent("Rate limit exceeded");
+
+    screen.getByRole("button", { name: /retry building the guided review/i }).click();
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits status/code rows when only a message is present", () => {
+    render(
+      <ContextPanel unit={null} error={{ message: "No API key configured." }} onRetry={vi.fn()} />,
+    );
+    expect(screen.queryByTestId("error-status-code")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("error-code")).not.toBeInTheDocument();
+    expect(screen.getByTestId("error-message")).toHaveTextContent("No API key configured.");
   });
 });

--- a/src/content/overlay/components/ContextPanel.tsx
+++ b/src/content/overlay/components/ContextPanel.tsx
@@ -1,4 +1,4 @@
-import type { ReviewUnit } from "../../../lib/types";
+import type { ReviewErrorInfo, ReviewUnit } from "../../../lib/types";
 import { KeyboardShortcuts } from "./KeyboardShortcuts";
 import { Spinner } from "./Spinner";
 import { missingMetadataHint, PR_DESCRIPTION_HINT } from "../missingMetadata";
@@ -12,8 +12,10 @@ interface ContextPanelProps {
   hasTitle?: boolean;
   /** Whether the PR has a non-empty description. Used when the description unit is active. */
   hasDescription?: boolean;
-  error?: string | null;
+  error?: ReviewErrorInfo | null;
   loading?: boolean;
+  /** Retry the failed API / review build step. */
+  onRetry?: () => void;
 }
 
 export function ContextPanel({
@@ -22,6 +24,7 @@ export function ContextPanel({
   hasDescription = true,
   error,
   loading,
+  onRetry,
 }: ContextPanelProps) {
   if (error) {
     return (
@@ -29,9 +32,44 @@ export function ContextPanel({
         <div className="mb-2 text-xs font-semibold tracking-[0.04em] text-gr-muted uppercase">
           Something went wrong
         </div>
+
+        {(error.statusCode !== undefined || error.code) && (
+          <dl className="mb-2 m-0 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-[12.5px] leading-normal">
+            {error.statusCode !== undefined && (
+              <>
+                <dt className="m-0 font-medium text-gr-muted">HTTP status</dt>
+                <dd className="m-0 font-mono text-gr-danger" data-testid="error-status-code">
+                  {error.statusCode}
+                </dd>
+              </>
+            )}
+            {error.code && (
+              <>
+                <dt className="m-0 font-medium text-gr-muted">Error code</dt>
+                <dd className="m-0 font-mono break-all text-gr-danger" data-testid="error-code">
+                  {error.code}
+                </dd>
+              </>
+            )}
+          </dl>
+        )}
+
         <pre className="m-0 max-h-[40vh] overflow-x-auto overflow-y-auto rounded-md border border-gr-danger bg-gr-danger-subtle p-3 text-left font-mono text-[12.5px] leading-normal break-words whitespace-pre-wrap text-gr-danger">
-          <code>{error}</code>
+          <code data-testid="error-message">{error.message}</code>
         </pre>
+
+        {onRetry && (
+          <div className="mt-3">
+            <button
+              type="button"
+              onClick={onRetry}
+              aria-label="Retry building the guided review"
+              className="inline-flex cursor-pointer items-center rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-[13px] font-medium text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover"
+            >
+              Retry
+            </button>
+          </div>
+        )}
       </div>
     );
   }

--- a/src/content/overlay/store.test.ts
+++ b/src/content/overlay/store.test.ts
@@ -104,7 +104,7 @@ describe("useReviewStore", () => {
   it("startLoading sets status to loading, stores sessionKey, clears plan/diff/error, and resets unit index", () => {
     resetStore();
     useReviewStore.setState({
-      error: "boom",
+      error: { message: "boom" },
       plan: planFixture(1),
       diff: diffFixture(),
       currentUnitIndex: 2,
@@ -194,11 +194,49 @@ describe("useReviewStore", () => {
     expect(useReviewStore.getState().currentUnitIndex).toBe(2);
   });
 
-  it("setError sets status to error with the message", () => {
+  it("setError sets status to error with a normalized message", () => {
     resetStore();
     useReviewStore.getState().setError("something broke");
     expect(useReviewStore.getState().status).toBe("error");
-    expect(useReviewStore.getState().error).toBe("something broke");
+    expect(useReviewStore.getState().error).toEqual({ message: "something broke" });
+  });
+
+  it("setError accepts structured ReviewErrorInfo", () => {
+    resetStore();
+    useReviewStore.getState().setError({
+      message: "Invalid API key",
+      statusCode: 401,
+      code: "authentication_error",
+    });
+    expect(useReviewStore.getState().error).toEqual({
+      message: "Invalid API key",
+      statusCode: 401,
+      code: "authentication_error",
+    });
+  });
+
+  it("beginRetry bumps generation, clears error/plan, keeps diff, and returns the new generation", () => {
+    resetStore();
+    useReviewStore.setState({
+      status: "error",
+      error: { message: "boom", statusCode: 500 },
+      diff: diffFixture(),
+      plan: planFixture(2),
+      prContext: prContextFixture(),
+      streamGeneration: 3,
+      sessionKey: SESSION_KEY,
+    });
+
+    const generation = useReviewStore.getState().beginRetry();
+    const state = useReviewStore.getState();
+
+    expect(generation).toBe(4);
+    expect(state.streamGeneration).toBe(4);
+    expect(state.status).toBe("streaming");
+    expect(state.error).toBeNull();
+    expect(state.plan).toEqual({ units: [] });
+    expect(state.diff).toEqual(diffFixture());
+    expect(state.sessionKey).toBe(SESSION_KEY);
   });
 
   it("setPRContext stores the context", () => {

--- a/src/content/overlay/store.ts
+++ b/src/content/overlay/store.ts
@@ -1,5 +1,11 @@
 import { create } from "zustand";
-import type { ParsedDiff, PRContext, ReviewPlan, ReviewUnit } from "../../lib/types";
+import type {
+  ParsedDiff,
+  PRContext,
+  ReviewErrorInfo,
+  ReviewPlan,
+  ReviewUnit,
+} from "../../lib/types";
 import {
   displayLineNumber,
   linesInSelection,
@@ -43,10 +49,14 @@ const COMMENT_UI_RESET = {
   selectableLines: [] as SelectableLine[],
 };
 
+function normalizeError(error: ReviewErrorInfo | string): ReviewErrorInfo {
+  return typeof error === "string" ? { message: error } : error;
+}
+
 interface ReviewState {
   isOpen: boolean;
   status: ReviewStatus;
-  error: string | null;
+  error: ReviewErrorInfo | null;
   diff: ParsedDiff | null;
   plan: ReviewPlan | null;
   prContext: PRContext | null;
@@ -79,9 +89,14 @@ interface ReviewState {
   setPRContext: (prContext: PRContext) => void;
   setDiff: (diff: ParsedDiff) => void;
   beginStreaming: (generation: number) => void;
+  /**
+   * Start a retry of the annotation stream without clearing the already-fetched
+   * diff. Bumps streamGeneration and returns the new generation.
+   */
+  beginRetry: () => number;
   appendUnit: (unit: ReviewUnit, generation: number) => void;
   setReady: (diff: ParsedDiff, plan: ReviewPlan, generation?: number) => void;
-  setError: (message: string, generation?: number) => void;
+  setError: (error: ReviewErrorInfo | string, generation?: number) => void;
   goToUnit: (index: number) => void;
   goNext: () => void;
   goPrev: () => void;
@@ -115,7 +130,10 @@ function storageKey(sessionKey: string): string {
 }
 
 function newDraftId(): string {
-  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
     return crypto.randomUUID();
   }
   return `draft-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
@@ -167,6 +185,19 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
     set({ status: "streaming", plan: { units: [] }, error: null });
   },
 
+  beginRetry: () => {
+    const nextGeneration = get().streamGeneration + 1;
+    const hasDiff = get().diff !== null;
+    set({
+      streamGeneration: nextGeneration,
+      status: hasDiff ? "streaming" : "loading",
+      error: null,
+      plan: hasDiff ? { units: [] } : null,
+      ...clearCommentUi(),
+    });
+    return nextGeneration;
+  },
+
   appendUnit: (unit, generation) => {
     if (get().streamGeneration !== generation) return;
     set((state) => {
@@ -183,17 +214,25 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   },
 
   setReady: (diff, plan, generation) => {
-    if (generation !== undefined && get().streamGeneration !== generation) return;
+    if (generation !== undefined && get().streamGeneration !== generation)
+      return;
     set((state) => {
       const total = displayUnitCount(plan);
       const index = Math.min(Math.max(state.currentUnitIndex, 0), total - 1);
-      return { status: "ready", diff, plan, currentUnitIndex: index, error: null };
+      return {
+        status: "ready",
+        diff,
+        plan,
+        currentUnitIndex: index,
+        error: null,
+      };
     });
   },
 
-  setError: (message, generation) => {
-    if (generation !== undefined && get().streamGeneration !== generation) return;
-    set({ status: "error", error: message });
+  setError: (error, generation) => {
+    if (generation !== undefined && get().streamGeneration !== generation)
+      return;
+    set({ status: "error", error: normalizeError(error) });
   },
 
   goToUnit: (index) => {
@@ -415,15 +454,8 @@ export function resetDiffViewModeHydrationForTests(): void {
  * review flow.
  */
 export async function persistSession(): Promise<void> {
-  const {
-    status,
-    diff,
-    plan,
-    prContext,
-    currentUnitIndex,
-    sessionKey,
-    draftComments,
-  } = useReviewStore.getState();
+  const { status, diff, plan, prContext, currentUnitIndex, sessionKey } =
+    useReviewStore.getState();
   if (status !== "ready" || !diff || !plan || !sessionKey) return;
 
   const payload: PersistedSession = {
@@ -457,7 +489,10 @@ export async function restoreSession(sessionKey: string): Promise<boolean> {
   if (!saved) return false;
 
   const total = displayUnitCount(saved.plan);
-  const currentUnitIndex = Math.min(Math.max(saved.currentUnitIndex, 0), total - 1);
+  const currentUnitIndex = Math.min(
+    Math.max(saved.currentUnitIndex, 0),
+    total - 1,
+  );
 
   useReviewStore.setState({
     status: "ready",

--- a/src/content/overlay/store.ts
+++ b/src/content/overlay/store.ts
@@ -454,8 +454,15 @@ export function resetDiffViewModeHydrationForTests(): void {
  * review flow.
  */
 export async function persistSession(): Promise<void> {
-  const { status, diff, plan, prContext, currentUnitIndex, sessionKey } =
-    useReviewStore.getState();
+  const {
+    status,
+    diff,
+    plan,
+    prContext,
+    currentUnitIndex,
+    sessionKey,
+    draftComments,
+  } = useReviewStore.getState();
   if (status !== "ready" || !diff || !plan || !sessionKey) return;
 
   const payload: PersistedSession = {

--- a/src/lib/messaging.test.ts
+++ b/src/lib/messaging.test.ts
@@ -67,9 +67,14 @@ describe("messaging", () => {
     streamReviewPlan({ files: [] }, { title: "t" } as PRContext, { onUnit, onDone, onError });
     const port = vi.mocked(chrome.runtime.connect).mock.results[0].value as MockPort;
 
-    port.__emitMessage({ type: "ERROR", error: "No API key configured." });
+    const error = {
+      message: "Invalid API key",
+      statusCode: 401,
+      code: "authentication_error",
+    };
+    port.__emitMessage({ type: "ERROR", error });
 
-    expect(onError).toHaveBeenCalledWith("No API key configured.");
+    expect(onError).toHaveBeenCalledWith(error);
     expect(onDone).not.toHaveBeenCalled();
   });
 

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -9,6 +9,7 @@ import type {
   ParsedDiff,
   PRContext,
   ProviderSettings,
+  ReviewErrorInfo,
   ReviewPlan,
   ReviewUnit,
 } from "./types";
@@ -18,7 +19,7 @@ const ANNOTATE_PORT_NAME = "annotate-review";
 export interface StreamReviewPlanHandlers {
   onUnit: (unit: ReviewUnit) => void;
   onDone: (plan: ReviewPlan) => void;
-  onError: (error: string) => void;
+  onError: (error: ReviewErrorInfo) => void;
 }
 
 /**
@@ -73,7 +74,9 @@ export function streamReviewPlan(
     // If the background dies or the port drops without DONE/ERROR, surface it.
     finish(() => {
       const err = chrome.runtime.lastError?.message;
-      handlers.onError(err ?? "Lost connection to the review worker before the plan finished.");
+      handlers.onError({
+        message: err ?? "Lost connection to the review worker before the plan finished.",
+      });
     });
   });
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -107,14 +107,25 @@ export interface AnnotateReviewRequest {
 }
 
 /**
+ * User-facing details for a failed review annotation (or related) step.
+ * `message` is always present; HTTP status / provider codes are optional.
+ */
+export interface ReviewErrorInfo {
+  message: string;
+  statusCode?: number;
+  /** Provider-specific code, e.g. `invalid_api_key` or `authentication_error`. */
+  code?: string;
+}
+
+/**
  * Progressive events on the `annotate-review` port from background → content.
  * Complete, validated units are pushed as they become available; DONE carries
- * the final merged plan; ERROR ends the stream with a user-safe message.
+ * the final merged plan; ERROR ends the stream with structured error details.
  */
 export type AnnotateReviewStreamEvent =
   | { type: "UNIT"; unit: ReviewUnit }
   | { type: "DONE"; plan: ReviewPlan }
-  | { type: "ERROR"; error: string };
+  | { type: "ERROR"; error: ReviewErrorInfo };
 
 export interface TestConnectionRequest {
   type: "TEST_CONNECTION";


### PR DESCRIPTION
## Summary
- Structure provider failures as `ProviderError` with optional `statusCode` and provider `code` (e.g. `invalid_api_key`, `authentication_error`), instead of a bare message string.
- Parse HTTP error bodies more carefully for OpenAI-compatible and Anthropic responses so the real provider message surfaces when available.
- Propagate structured `ReviewErrorInfo` over the annotate-review stream (`ERROR` events) and messaging layer into the overlay store/UI.
- Show clearer failure UX in the overlay (auth vs other failures) via ContextPanel / Overlay, with tests covering the new paths.

## Test plan
- [ ] Start a guided review with a valid API key and confirm units stream as before
- [ ] Trigger an invalid API key and confirm a clear auth-style error message (and status/code when present)
- [ ] Trigger a rate limit or other provider failure and confirm the provider message is shown when available
- [ ] Confirm a mid-stream failure ends the review cleanly without a stuck loading state
- [ ] Run `npm test` and `npm run build`