### PR TITLE
feat(a11y): WCAG 2.1 AA improvements for overlay, options, and popup

### DIFF
--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -24,7 +24,11 @@ function ensureButtonStyles(): void {
   if (document.getElementById(BUTTON_STYLE_ID)) return;
   const style = document.createElement("style");
   style.id = BUTTON_STYLE_ID;
-  style.textContent = `#${BUTTON_ID}:hover{background:${ACCENT_HOVER};border-color:${ACCENT_HOVER}}`;
+  style.textContent = [
+    `#${BUTTON_ID}:hover{background:${ACCENT_HOVER};border-color:${ACCENT_HOVER}}`,
+    `#${BUTTON_ID}:focus-visible{outline:2px solid #CAFF57;outline-offset:2px}`,
+    `@media (prefers-reduced-motion:reduce){#${BUTTON_ID}{transition:none}}`,
+  ].join("");
   document.documentElement.appendChild(style);
 }
 

--- a/src/content/overlay/Overlay.test.tsx
+++ b/src/content/overlay/Overlay.test.tsx
@@ -218,7 +218,7 @@ describe("Overlay", () => {
     expect(screen.getAllByText(PR_DESCRIPTION_UNIT_TITLE).length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("This PR adds a feature.")).toBeInTheDocument();
 
-    screen.getByRole("button", { name: /retry building the guided review/i }).click();
+    screen.getByRole("button", { name: /^retry$/i }).click();
     expect(onRetry).toHaveBeenCalledTimes(1);
   });
 

--- a/src/content/overlay/Overlay.tsx
+++ b/src/content/overlay/Overlay.tsx
@@ -1,8 +1,13 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { useReviewStore, persistSession } from "./store";
 import { resolveUnitFiles } from "./selectors";
 import { buildDisplayUnits, displayUnitCount } from "./displayUnits";
 import { buildSelectableLines } from "./buildSelectableLines";
+import {
+  getFocusableElements,
+  restoreFocusAfterOverlay,
+  trapTabKey,
+} from "./focusTrap";
 import { recordViewChordKey, type ViewChordPending } from "./viewModeChord";
 import type { ReviewSubmission } from "./commentTypes";
 import { ProgressHeader } from "./components/ProgressHeader";
@@ -61,8 +66,12 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
   const goToUnit = useReviewStore((s) => s.goToUnit);
   const goNext = useReviewStore((s) => s.goNext);
   const goPrev = useReviewStore((s) => s.goPrev);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const submitModalDialogRef = useRef<HTMLDivElement>(null);
   const codeColRef = useRef<HTMLElement>(null);
   const contextPaneRef = useRef<HTMLDivElement>(null);
+  /** Element focused before the overlay opened (for restore if start button gone). */
+  const previousFocusRef = useRef<Element | null>(null);
   /** Pending `v` leader for view-mode chords (`v+u` / `v+s`). */
   const viewChordRef = useRef<ViewChordPending>(null);
   const [submitReviewOpen, setSubmitReviewOpen] = useState(false);
@@ -72,16 +81,30 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
   const submitReviewKeyRef = useRef<((e: KeyboardEvent) => boolean) | null>(
     null,
   );
+  const titleId = useId();
 
   const handleExit = () => {
     onRequestClose?.();
     close();
   };
 
-  const handleSubmitReview = (_submission: ReviewSubmission) => {
-    // API integration later — UI only closes the modal for now.
+  const closeSubmitReview = useCallback(() => {
     setSubmitReviewOpen(false);
-  };
+    // Return focus to the trigger so keyboard users are not dropped into limbo.
+    requestAnimationFrame(() => {
+      overlayRef.current
+        ?.querySelector<HTMLElement>('[data-testid="submit-review-button"]')
+        ?.focus();
+    });
+  }, []);
+
+  const handleSubmitReview = useCallback(
+    (_submission: ReviewSubmission) => {
+      // API integration later — UI only closes the modal for now.
+      closeSubmitReview();
+    },
+    [closeSubmitReview],
+  );
 
   const draftComments = useReviewStore((s) => s.draftComments);
 
@@ -105,6 +128,24 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
     document.body.style.overflow = "hidden";
     return () => {
       document.body.style.overflow = overflow;
+    };
+  }, [isOpen]);
+
+  // Modal focus: move into the overlay on open; restore to the start button on close.
+  useEffect(() => {
+    if (!isOpen) return;
+
+    previousFocusRef.current = document.activeElement;
+    const frame = requestAnimationFrame(() => {
+      const root = overlayRef.current;
+      if (!root) return;
+      const focusable = getFocusableElements(root);
+      (focusable[0] ?? root).focus();
+    });
+
+    return () => {
+      cancelAnimationFrame(frame);
+      restoreFocusAfterOverlay(previousFocusRef.current);
     };
   }, [isOpen]);
 
@@ -156,6 +197,16 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
     function onKeyDown(event: KeyboardEvent): void {
       event.stopPropagation();
 
+      // Tab trap: keep focus inside the submit modal when open, else the overlay.
+      // Must run here — window capture stopPropagation means element traps never see Tab.
+      if (event.key === "Tab") {
+        const trapRoot = submitReviewOpen
+          ? submitModalDialogRef.current
+          : overlayRef.current;
+        if (trapRoot) trapTabKey(event, trapRoot);
+        return;
+      }
+
       // Submit-review modal: Esc closes the dialog only (not the whole overlay).
       // ⌘/Ctrl+Enter submits on the compose step; ↑/↓/Enter drive the choose step.
       // Handled here because capture stopPropagation blocks element React handlers.
@@ -163,7 +214,7 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
         viewChordRef.current = null;
         if (event.key === "Escape") {
           event.preventDefault();
-          setSubmitReviewOpen(false);
+          closeSubmitReview();
           return;
         }
         if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
@@ -327,24 +378,68 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
     selectableForUnit,
     currentUnitId,
     submitReviewOpen,
+    closeSubmitReview,
   ]);
+
+  const statusAnnouncement = useMemo(() => {
+    if (status === "error" && error) {
+      return `Error: ${error.message}`;
+    }
+    if (status === "loading") {
+      return "Loading pull request diff…";
+    }
+    if (status === "streaming") {
+      const n = plan?.units.length ?? 0;
+      return n > 0
+        ? `Building walkthrough. ${n} review unit${n === 1 ? "" : "s"} ready.`
+        : "Building walkthrough…";
+    }
+    if (status === "ready" && plan) {
+      return `Walkthrough ready. ${displayUnitCount(plan)} steps.`;
+    }
+    return "";
+  }, [status, error, plan]);
 
   if (!isOpen) return null;
 
+  const dialogTitle = prContext?.title?.trim() || "Guided Review";
+
   return (
-    <div className="fixed inset-0 z-[2147483000] flex flex-col bg-gr-bg font-sans text-sm text-gr-text antialiased [color-scheme:dark] [text-rendering:optimizeLegibility]">
+    <div
+      ref={overlayRef}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      tabIndex={-1}
+      className="fixed inset-0 z-[2147483000] flex flex-col bg-gr-bg font-sans text-sm text-gr-text antialiased outline-none [color-scheme:dark] [text-rendering:optimizeLegibility]"
+      data-testid="guided-review-overlay"
+    >
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="gr-sr-only"
+        data-testid="overlay-status-live"
+      >
+        {statusAnnouncement}
+      </div>
+
       <ProgressHeader
         prContext={prContext}
         diff={diff}
+        titleId={titleId}
+        title={dialogTitle}
         onExit={handleExit}
         onSubmitReview={() => setSubmitReviewOpen(true)}
       />
 
       <div className="flex min-h-0 flex-1">
         <main
+          id="main-content"
           className="min-w-0 flex-[1_1_68%] overflow-y-auto border-r border-gr-border bg-gr-bg px-8 py-6"
           ref={codeColRef}
           data-testid="code-col"
+          tabIndex={-1}
         >
           {isDescriptionUnit ? (
             <DescriptionPane prContext={prContext} diff={diff} />
@@ -357,7 +452,10 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
           )}
         </main>
 
-        <aside className="flex max-w-[420px] min-w-[300px] flex-[1_1_32%] flex-col overflow-hidden bg-gr-chrome px-5 py-6">
+        <aside
+          className="flex max-w-[420px] min-w-[300px] flex-[1_1_32%] flex-col overflow-hidden bg-gr-chrome px-5 py-6"
+          aria-label="Review context and plan"
+        >
           <div
             className="min-h-0 flex-[1_1_50%] overflow-y-auto"
             ref={contextPaneRef}
@@ -393,10 +491,11 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
 
       <SubmitReviewModal
         open={submitReviewOpen}
-        onClose={() => setSubmitReviewOpen(false)}
+        onClose={closeSubmitReview}
         onSubmit={handleSubmitReview}
         submitActionRef={submitReviewActionRef}
         keyActionRef={submitReviewKeyRef}
+        dialogRef={submitModalDialogRef}
       />
     </div>
   );

--- a/src/content/overlay/components/CommentComposer.tsx
+++ b/src/content/overlay/components/CommentComposer.tsx
@@ -57,7 +57,7 @@ export function CommentComposer({
       </div>
       <textarea
         ref={textareaRef}
-        className="min-h-[88px] w-full resize-y rounded-md border border-gr-border bg-gr-bg px-3 py-2 font-sans text-[14px] leading-relaxed text-gr-text outline-none placeholder:text-gr-faint focus:border-gr-accent"
+        className="min-h-[88px] w-full resize-y rounded-md border border-gr-border bg-gr-bg px-3 py-2 font-sans text-[14px] leading-relaxed text-gr-text placeholder:text-gr-faint focus:border-gr-accent"
         placeholder="Leave a review comment (markdown supported)…"
         value={body}
         onChange={(e) => setBody(e.target.value)}
@@ -68,7 +68,7 @@ export function CommentComposer({
       <div className="mt-2 flex flex-wrap items-center justify-end gap-2">
         <button
           type="button"
-          className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-[13px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+          className="inline-flex min-h-11 cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-2 text-[13px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
           onClick={onCancel}
         >
           Cancel
@@ -76,7 +76,7 @@ export function CommentComposer({
         </button>
         <button
           type="button"
-          className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-[13px] font-medium text-gr-accent-on enabled:hover:border-gr-accent-hover enabled:hover:bg-gr-accent-hover disabled:cursor-not-allowed disabled:opacity-40 [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
+          className="inline-flex min-h-11 cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-3 py-2 text-[13px] font-medium text-gr-accent-on enabled:hover:border-gr-accent-hover enabled:hover:bg-gr-accent-hover disabled:cursor-not-allowed disabled:opacity-40 [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
           disabled={!canSave}
           onClick={() => {
             if (canSave) onSave(body);

--- a/src/content/overlay/components/ContextPanel.test.tsx
+++ b/src/content/overlay/components/ContextPanel.test.tsx
@@ -42,7 +42,8 @@ describe("ContextPanel error state", () => {
     expect(screen.getByTestId("error-code")).toHaveTextContent("rate_limit_error");
     expect(screen.getByTestId("error-message")).toHaveTextContent("Rate limit exceeded");
 
-    screen.getByRole("button", { name: /retry building the guided review/i }).click();
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    screen.getByRole("button", { name: /^retry$/i }).click();
     expect(onRetry).toHaveBeenCalledTimes(1);
   });
 

--- a/src/content/overlay/components/ContextPanel.tsx
+++ b/src/content/overlay/components/ContextPanel.tsx
@@ -28,7 +28,11 @@ export function ContextPanel({
 }: ContextPanelProps) {
   if (error) {
     return (
-      <div className="rounded-none border-0 bg-transparent px-0 py-0.5 pb-1">
+      <div
+        className="rounded-none border-0 bg-transparent px-0 py-0.5 pb-1"
+        role="alert"
+        data-testid="context-panel-error"
+      >
         <div className="mb-2 text-xs font-semibold tracking-[0.04em] text-gr-muted uppercase">
           Something went wrong
         </div>
@@ -63,8 +67,7 @@ export function ContextPanel({
             <button
               type="button"
               onClick={onRetry}
-              aria-label="Retry building the guided review"
-              className="inline-flex cursor-pointer items-center rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-[13px] font-medium text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover"
+              className="inline-flex min-h-11 cursor-pointer items-center rounded-md border border-gr-accent bg-gr-accent px-3 py-2 text-[13px] font-medium text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover"
             >
               Retry
             </button>

--- a/src/content/overlay/components/DiffPane.tsx
+++ b/src/content/overlay/components/DiffPane.tsx
@@ -213,6 +213,7 @@ function UnifiedHunk({
             <div
               data-line-id={id}
               data-testid={isFocus ? "diff-line-focus" : undefined}
+              aria-current={isFocus ? "true" : undefined}
               className={cn(
                 DIFF_LINE_WRAP,
                 showDiffBg && line.type === "add" && "bg-gr-add-bg",
@@ -308,6 +309,7 @@ function SplitCellView({
       data-side={side}
       data-line-id={lineId}
       data-testid={isFocus ? "diff-line-focus" : undefined}
+      aria-current={isFocus ? "true" : undefined}
     >
       <span
         className={lineNumberClasses(highlightNumber)}
@@ -460,32 +462,34 @@ function DiffViewToggle({
         <button
           type="button"
           className={cn(
-            "inline-flex cursor-pointer items-center gap-1.5 px-3 py-1.5 text-[13px] transition-colors",
+            "inline-flex min-h-11 cursor-pointer items-center gap-1.5 px-3 py-2 text-[13px] transition-colors",
             mode === "unified"
               ? "bg-gr-subtle text-gr-text"
               : "bg-transparent text-gr-muted hover:bg-gr-subtle hover:text-gr-text",
           )}
-          aria-label="Unified"
           aria-pressed={mode === "unified"}
           onClick={() => onChange("unified")}
         >
           Unified
-          <ShortcutKeys keys={["v", "u"]} join="sequence" />
+          <span aria-hidden="true">
+            <ShortcutKeys keys={["v", "u"]} join="sequence" />
+          </span>
         </button>
         <button
           type="button"
           className={cn(
-            "inline-flex cursor-pointer items-center gap-1.5 border-l border-gr-border px-3 py-1.5 text-[13px] transition-colors",
+            "inline-flex min-h-11 cursor-pointer items-center gap-1.5 border-l border-gr-border px-3 py-2 text-[13px] transition-colors",
             mode === "split"
               ? "bg-gr-subtle text-gr-text"
               : "bg-transparent text-gr-muted hover:bg-gr-subtle hover:text-gr-text",
           )}
-          aria-label="Split"
           aria-pressed={mode === "split"}
           onClick={() => onChange("split")}
         >
           Split
-          <ShortcutKeys keys={["v", "s"]} join="sequence" />
+          <span aria-hidden="true">
+            <ShortcutKeys keys={["v", "s"]} join="sequence" />
+          </span>
         </button>
       </div>
     </div>
@@ -517,12 +521,11 @@ function AddCommentButton({
     <button
       type="button"
       className={cn(
-        "inline-flex shrink-0 items-center gap-1.5 rounded-md border border-gr-border px-3 py-1.5 text-[13px] transition-colors",
+        "inline-flex min-h-11 shrink-0 items-center gap-1.5 rounded-md border border-gr-border px-3 py-2 text-[13px] transition-colors",
         disabled
           ? "cursor-not-allowed bg-gr-bg text-gr-faint opacity-60"
           : "cursor-pointer bg-gr-bg text-gr-text hover:bg-gr-subtle",
       )}
-      aria-label="Add Comment"
       disabled={disabled}
       data-testid="enter-comment-mode"
       onClick={() => {
@@ -531,7 +534,9 @@ function AddCommentButton({
       }}
     >
       Add Comment
-      <Kbd>c</Kbd>
+      <span aria-hidden="true">
+        <Kbd>c</Kbd>
+      </span>
     </button>
   );
 }
@@ -701,8 +706,41 @@ export function DiffPane({ files, unitTitle, unitId }: DiffPaneProps) {
   const commentModeActive = uiMode === "comment";
   const commentModeDisabled = unitSelectableLines.length === 0;
 
+  // Announce focused/selected lines so comment mode is not color-only (1.4.1 / 4.1.3).
+  const selectionAnnouncement = useMemo(() => {
+    if (uiMode !== "comment" || !lineSelection) return "";
+    const lines =
+      selectableLines.length > 0 ? selectableLines : unitSelectableLines;
+    const focused = lines[lineSelection.focusIndex];
+    if (!focused) return "Comment mode. No line focused.";
+    const selected = linesInSelection(lines, lineSelection);
+    const focusNum = displayLineNumber(focused);
+    if (selected.length > 1) {
+      const first = selected[0];
+      const last = selected[selected.length - 1];
+      const start = displayLineNumber(first);
+      const end = displayLineNumber(last);
+      return `Comment mode. ${focused.filePath}, lines ${start ?? "?"} to ${end ?? "?"} selected.`;
+    }
+    return `Comment mode. ${focused.filePath}, line ${focusNum ?? "?"}.`;
+  }, [
+    uiMode,
+    lineSelection,
+    selectableLines,
+    unitSelectableLines,
+  ]);
+
   return (
     <div ref={rootRef}>
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="gr-sr-only"
+        data-testid="comment-selection-status"
+      >
+        {selectionAnnouncement}
+      </div>
       <div className="mb-4 flex items-center justify-between gap-4">
         <h2
           className="min-w-0 truncate text-[15px] font-semibold text-gr-text"

--- a/src/content/overlay/components/DraftCommentCard.tsx
+++ b/src/content/overlay/components/DraftCommentCard.tsx
@@ -72,7 +72,7 @@ export function DraftCommentCard({
           {!editing && (
             <button
               type="button"
-              className="cursor-pointer rounded px-1.5 py-0.5 text-[12px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+              className="min-h-9 min-w-9 cursor-pointer rounded px-2 py-1.5 text-[12px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
               onClick={() => setEditing(true)}
               aria-label="Edit draft comment"
               data-testid="draft-comment-edit"
@@ -82,7 +82,7 @@ export function DraftCommentCard({
           )}
           <button
             type="button"
-            className="cursor-pointer rounded px-1.5 py-0.5 text-[12px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+            className="min-h-9 min-w-9 cursor-pointer rounded px-2 py-1.5 text-[12px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
             onClick={() => onRemove(comment.id)}
             aria-label="Remove draft comment"
             data-testid="draft-comment-remove"
@@ -95,7 +95,7 @@ export function DraftCommentCard({
         <>
           <textarea
             ref={textareaRef}
-            className="min-h-[88px] w-full resize-y rounded-md border border-gr-border bg-gr-chrome px-3 py-2 font-sans text-[14px] leading-relaxed text-gr-text outline-none placeholder:text-gr-faint focus:border-gr-accent"
+            className="min-h-[88px] w-full resize-y rounded-md border border-gr-border bg-gr-chrome px-3 py-2 font-sans text-[14px] leading-relaxed text-gr-text placeholder:text-gr-faint focus:border-gr-accent"
             value={body}
             onChange={(e) => setBody(e.target.value)}
             onKeyDown={handleKeyDown}
@@ -105,7 +105,7 @@ export function DraftCommentCard({
           <div className="mt-2 flex flex-wrap items-center justify-end gap-2">
             <button
               type="button"
-              className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-chrome px-3 py-1.5 text-[13px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+              className="inline-flex min-h-11 cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-chrome px-3 py-2 text-[13px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
               onClick={exitEdit}
               data-testid="draft-comment-edit-cancel"
             >
@@ -114,7 +114,7 @@ export function DraftCommentCard({
             </button>
             <button
               type="button"
-              className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-[13px] font-medium text-gr-accent-on enabled:hover:border-gr-accent-hover enabled:hover:bg-gr-accent-hover disabled:cursor-not-allowed disabled:opacity-40 [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
+              className="inline-flex min-h-11 cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-3 py-2 text-[13px] font-medium text-gr-accent-on enabled:hover:border-gr-accent-hover enabled:hover:bg-gr-accent-hover disabled:cursor-not-allowed disabled:opacity-40 [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
               disabled={!canSave}
               onClick={saveEdit}
               data-testid="draft-comment-edit-save"

--- a/src/content/overlay/components/FooterNav.tsx
+++ b/src/content/overlay/components/FooterNav.tsx
@@ -9,34 +9,58 @@ interface FooterNavProps {
 }
 
 const navBtnBase =
-  "inline-flex cursor-pointer items-center gap-2 rounded-md border px-4 py-[7px] text-[13px] font-medium disabled:cursor-default disabled:opacity-40";
+  "inline-flex min-h-11 cursor-pointer items-center gap-2 rounded-md border px-4 py-2 text-[13px] font-medium disabled:cursor-default disabled:opacity-40";
 
-export function FooterNav({ currentIndex, total, onPrev, onNext }: FooterNavProps) {
+export function FooterNav({
+  currentIndex,
+  total,
+  onPrev,
+  onNext,
+}: FooterNavProps) {
+  const stepLabel =
+    total > 0 ? `Step ${currentIndex + 1} of ${total}` : "No steps yet";
+
   return (
-    <footer className="flex shrink-0 justify-between border-t border-gr-border bg-gr-chrome px-5 py-3">
+    <footer
+      className="flex shrink-0 items-center justify-between gap-3 border-t border-gr-border bg-gr-chrome px-5 py-3"
+      aria-label="Review navigation"
+    >
       <button
         type="button"
         className={cn(
           navBtnBase,
           "border-gr-border bg-gr-bg text-gr-text",
-          "[&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
+          "[&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit",
         )}
         onClick={onPrev}
-        disabled={currentIndex === 0}
+        disabled={currentIndex === 0 || total === 0}
+        aria-label="Previous step"
       >
         Previous
         <Kbd>←</Kbd>
       </button>
+
+      <p
+        className="m-0 min-w-0 text-center text-[13px] tabular-nums text-gr-muted"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        data-testid="footer-step-status"
+      >
+        {stepLabel}
+      </p>
+
       <button
         type="button"
         className={cn(
           navBtnBase,
           "border-gr-accent bg-gr-accent text-gr-accent-on",
           "enabled:hover:border-gr-accent-hover enabled:hover:bg-gr-accent-hover",
-          "[&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
+          "[&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit",
         )}
         onClick={onNext}
-        disabled={currentIndex >= total - 1}
+        disabled={total === 0 || currentIndex >= total - 1}
+        aria-label="Next step"
       >
         Next
         <Kbd>→</Kbd>

--- a/src/content/overlay/components/KeyboardShortcuts.tsx
+++ b/src/content/overlay/components/KeyboardShortcuts.tsx
@@ -57,10 +57,16 @@ function ShortcutRowKeys({ row }: { row: ShortcutRow }) {
 
 export function KeyboardShortcuts() {
   return (
-    <div className="mt-4 border-t border-gr-border-muted pt-3" aria-label="Keyboard shortcuts">
-      <div className="mb-2 text-xs font-semibold tracking-[0.04em] text-gr-muted uppercase">
+    <section
+      className="mt-4 border-t border-gr-border-muted pt-3"
+      aria-labelledby="keyboard-shortcuts-heading"
+    >
+      <h2
+        id="keyboard-shortcuts-heading"
+        className="mb-2 text-xs font-semibold tracking-[0.04em] text-gr-muted uppercase"
+      >
         Keyboard shortcuts
-      </div>
+      </h2>
       <ul className="m-0 flex list-none flex-col gap-2 p-0">
         {SHORTCUTS.map((row) => (
           <li key={row.description} className="flex items-center gap-3 text-[13px] text-gr-muted">
@@ -71,6 +77,6 @@ export function KeyboardShortcuts() {
           </li>
         ))}
       </ul>
-    </div>
+    </section>
   );
 }

--- a/src/content/overlay/components/ProgressHeader.tsx
+++ b/src/content/overlay/components/ProgressHeader.tsx
@@ -6,14 +6,23 @@ import { ModEnterChord } from "./ShortcutKeys";
 interface ProgressHeaderProps {
   prContext: PRContext | null;
   diff: ParsedDiff | null;
+  /** Id for the dialog title (overlay aria-labelledby). */
+  titleId: string;
+  /** Accessible / visible title text. */
+  title: string;
   onExit: () => void;
   /** Opens the Submit Review modal. */
   onSubmitReview: () => void;
 }
 
+const headerBtn =
+  "inline-flex min-h-11 cursor-pointer items-center gap-1.5 rounded-md border px-3 py-2 text-[13px] font-medium";
+
 export function ProgressHeader({
   prContext,
   diff,
+  titleId,
+  title,
   onExit,
   onSubmitReview,
 }: ProgressHeaderProps) {
@@ -34,36 +43,51 @@ export function ProgressHeader({
           />
           <div className="flex min-w-0 flex-col gap-1">
             <div className="flex min-w-0 items-baseline gap-2">
-              <span className="truncate text-[15px] font-semibold">
-                {prContext?.title || "Guided Review"}
-              </span>
+              <h1
+                id={titleId}
+                className="m-0 truncate text-[15px] font-semibold leading-snug"
+              >
+                {title}
+              </h1>
               {prContext && (
-                <span className="shrink-0 text-[13px] text-gr-muted">#{prContext.number}</span>
+                <span className="shrink-0 text-[13px] text-gr-muted">
+                  #{prContext.number}
+                </span>
               )}
             </div>
-            {prContext && (prContext.author || prContext.baseRef || prContext.headRef || stats) && (
-              <div className="flex items-center gap-2.5 text-[12.5px] text-gr-muted">
-                {prContext.author && <span>@{prContext.author}</span>}
-                {(prContext.baseRef || prContext.headRef) && (
-                  <span className="inline-block rounded-full border border-gr-border bg-gr-bg px-2.5 py-px font-mono text-xs text-gr-text">
-                    {prContext.baseRef || "?"} ← {prContext.headRef || "?"}
-                  </span>
-                )}
-                {stats && (
-                  <span>
-                    {stats.files} file{stats.files === 1 ? "" : "s"} changed
-                    <span className="ml-1 text-gr-add-text"> +{stats.additions}</span>
-                    <span className="ml-1 text-gr-del-text"> −{stats.deletions}</span>
-                  </span>
-                )}
-              </div>
-            )}
+            {prContext &&
+              (prContext.author ||
+                prContext.baseRef ||
+                prContext.headRef ||
+                stats) && (
+                <div className="flex items-center gap-2.5 text-[12.5px] text-gr-muted">
+                  {prContext.author && <span>@{prContext.author}</span>}
+                  {(prContext.baseRef || prContext.headRef) && (
+                    <span className="inline-block rounded-full border border-gr-border bg-gr-bg px-2.5 py-px font-mono text-xs text-gr-text">
+                      {prContext.baseRef || "?"} ← {prContext.headRef || "?"}
+                    </span>
+                  )}
+                  {stats && (
+                    <span>
+                      {stats.files} file{stats.files === 1 ? "" : "s"} changed
+                      <span className="ml-1 text-gr-add-text">
+                        {" "}
+                        +{stats.additions}
+                      </span>
+                      <span className="ml-1 text-gr-del-text">
+                        {" "}
+                        −{stats.deletions}
+                      </span>
+                    </span>
+                  )}
+                </div>
+              )}
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-3">
           <button
             type="button"
-            className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-[13px] font-medium text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
+            className={`${headerBtn} border-gr-accent bg-gr-accent text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit`}
             onClick={onSubmitReview}
             data-testid="submit-review-button"
           >
@@ -72,7 +96,7 @@ export function ProgressHeader({
           </button>
           <button
             type="button"
-            className="inline-flex cursor-pointer items-center gap-2 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-[13px] text-gr-text hover:bg-gr-subtle"
+            className={`${headerBtn} gap-2 border-gr-border bg-gr-bg text-gr-text hover:bg-gr-subtle`}
             onClick={onExit}
           >
             Exit

--- a/src/content/overlay/components/Sidebar.tsx
+++ b/src/content/overlay/components/Sidebar.tsx
@@ -50,7 +50,7 @@ export function Sidebar({
             ref={isActive ? activeItemRef : undefined}
             aria-current={isActive ? "true" : undefined}
             className={cn(
-              "mb-0.5 block w-full cursor-pointer rounded-md border-none bg-transparent p-2 text-left text-[13px] leading-snug text-gr-text",
+              "mb-0.5 block min-h-11 w-full cursor-pointer rounded-md border-none bg-transparent px-2 py-2.5 text-left text-[13px] leading-snug text-gr-text",
               isActive &&
                 "bg-gr-accent-subtle text-gr-accent! hover:bg-gr-accent-subtle",
             )}

--- a/src/content/overlay/components/SubmitReviewModal.tsx
+++ b/src/content/overlay/components/SubmitReviewModal.tsx
@@ -5,6 +5,7 @@ import {
   useState,
   type KeyboardEvent as ReactKeyboardEvent,
   type MutableRefObject,
+  type Ref,
 } from "react";
 import type { ReviewEvent, ReviewSubmission } from "../commentTypes";
 import { Kbd } from "./Kbd";
@@ -25,7 +26,12 @@ interface SubmitReviewModalProps {
    * Returns true when the key was handled (caller should preventDefault).
    */
   keyActionRef?: MutableRefObject<((e: KeyboardEvent) => boolean) | null>;
+  /** Dialog panel node for Tab focus trapping in the overlay capture handler. */
+  dialogRef?: Ref<HTMLDivElement>;
 }
+
+const modalBtn =
+  "inline-flex min-h-11 cursor-pointer items-center gap-1.5 rounded-md border px-3 py-2 text-[13px]";
 
 const REVIEW_EVENTS: {
   value: ReviewEvent;
@@ -66,6 +72,7 @@ export function SubmitReviewModal({
   onSubmit,
   submitActionRef,
   keyActionRef,
+  dialogRef,
 }: SubmitReviewModalProps) {
   const titleId = useId();
   const listboxId = useId();
@@ -223,6 +230,7 @@ export function SubmitReviewModal({
       }}
     >
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}
@@ -237,7 +245,7 @@ export function SubmitReviewModal({
           </h2>
           <button
             type="button"
-            className="inline-flex cursor-pointer items-center justify-center rounded-md border border-gr-border bg-gr-bg p-1.5 text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+            className="inline-flex min-h-11 min-w-11 cursor-pointer items-center justify-center rounded-md border border-gr-border bg-gr-bg p-2 text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
             onClick={onClose}
             aria-label="Close"
             data-testid="submit-review-close"
@@ -272,7 +280,7 @@ export function SubmitReviewModal({
                 aria-label="Review type"
                 aria-activedescendant={activeOptionId}
                 data-testid="submit-review-event-list"
-                className="flex flex-col gap-2 outline-none"
+                className="flex flex-col gap-2 rounded-md"
                 onKeyDown={handleListboxKeyDown}
               >
                 {REVIEW_EVENTS.map((opt, index) => {
@@ -316,7 +324,7 @@ export function SubmitReviewModal({
             <div className="flex items-center justify-end gap-2 border-t border-gr-border px-4 py-3">
               <button
                 type="button"
-                className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-[13px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+                className={`${modalBtn} border-gr-border bg-gr-bg text-gr-muted hover:bg-gr-subtle hover:text-gr-text`}
                 onClick={onClose}
                 data-testid="submit-review-cancel"
               >
@@ -330,7 +338,7 @@ export function SubmitReviewModal({
             <div className="flex flex-col gap-4 px-4 py-4">
               <textarea
                 ref={textareaRef}
-                className="min-h-[100px] w-full resize-y rounded-md border border-gr-border bg-gr-bg px-3 py-2 font-sans text-[14px] leading-relaxed text-gr-text outline-none placeholder:text-gr-faint focus:border-gr-accent"
+                className="min-h-[100px] w-full resize-y rounded-md border border-gr-border bg-gr-bg px-3 py-2 font-sans text-[14px] leading-relaxed text-gr-text placeholder:text-gr-faint focus:border-gr-accent"
                 placeholder="Leave a comment"
                 value={body}
                 onChange={(e) => setBody(e.target.value)}
@@ -356,7 +364,7 @@ export function SubmitReviewModal({
             <div className="flex items-center justify-between gap-2 border-t border-gr-border px-4 py-3">
               <button
                 type="button"
-                className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-[13px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+                className={`${modalBtn} border-gr-border bg-gr-bg text-gr-muted hover:bg-gr-subtle hover:text-gr-text`}
                 onClick={goBack}
                 data-testid="submit-review-back"
               >
@@ -365,7 +373,7 @@ export function SubmitReviewModal({
               <div className="flex items-center gap-2">
                 <button
                   type="button"
-                  className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-[13px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+                  className={`${modalBtn} border-gr-border bg-gr-bg text-gr-muted hover:bg-gr-subtle hover:text-gr-text`}
                   onClick={onClose}
                   data-testid="submit-review-cancel"
                 >
@@ -374,7 +382,7 @@ export function SubmitReviewModal({
                 </button>
                 <button
                   type="button"
-                  className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-[13px] font-medium text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
+                  className={`${modalBtn} border-gr-accent bg-gr-accent font-medium text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit`}
                   onClick={handleSubmit}
                   data-testid="submit-review-confirm"
                 >

--- a/src/content/overlay/focusTrap.test.ts
+++ b/src/content/overlay/focusTrap.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import { getFocusableElements, trapTabKey } from "./focusTrap";
+
+describe("getFocusableElements", () => {
+  it("returns visible enabled controls in order", () => {
+    const root = document.createElement("div");
+    root.innerHTML = `
+      <button type="button">A</button>
+      <button type="button" disabled>B</button>
+      <a href="#x">C</a>
+      <button type="button" aria-hidden="true">D</button>
+      <textarea>E</textarea>
+    `;
+    document.body.appendChild(root);
+    const found = getFocusableElements(root).map(
+      (el) => el.textContent?.trim() || el.tagName,
+    );
+    // Textarea content is "E"; disabled B and aria-hidden D are excluded.
+    expect(found).toEqual(["A", "C", "E"]);
+    root.remove();
+  });
+});
+
+describe("trapTabKey", () => {
+  it("wraps forward Tab from the last control to the first", () => {
+    const root = document.createElement("div");
+    const a = document.createElement("button");
+    a.textContent = "A";
+    const b = document.createElement("button");
+    b.textContent = "B";
+    root.append(a, b);
+    document.body.appendChild(root);
+    b.focus();
+
+    const event = new KeyboardEvent("keydown", {
+      key: "Tab",
+      bubbles: true,
+      cancelable: true,
+    });
+    const prevent = vi.spyOn(event, "preventDefault");
+    trapTabKey(event, root);
+    expect(prevent).toHaveBeenCalled();
+    expect(document.activeElement).toBe(a);
+    root.remove();
+  });
+
+  it("wraps Shift+Tab from the first control to the last", () => {
+    const root = document.createElement("div");
+    const a = document.createElement("button");
+    a.textContent = "A";
+    const b = document.createElement("button");
+    b.textContent = "B";
+    root.append(a, b);
+    document.body.appendChild(root);
+    a.focus();
+
+    const event = new KeyboardEvent("keydown", {
+      key: "Tab",
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    const prevent = vi.spyOn(event, "preventDefault");
+    trapTabKey(event, root);
+    expect(prevent).toHaveBeenCalled();
+    expect(document.activeElement).toBe(b);
+    root.remove();
+  });
+
+  it("ignores non-Tab keys", () => {
+    const root = document.createElement("div");
+    const a = document.createElement("button");
+    root.append(a);
+    document.body.appendChild(root);
+    a.focus();
+    const event = new KeyboardEvent("keydown", {
+      key: "Escape",
+      bubbles: true,
+      cancelable: true,
+    });
+    const prevent = vi.spyOn(event, "preventDefault");
+    trapTabKey(event, root);
+    expect(prevent).not.toHaveBeenCalled();
+    root.remove();
+  });
+});

--- a/src/content/overlay/focusTrap.ts
+++ b/src/content/overlay/focusTrap.ts
@@ -1,0 +1,78 @@
+/**
+ * Focus-trap helpers for the overlay Shadow DOM and nested dialogs.
+ * Tab handling must run in the overlay's window capture listener (which
+ * stopPropagations all keys); element-level listeners alone never see Tab.
+ */
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(", ");
+
+function isVisible(el: HTMLElement): boolean {
+  if (!el.isConnected || el.hidden) return false;
+  // Walk ancestors for display:none / visibility:hidden (works in jsdom).
+  let node: HTMLElement | null = el;
+  while (node) {
+    const style = window.getComputedStyle(node);
+    if (style.display === "none" || style.visibility === "hidden") return false;
+    node = node.parentElement;
+  }
+  return true;
+}
+
+/** Focusable, visible descendants of `container` in DOM order. */
+export function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+  ).filter((el) => isVisible(el) && el.getAttribute("aria-hidden") !== "true");
+}
+
+/**
+ * If Tab would leave `container`, preventDefault and wrap focus.
+ * Safe to call for non-Tab keys (no-op).
+ */
+export function trapTabKey(event: KeyboardEvent, container: HTMLElement): void {
+  if (event.key !== "Tab") return;
+
+  const focusable = getFocusableElements(container);
+  if (focusable.length === 0) {
+    event.preventDefault();
+    return;
+  }
+
+  const root = container.getRootNode() as Document | ShadowRoot;
+  const active = root.activeElement as HTMLElement | null;
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  const activeOutside =
+    !active || active === container || !container.contains(active);
+
+  if (event.shiftKey) {
+    if (active === first || activeOutside) {
+      event.preventDefault();
+      last.focus();
+    }
+  } else if (active === last || activeOutside) {
+    event.preventDefault();
+    first.focus();
+  }
+}
+
+/** Best-effort restore target when the guided review overlay closes. */
+export function restoreFocusAfterOverlay(
+  previous: Element | null | undefined,
+): void {
+  const startBtn = document.getElementById("guided-review-start-btn");
+  if (startBtn instanceof HTMLElement) {
+    startBtn.focus();
+    return;
+  }
+  if (previous instanceof HTMLElement && previous.isConnected) {
+    previous.focus();
+  }
+}

--- a/src/content/overlay/styles/overlay.css
+++ b/src/content/overlay/styles/overlay.css
@@ -47,3 +47,25 @@
 @import "./_highlight.scss";
 @import "./_markdown.scss";
 @import "./_animations.scss";
+
+/*
+ * Visible focus for keyboard users (2.4.7). Prefer :focus-visible so mouse
+ * clicks do not show a ring. Accent meets ≥ 3:1 against dark surfaces.
+ */
+:focus-visible {
+  outline: 2px solid var(--color-gr-accent, #caff57);
+  outline-offset: 2px;
+}
+
+/* Screen-reader-only utility (Tailwind sr-only may not always ship into the host) */
+.gr-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}

--- a/src/options/About.tsx
+++ b/src/options/About.tsx
@@ -11,7 +11,7 @@ export function About() {
   const version = chrome.runtime.getManifest().version;
 
   return (
-    <div className="mx-auto max-w-[480px] px-6 py-8">
+    <main id="main-content" className="mx-auto max-w-[480px] px-6 py-8">
       <BrandHeader />
       <p className="mb-6 text-[13px] text-opt-muted">
         AI-structured walkthroughs for GitHub pull requests
@@ -65,14 +65,14 @@ export function About() {
         </p>
       </section>
 
-      <nav className="mt-8 border-t border-opt-border pt-6">
+      <nav className="mt-8 border-t border-opt-border pt-6" aria-label="Settings">
         <a
           href="#settings"
-          className="text-[13px] font-semibold text-opt-muted no-underline hover:text-opt-text hover:underline"
+          className="text-[13px] font-semibold text-opt-muted no-underline hover:text-opt-text hover:underline focus-visible:rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-opt-accent"
         >
           ← Settings
         </a>
       </nav>
-    </div>
+    </main>
   );
 }

--- a/src/options/BrandHeader.tsx
+++ b/src/options/BrandHeader.tsx
@@ -8,6 +8,7 @@ export function BrandHeader({ title = "Guided Review" }: { title?: string }) {
         alt=""
         width={40}
         height={40}
+        aria-hidden="true"
       />
       <h1 className="m-0 text-lg font-bold">{title}</h1>
     </div>

--- a/src/options/Options.test.tsx
+++ b/src/options/Options.test.tsx
@@ -81,7 +81,7 @@ describe("Options", () => {
     await user.type(screen.getByLabelText(/api key/i), "sk-x");
     await user.click(screen.getByRole("button", { name: "Save" }));
 
-    expect(await screen.findByText("Quota exceeded")).toBeInTheDocument();
+    expect(await screen.findByText("Error: Quota exceeded")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled();
   });
 
@@ -115,7 +115,9 @@ describe("Options", () => {
     await user.type(screen.getByLabelText(/api key/i), "sk-bad");
     await user.click(screen.getByRole("button", { name: /test connection/i }));
 
-    await waitFor(() => expect(screen.getByText("Invalid API key")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByText("Error: Invalid API key")).toBeInTheDocument(),
+    );
   });
 
   it("shows an error when the connection test throws", async () => {
@@ -130,7 +132,7 @@ describe("Options", () => {
     await user.click(screen.getByRole("button", { name: /test connection/i }));
 
     await waitFor(() =>
-      expect(screen.getByText("Extension context invalidated")).toBeInTheDocument(),
+      expect(screen.getByText("Error: Extension context invalidated")).toBeInTheDocument(),
     );
     // Must not remain stuck on "Testing…"
     expect(screen.getByRole("button", { name: /test connection/i })).not.toBeDisabled();

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -21,7 +21,10 @@ type ActionStatus =
   | { kind: "error"; message: string };
 
 const fieldControl =
-  "w-full rounded-md border border-opt-border bg-opt-subtle px-2.5 py-2 text-[13px] text-opt-text";
+  "w-full rounded-md border border-opt-border bg-opt-subtle px-2.5 py-2 text-[13px] text-opt-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-opt-accent";
+
+const actionBtn =
+  "inline-flex min-h-11 cursor-pointer items-center gap-2 rounded-md border px-4 py-2 text-[13px] font-semibold disabled:cursor-default disabled:opacity-60";
 
 function OptionRow({ icon, label }: { icon: ProviderId; label: string }) {
   return (
@@ -125,7 +128,7 @@ export function Options() {
         : null;
 
   return (
-    <div className="mx-auto max-w-[480px] px-6 py-8">
+    <main id="main-content" className="mx-auto max-w-[480px] px-6 py-8">
       <BrandHeader />
       <p className="mb-6 text-[13px] text-opt-muted">
         Choose an AI provider and paste your own API key. The key is stored only in this
@@ -173,8 +176,9 @@ export function Options() {
           value={settings.apiKey}
           onChange={(e) => onApiKeyChange(e.target.value)}
           disabled={busy}
+          aria-describedby="apiKey-hint"
         />
-        <p className="mt-1 text-xs text-opt-muted">
+        <p id="apiKey-hint" className="mt-1 text-xs text-opt-muted">
           Stored locally on this device via chrome.storage.local — never synced.
         </p>
       </div>
@@ -183,9 +187,10 @@ export function Options() {
         <button
           type="button"
           className={cn(
-            "inline-flex cursor-pointer items-center gap-2 rounded-md border border-opt-accent bg-opt-accent px-4 py-2 text-[13px] font-semibold text-opt-accent-on",
+            actionBtn,
+            "border-opt-accent bg-opt-accent text-opt-accent-on",
             "enabled:hover:border-opt-accent-hover enabled:hover:bg-opt-accent-hover",
-            "disabled:cursor-default disabled:opacity-60",
+            "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-opt-accent",
           )}
           onClick={onSave}
           disabled={busy}
@@ -196,8 +201,9 @@ export function Options() {
         <button
           type="button"
           className={cn(
-            "inline-flex cursor-pointer items-center gap-2 rounded-md border border-opt-border bg-opt-subtle px-4 py-2 text-[13px] font-semibold text-opt-text",
-            "disabled:cursor-default disabled:opacity-60",
+            actionBtn,
+            "border-opt-border bg-opt-subtle text-opt-text",
+            "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-opt-accent",
           )}
           onClick={onTestConnection}
           disabled={!settings.apiKey || busy}
@@ -215,19 +221,19 @@ export function Options() {
               statusMessage.kind === "error" && "text-opt-error",
             )}
           >
-            {statusMessage.message}
+            {statusMessage.kind === "error" ? `Error: ${statusMessage.message}` : statusMessage.message}
           </span>
         )}
       </div>
 
-      <nav className="mt-8 border-t border-opt-border pt-6">
+      <nav className="mt-8 border-t border-opt-border pt-6" aria-label="About">
         <a
           href="#about"
-          className="text-[13px] font-semibold text-opt-muted no-underline hover:text-opt-text hover:underline"
+          className="text-[13px] font-semibold text-opt-muted no-underline hover:text-opt-text hover:underline focus-visible:rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-opt-accent"
         >
           About Guided Review
         </a>
       </nav>
-    </div>
+    </main>
   );
 }

--- a/src/options/components/ProviderIcon.tsx
+++ b/src/options/components/ProviderIcon.tsx
@@ -27,6 +27,7 @@ export function ProviderIcon({ provider, size = 16, className }: ProviderIconPro
       width={size}
       height={size}
       draggable={false}
+      aria-hidden="true"
       className={cn(
         "shrink-0 object-contain",
         // OpenAI asset is dark-on-transparent; invert for dark color scheme.

--- a/src/options/components/Select.tsx
+++ b/src/options/components/Select.tsx
@@ -231,7 +231,7 @@ export function Select<T extends string = string>({
         aria-label={ariaLabel}
         disabled={disabled}
         className={cn(
-          "flex w-full items-center gap-2 rounded-md border border-opt-border bg-opt-subtle px-2.5 py-2 text-left text-[13px] text-opt-text",
+          "flex min-h-11 w-full items-center gap-2 rounded-md border border-opt-border bg-opt-subtle px-2.5 py-2 text-left text-[13px] text-opt-text",
           "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-opt-accent",
           "disabled:cursor-not-allowed disabled:opacity-60",
         )}

--- a/src/options/options.scss
+++ b/src/options/options.scss
@@ -12,3 +12,8 @@ body {
   background: var(--color-opt-bg);
   color: var(--color-opt-text);
 }
+
+:focus-visible {
+  outline: 2px solid var(--color-opt-accent, #caff57);
+  outline-offset: 2px;
+}

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -65,8 +65,24 @@ body {
   font-weight: 600;
   color: #caff57;
   text-decoration: none;
+  border-radius: 4px;
 }
 
 .popup__link:hover {
   text-decoration: underline;
+}
+
+.popup__link:focus-visible {
+  outline: 2px solid #caff57;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -11,11 +11,13 @@
   --color-gr-bg: #110e0b;
   --color-gr-canvas: #16120f;
   --color-gr-subtle: #1c1814;
-  --color-gr-border: #3a342e;
-  --color-gr-border-muted: #2a2420;
+  /* Borders ≥ 3:1 against gr-bg/gr-chrome for WCAG 1.4.11 UI contrast */
+  --color-gr-border: #6b635a;
+  --color-gr-border-muted: #4a433c;
   --color-gr-text: #fefefe;
   --color-gr-muted: #8b949e;
-  --color-gr-faint: #6e7781;
+  /* ≥ 4.5:1 on gr-bg for normal text (line numbers, placeholders) */
+  --color-gr-faint: #768088;
   --color-gr-accent: #caff57;
   --color-gr-accent-hover: #b6e64e;
   --color-gr-accent-on: #0d0806;
@@ -82,7 +84,8 @@
   color-scheme: light dark;
   --opt-bg: #fefefe;
   --opt-subtle: #f6f8fa;
-  --opt-border: #d0d7de;
+  /* ≥ 3:1 against opt-bg for control borders (1.4.11) */
+  --opt-border: #8b949e;
   --opt-text: #0d0806;
   --opt-muted: #59636e;
   --opt-accent: #caff57;
@@ -96,7 +99,7 @@
   :root {
     --opt-bg: #0d0806;
     --opt-subtle: #16120f;
-    --opt-border: #3a342e;
+    --opt-border: #6b635a;
     --opt-text: #fefefe;
     --opt-muted: #8b949e;
     --opt-accent: #caff57;
@@ -104,5 +107,17 @@
     --opt-accent-on: #0d0806;
     --opt-ok: #3fb950;
     --opt-error: #ff7b72;
+  }
+}
+
+/* WCAG 2.3.3 — respect reduced-motion preference (overlay + options import this file) */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }


### PR DESCRIPTION
## Summary

Improves accessibility across the Guided Review Chrome extension toward WCAG 2.1 AA:

- **Overlay as modal**: `role="dialog"`, focus trap, initial focus, restore to Start Guided Review on close
- **Submit Review dialog**: Tab trap within the modal; focus returns to the trigger on close
- **Focus styles**: visible `:focus-visible` rings on overlay, options, popup, and start button
- **Live regions**: status/errors, streaming progress, step counter, comment-mode line selection
- **Motion**: `prefers-reduced-motion` support
- **Contrast**: stronger control borders and faint text tokens for 1.4.11 / 1.4.3
- **Forms & polish**: options labels/`aria-describedby`, landmarks, larger touch targets, decorative icons `aria-hidden`

## Test plan

- [x] `npm test` (290 tests)
- [x] `npm run typecheck`
- [ ] Load `dist/` unpacked extension; Tab through overlay — ring visible, Tab does not escape to GitHub
- [ ] Open Submit Review — Tab stays in dialog; Esc restores focus to Submit Review
- [ ] Exit overlay — focus returns to Start Guided Review
- [ ] Force a review error — announced via `role="alert"`
- [ ] Comment mode ↑/↓ — selection announced
- [ ] Reduced motion enabled — spinners/skeletons do not animate
- [ ] Options: tab through fields; error/success status announced