### PR TITLE
feat: submit PR reviews via GitHub device OAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Public GitHub OAuth App client ID (device flow — no client secret).
+# Create an OAuth App at https://github.com/settings/developers and enable Device Flow.
+VITE_GITHUB_CLIENT_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ test-results/
 playwright-report/
 blob-report/
 coverage/
+.env

--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -16,6 +16,7 @@ export default defineManifest({
   host_permissions: [
     "https://github.com/*",
     "https://patch-diff.githubusercontent.com/*",
+    "https://api.github.com/*",
     "https://api.anthropic.com/*",
     "https://api.openai.com/*",
     "https://api.x.ai/*",

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -6,12 +6,33 @@ import type {
   FetchDiffError,
   FetchDiffRequest,
   FetchDiffResponse,
+  GitHubAuthClearResponse,
+  GitHubAuthGetResponse,
+  GitHubAuthState,
+  GitHubDevicePollRequest,
+  GitHubDevicePollResponse,
+  GitHubDeviceStartResponse,
   ReviewErrorInfo,
   ReviewPlan,
   ReviewUnit,
   TestConnectionRequest,
   TestConnectionResponse,
 } from "../lib/types";
+import {
+  clearGitHubAuth,
+  getGitHubAuth,
+  setGitHubAuth,
+} from "../lib/github/authStorage";
+import {
+  fetchGitHubUser,
+  pollAccessToken,
+  requestDeviceCode,
+} from "../lib/github/deviceOAuth";
+import {
+  GITHUB_OAUTH_CLIENT_ID,
+  GITHUB_OAUTH_SCOPES,
+  isGitHubOAuthConfigured,
+} from "../lib/github/oauthConfig";
 import { fetchPRDiff } from "../lib/github/diffFetch";
 import { chunkDiffByFile } from "../lib/review/buildPrompt";
 import { StreamPlanParser } from "../lib/review/streamPlanParser";
@@ -48,6 +69,56 @@ chrome.runtime.onMessage.addListener((message: BackgroundRequest, _sender, sendR
       .then(sendResponse)
       .catch((error: unknown) => {
         const response: FetchDiffError = { ok: false, error: describeErrorMessage(error) };
+        sendResponse(response);
+      });
+    return true;
+  }
+
+  if (message.type === "GITHUB_DEVICE_START") {
+    handleGitHubDeviceStart()
+      .then(sendResponse)
+      .catch((error: unknown) => {
+        const response: GitHubDeviceStartResponse = {
+          ok: false,
+          error: describeErrorMessage(error),
+        };
+        sendResponse(response);
+      });
+    return true;
+  }
+
+  if (message.type === "GITHUB_DEVICE_POLL") {
+    handleGitHubDevicePoll(message)
+      .then(sendResponse)
+      .catch((error: unknown) => {
+        const response: GitHubDevicePollResponse = {
+          ok: false,
+          status: "error",
+          error: describeErrorMessage(error),
+        };
+        sendResponse(response);
+      });
+    return true;
+  }
+
+  if (message.type === "GITHUB_AUTH_GET") {
+    handleGitHubAuthGet()
+      .then(sendResponse)
+      .catch((error: unknown) => {
+        // Still a valid response shape; treat failure as signed-out.
+        console.error("GITHUB_AUTH_GET failed:", error);
+        const response: GitHubAuthGetResponse = { ok: true, auth: null };
+        sendResponse(response);
+      });
+    return true;
+  }
+
+  if (message.type === "GITHUB_AUTH_CLEAR") {
+    handleGitHubAuthClear()
+      .then(sendResponse)
+      .catch((error: unknown) => {
+        console.error("GITHUB_AUTH_CLEAR failed:", error);
+        const response: GitHubAuthClearResponse = { ok: true };
         sendResponse(response);
       });
     return true;
@@ -184,6 +255,93 @@ async function handleTestConnection(request: TestConnectionRequest): Promise<Tes
 async function handleFetchDiff(request: FetchDiffRequest): Promise<FetchDiffResponse> {
   const diff = await fetchPRDiff(request.pr);
   return { ok: true, diff };
+}
+
+async function handleGitHubDeviceStart(): Promise<GitHubDeviceStartResponse> {
+  if (!isGitHubOAuthConfigured()) {
+    return {
+      ok: false,
+      error:
+        "GitHub connection isn’t configured in this build. Set VITE_GITHUB_CLIENT_ID and rebuild.",
+    };
+  }
+
+  const device = await requestDeviceCode(GITHUB_OAUTH_CLIENT_ID, GITHUB_OAUTH_SCOPES);
+  return {
+    ok: true,
+    userCode: device.userCode,
+    verificationUri: device.verificationUri,
+    deviceCode: device.deviceCode,
+    interval: device.interval,
+    expiresIn: device.expiresIn,
+  };
+}
+
+async function handleGitHubDevicePoll(
+  request: GitHubDevicePollRequest,
+): Promise<GitHubDevicePollResponse> {
+  if (!isGitHubOAuthConfigured()) {
+    return {
+      ok: false,
+      status: "error",
+      error:
+        "GitHub connection isn’t configured in this build. Set VITE_GITHUB_CLIENT_ID and rebuild.",
+    };
+  }
+
+  const result = await pollAccessToken(GITHUB_OAUTH_CLIENT_ID, request.deviceCode);
+
+  switch (result.status) {
+    case "pending":
+      return { ok: true, status: "pending" };
+    case "slow_down":
+      return { ok: true, status: "slow_down", interval: result.interval };
+    case "expired":
+      return {
+        ok: false,
+        status: "expired",
+        error: "The device code expired. Start the connection again.",
+      };
+    case "denied":
+      return {
+        ok: false,
+        status: "denied",
+        error: "GitHub authorization was cancelled. You can try connecting again.",
+      };
+    case "error":
+      return { ok: false, status: "error", error: result.message };
+    case "authorized": {
+      const user = await fetchGitHubUser(result.accessToken);
+      const auth: GitHubAuthState = {
+        accessToken: result.accessToken,
+        tokenType: result.tokenType,
+        scope: result.scope,
+        login: user.login,
+        ...(user.avatarUrl ? { avatarUrl: user.avatarUrl } : {}),
+        ...(user.name ? { name: user.name } : {}),
+      };
+      await setGitHubAuth(auth);
+      return { ok: true, status: "authorized", auth };
+    }
+    default: {
+      const _exhaustive: never = result;
+      return {
+        ok: false,
+        status: "error",
+        error: `Unexpected poll status: ${JSON.stringify(_exhaustive)}`,
+      };
+    }
+  }
+}
+
+async function handleGitHubAuthGet(): Promise<GitHubAuthGetResponse> {
+  const auth = await getGitHubAuth();
+  return { ok: true, auth };
+}
+
+async function handleGitHubAuthClear(): Promise<GitHubAuthClearResponse> {
+  await clearGitHubAuth();
+  return { ok: true };
 }
 
 function describeError(error: unknown): ReviewErrorInfo {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -15,6 +15,8 @@ import type {
   ReviewErrorInfo,
   ReviewPlan,
   ReviewUnit,
+  SubmitReviewRequest,
+  SubmitReviewResponse,
   TestConnectionRequest,
   TestConnectionResponse,
 } from "../lib/types";
@@ -34,6 +36,7 @@ import {
   isGitHubOAuthConfigured,
 } from "../lib/github/oauthConfig";
 import { fetchPRDiff } from "../lib/github/diffFetch";
+import { submitPullRequestReview } from "../lib/github/submitReview";
 import { chunkDiffByFile } from "../lib/review/buildPrompt";
 import { StreamPlanParser } from "../lib/review/streamPlanParser";
 import { prefixChunkUnitId, validateAndCleanUnit } from "../lib/review/reviewPlan";
@@ -119,6 +122,20 @@ chrome.runtime.onMessage.addListener((message: BackgroundRequest, _sender, sendR
       .catch((error: unknown) => {
         console.error("GITHUB_AUTH_CLEAR failed:", error);
         const response: GitHubAuthClearResponse = { ok: true };
+        sendResponse(response);
+      });
+    return true;
+  }
+
+  if (message.type === "SUBMIT_REVIEW") {
+    handleSubmitReview(message)
+      .then(sendResponse)
+      .catch((error: unknown) => {
+        const response: SubmitReviewResponse = {
+          ok: false,
+          code: "unknown",
+          error: describeErrorMessage(error),
+        };
         sendResponse(response);
       });
     return true;
@@ -342,6 +359,35 @@ async function handleGitHubAuthGet(): Promise<GitHubAuthGetResponse> {
 async function handleGitHubAuthClear(): Promise<GitHubAuthClearResponse> {
   await clearGitHubAuth();
   return { ok: true };
+}
+
+async function handleSubmitReview(
+  request: SubmitReviewRequest,
+): Promise<SubmitReviewResponse> {
+  const auth = await getGitHubAuth();
+  if (!auth) {
+    return {
+      ok: false,
+      code: "not_authenticated",
+      error:
+        "Connect GitHub in the extension options before submitting a review.",
+    };
+  }
+
+  const result = await submitPullRequestReview({
+    accessToken: auth.accessToken,
+    pr: request.pr,
+    body: request.body,
+    event: request.event,
+    comments: request.comments,
+  });
+
+  // Stale / revoked token: drop the stored session so Options shows disconnected.
+  if (!result.ok && result.code === "not_authenticated") {
+    await clearGitHubAuth();
+  }
+
+  return result;
 }
 
 function describeError(error: unknown): ReviewErrorInfo {

--- a/src/content/overlay/Overlay.test.tsx
+++ b/src/content/overlay/Overlay.test.tsx
@@ -8,8 +8,18 @@ import { VIEW_CHORD_WINDOW_MS } from "./viewModeChord";
 import type { ParsedDiff, PRContext, ReviewPlan } from "../../lib/types";
 import * as messaging from "../../lib/messaging";
 
+const sampleAuth = {
+  accessToken: "gho_test",
+  tokenType: "bearer",
+  scope: "repo,read:user",
+  login: "octocat",
+};
+
 vi.mock("../../lib/messaging", () => ({
   submitPullRequestReview: vi.fn(),
+  getGitHubAuthStatus: vi.fn(),
+  startGitHubDeviceAuth: vi.fn(),
+  pollGitHubDeviceAuth: vi.fn(),
 }));
 
 function diffFixture(): ParsedDiff {
@@ -107,6 +117,11 @@ describe("Overlay", () => {
       ok: true,
       reviewId: 1,
       htmlUrl: "https://github.com/acme/widgets/pull/1#pullrequestreview-1",
+    });
+    vi.mocked(messaging.getGitHubAuthStatus).mockReset();
+    vi.mocked(messaging.getGitHubAuthStatus).mockResolvedValue({
+      ok: true,
+      auth: sampleAuth,
     });
   });
 
@@ -524,34 +539,116 @@ describe("Overlay", () => {
   });
 
   describe("submit review modal", () => {
-    it("opens from the header Submit Review button", () => {
+    async function openSubmitReviewModal(): Promise<void> {
+      fireEvent.click(screen.getByTestId("submit-review-button"));
+      expect(await screen.findByTestId("submit-review-modal")).toBeInTheDocument();
+    }
+
+    it("opens from the header Submit Review button when authenticated", async () => {
       seedReadyReview(0);
       render(<Overlay />);
 
       expect(screen.queryByTestId("submit-review-modal")).not.toBeInTheDocument();
-      fireEvent.click(screen.getByTestId("submit-review-button"));
-      expect(screen.getByTestId("submit-review-modal")).toBeInTheDocument();
+      await openSubmitReviewModal();
       expect(screen.getByRole("dialog", { name: "Submit Review" })).toBeInTheDocument();
     });
 
-    it("opens with meta+Enter when the modal is closed", () => {
+    it("opens the Connect GitHub modal when unauthenticated", async () => {
+      vi.mocked(messaging.getGitHubAuthStatus).mockResolvedValue({
+        ok: true,
+        auth: null,
+      });
+      seedReadyReview(0);
+      render(<Overlay />);
+
+      fireEvent.click(screen.getByTestId("submit-review-button"));
+      expect(await screen.findByTestId("connect-github-modal")).toBeInTheDocument();
+      expect(screen.queryByTestId("submit-review-modal")).not.toBeInTheDocument();
+      expect(screen.getByTestId("connect-github-prompt")).toHaveTextContent(
+        /authenticate via GitHub/i,
+      );
+    });
+
+    it("opens submit review after successful connect-from-modal auth", async () => {
+      vi.mocked(messaging.getGitHubAuthStatus).mockResolvedValue({
+        ok: true,
+        auth: null,
+      });
+      vi.mocked(messaging.startGitHubDeviceAuth).mockResolvedValue({
+        ok: true,
+        userCode: "ABCD-EFGH",
+        verificationUri: "https://github.com/login/device",
+        deviceCode: "device-auth",
+        interval: 0,
+        expiresIn: 900,
+      });
+      vi.mocked(messaging.pollGitHubDeviceAuth).mockResolvedValue({
+        ok: true,
+        status: "authorized",
+        auth: sampleAuth,
+      });
+
+      seedReadyReview(0);
+      render(<Overlay />);
+
+      fireEvent.click(screen.getByTestId("submit-review-button"));
+      expect(await screen.findByTestId("connect-github-modal")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId("connect-github-connect"));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("connect-github-modal")).not.toBeInTheDocument();
+      });
+      expect(await screen.findByTestId("submit-review-modal")).toBeInTheDocument();
+    });
+
+    it("closes the Connect GitHub modal on Esc without exiting the overlay", async () => {
+      vi.mocked(messaging.getGitHubAuthStatus).mockResolvedValue({
+        ok: true,
+        auth: null,
+      });
+      seedReadyReview(0);
+      render(<Overlay />);
+
+      fireEvent.click(screen.getByTestId("submit-review-button"));
+      expect(await screen.findByTestId("connect-github-modal")).toBeInTheDocument();
+
+      fireEvent.keyDown(window, { key: "Escape" });
+      expect(screen.queryByTestId("connect-github-modal")).not.toBeInTheDocument();
+      expect(useReviewStore.getState().isOpen).toBe(true);
+    });
+
+    it("opens with meta+Enter when the modal is closed", async () => {
       seedReadyReview(0);
       render(<Overlay />);
 
       expect(screen.queryByTestId("submit-review-modal")).not.toBeInTheDocument();
       fireEvent.keyDown(window, { key: "Enter", metaKey: true });
-      expect(screen.getByTestId("submit-review-modal")).toBeInTheDocument();
+      expect(await screen.findByTestId("submit-review-modal")).toBeInTheDocument();
     });
 
-    it("opens with Ctrl+Enter when the modal is closed", () => {
+    it("opens Connect GitHub with meta+Enter when unauthenticated", async () => {
+      vi.mocked(messaging.getGitHubAuthStatus).mockResolvedValue({
+        ok: true,
+        auth: null,
+      });
+      seedReadyReview(0);
+      render(<Overlay />);
+
+      fireEvent.keyDown(window, { key: "Enter", metaKey: true });
+      expect(await screen.findByTestId("connect-github-modal")).toBeInTheDocument();
+      expect(screen.queryByTestId("submit-review-modal")).not.toBeInTheDocument();
+    });
+
+    it("opens with Ctrl+Enter when the modal is closed", async () => {
       seedReadyReview(0);
       render(<Overlay />);
 
       fireEvent.keyDown(window, { key: "Enter", ctrlKey: true });
-      expect(screen.getByTestId("submit-review-modal")).toBeInTheDocument();
+      expect(await screen.findByTestId("submit-review-modal")).toBeInTheDocument();
     });
 
-    it("opens with meta+Enter from comment mode (without opening the line composer)", () => {
+    it("opens with meta+Enter from comment mode (without opening the line composer)", async () => {
       seedReadyReview(1);
       render(<Overlay />);
 
@@ -559,27 +656,26 @@ describe("Overlay", () => {
       expect(useReviewStore.getState().uiMode).toBe("comment");
 
       fireEvent.keyDown(window, { key: "Enter", metaKey: true });
-      expect(screen.getByTestId("submit-review-modal")).toBeInTheDocument();
+      expect(await screen.findByTestId("submit-review-modal")).toBeInTheDocument();
       expect(useReviewStore.getState().composerOpen).toBe(false);
     });
 
-    it("closes on Esc without exiting the overlay", () => {
+    it("closes on Esc without exiting the overlay", async () => {
       seedReadyReview(0);
       render(<Overlay />);
 
-      fireEvent.click(screen.getByTestId("submit-review-button"));
-      expect(screen.getByTestId("submit-review-modal")).toBeInTheDocument();
+      await openSubmitReviewModal();
 
       fireEvent.keyDown(window, { key: "Escape" });
       expect(screen.queryByTestId("submit-review-modal")).not.toBeInTheDocument();
       expect(useReviewStore.getState().isOpen).toBe(true);
     });
 
-    it("exits the overlay on Esc after the modal is closed", () => {
+    it("exits the overlay on Esc after the modal is closed", async () => {
       seedReadyReview(0);
       render(<Overlay />);
 
-      fireEvent.click(screen.getByTestId("submit-review-button"));
+      await openSubmitReviewModal();
       fireEvent.keyDown(window, { key: "Escape" });
       expect(screen.queryByTestId("submit-review-modal")).not.toBeInTheDocument();
 
@@ -604,7 +700,7 @@ describe("Overlay", () => {
       });
       render(<Overlay />);
 
-      fireEvent.click(screen.getByTestId("submit-review-button"));
+      await openSubmitReviewModal();
       fireEvent.click(screen.getByTestId("submit-review-event-APPROVE"));
       fireEvent.change(screen.getByTestId("submit-review-body"), {
         target: { value: "Looks good" },
@@ -646,7 +742,7 @@ describe("Overlay", () => {
       seedReadyReview(0);
       render(<Overlay />);
 
-      fireEvent.click(screen.getByTestId("submit-review-button"));
+      await openSubmitReviewModal();
       fireEvent.click(screen.getByTestId("submit-review-event-APPROVE"));
       fireEvent.change(screen.getByTestId("submit-review-body"), {
         target: { value: "Looks good" },
@@ -682,7 +778,7 @@ describe("Overlay", () => {
       seedReadyReview(0);
       render(<Overlay />);
 
-      fireEvent.click(screen.getByTestId("submit-review-button"));
+      await openSubmitReviewModal();
       fireEvent.click(screen.getByTestId("submit-review-event-APPROVE"));
       fireEvent.change(screen.getByTestId("submit-review-body"), {
         target: { value: "Looks good" },
@@ -715,7 +811,7 @@ describe("Overlay", () => {
       seedReadyReview(0);
       render(<Overlay />);
 
-      fireEvent.click(screen.getByTestId("submit-review-button"));
+      await openSubmitReviewModal();
       fireEvent.click(screen.getByTestId("submit-review-event-APPROVE"));
       fireEvent.click(screen.getByTestId("submit-review-confirm"));
 
@@ -731,7 +827,7 @@ describe("Overlay", () => {
       seedReadyReview(0);
       render(<Overlay />);
 
-      fireEvent.click(screen.getByTestId("submit-review-button"));
+      await openSubmitReviewModal();
       fireEvent.click(screen.getByTestId("submit-review-event-COMMENT"));
       fireEvent.click(screen.getByTestId("submit-review-confirm"));
 
@@ -747,7 +843,7 @@ describe("Overlay", () => {
       seedReadyReview(0);
       render(<Overlay />);
 
-      fireEvent.click(screen.getByTestId("submit-review-button"));
+      await openSubmitReviewModal();
       fireEvent.click(screen.getByTestId("submit-review-event-APPROVE"));
       fireEvent.change(screen.getByTestId("submit-review-body"), {
         target: { value: "Approved via shortcut" },
@@ -771,7 +867,7 @@ describe("Overlay", () => {
       seedReadyReview(0);
       render(<Overlay />);
 
-      fireEvent.click(screen.getByTestId("submit-review-button"));
+      await openSubmitReviewModal();
       fireEvent.click(screen.getByTestId("submit-review-event-COMMENT"));
       fireEvent.change(screen.getByTestId("submit-review-body"), {
         target: { value: "General feedback" },
@@ -794,11 +890,11 @@ describe("Overlay", () => {
       expect(useReviewStore.getState().isOpen).toBe(true);
     });
 
-    it("ArrowDown and Enter on choose step advance via window capture", () => {
+    it("ArrowDown and Enter on choose step advance via window capture", async () => {
       seedReadyReview(0);
       render(<Overlay />);
 
-      fireEvent.click(screen.getByTestId("submit-review-button"));
+      await openSubmitReviewModal();
       expect(screen.getByTestId("submit-review-modal")).toHaveAttribute(
         "data-step",
         "choose",

--- a/src/content/overlay/Overlay.test.tsx
+++ b/src/content/overlay/Overlay.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Overlay } from "./Overlay";
 import { DEFAULT_DIFF_VIEW_MODE } from "./diffViewMode";
@@ -6,6 +6,11 @@ import { useReviewStore } from "./store";
 import { PR_DESCRIPTION_UNIT_TITLE } from "./displayUnits";
 import { VIEW_CHORD_WINDOW_MS } from "./viewModeChord";
 import type { ParsedDiff, PRContext, ReviewPlan } from "../../lib/types";
+import * as messaging from "../../lib/messaging";
+
+vi.mock("../../lib/messaging", () => ({
+  submitPullRequestReview: vi.fn(),
+}));
 
 function diffFixture(): ParsedDiff {
   return {
@@ -97,6 +102,12 @@ describe("Overlay", () => {
     Element.prototype.scrollTo = vi.fn();
     // jsdom does not implement scrollBy; ArrowDown scrolls the code column.
     Element.prototype.scrollBy = vi.fn();
+    vi.mocked(messaging.submitPullRequestReview).mockReset();
+    vi.mocked(messaging.submitPullRequestReview).mockResolvedValue({
+      ok: true,
+      reviewId: 1,
+      htmlUrl: "https://github.com/acme/widgets/pull/1#pullrequestreview-1",
+    });
   });
 
   it("renders nothing when the review isn't open", () => {
@@ -576,8 +587,21 @@ describe("Overlay", () => {
       expect(useReviewStore.getState().isOpen).toBe(false);
     });
 
-    it("closes the modal on submit without calling network", () => {
+    it("submits a review to GitHub and closes the modal on success", async () => {
       seedReadyReview(0);
+      useReviewStore.setState({
+        draftComments: [
+          {
+            id: "d1",
+            filePath: "src/foo.ts",
+            side: "RIGHT",
+            startLine: 1,
+            endLine: 1,
+            lineIds: ["src/foo.ts#0:0:RIGHT"],
+            body: "inline note",
+          },
+        ],
+      });
       render(<Overlay />);
 
       fireEvent.click(screen.getByTestId("submit-review-button"));
@@ -587,11 +611,65 @@ describe("Overlay", () => {
       });
       fireEvent.click(screen.getByTestId("submit-review-confirm"));
 
-      expect(screen.queryByTestId("submit-review-modal")).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.queryByTestId("submit-review-modal")).not.toBeInTheDocument();
+      });
+      expect(messaging.submitPullRequestReview).toHaveBeenCalledWith(
+        { owner: "acme", repo: "widgets", number: 1 },
+        "Looks good",
+        "APPROVE",
+        [
+          {
+            path: "src/foo.ts",
+            body: "inline note",
+            side: "RIGHT",
+            line: 1,
+          },
+        ],
+      );
+      expect(useReviewStore.getState().draftComments).toHaveLength(0);
       expect(useReviewStore.getState().isOpen).toBe(true);
     });
 
-    it("submits with meta+Enter via the window capture handler", () => {
+    it("keeps the modal open and shows an error when submit fails", async () => {
+      vi.mocked(messaging.submitPullRequestReview).mockResolvedValueOnce({
+        ok: false,
+        code: "not_authenticated",
+        error:
+          "Connect GitHub in the extension options before submitting a review.",
+      });
+      seedReadyReview(0);
+      render(<Overlay />);
+
+      fireEvent.click(screen.getByTestId("submit-review-button"));
+      fireEvent.click(screen.getByTestId("submit-review-event-APPROVE"));
+      fireEvent.click(screen.getByTestId("submit-review-confirm"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("submit-review-error")).toHaveTextContent(
+          /Connect GitHub/,
+        );
+      });
+      expect(screen.getByTestId("submit-review-modal")).toBeInTheDocument();
+    });
+
+    it("blocks empty COMMENT body without calling the API", async () => {
+      seedReadyReview(0);
+      render(<Overlay />);
+
+      fireEvent.click(screen.getByTestId("submit-review-button"));
+      fireEvent.click(screen.getByTestId("submit-review-event-COMMENT"));
+      fireEvent.click(screen.getByTestId("submit-review-confirm"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("submit-review-error")).toHaveTextContent(
+          /Add a review comment/,
+        );
+      });
+      expect(messaging.submitPullRequestReview).not.toHaveBeenCalled();
+    });
+
+    it("submits with meta+Enter via the window capture handler", async () => {
       seedReadyReview(0);
       render(<Overlay />);
 
@@ -602,19 +680,38 @@ describe("Overlay", () => {
       });
       fireEvent.keyDown(window, { key: "Enter", metaKey: true });
 
-      expect(screen.queryByTestId("submit-review-modal")).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.queryByTestId("submit-review-modal")).not.toBeInTheDocument();
+      });
+      expect(messaging.submitPullRequestReview).toHaveBeenCalledWith(
+        { owner: "acme", repo: "widgets", number: 1 },
+        "Approved via shortcut",
+        "APPROVE",
+        [],
+      );
       expect(useReviewStore.getState().isOpen).toBe(true);
     });
 
-    it("submits with Ctrl+Enter via the window capture handler", () => {
+    it("submits with Ctrl+Enter via the window capture handler", async () => {
       seedReadyReview(0);
       render(<Overlay />);
 
       fireEvent.click(screen.getByTestId("submit-review-button"));
       fireEvent.click(screen.getByTestId("submit-review-event-COMMENT"));
+      fireEvent.change(screen.getByTestId("submit-review-body"), {
+        target: { value: "General feedback" },
+      });
       fireEvent.keyDown(window, { key: "Enter", ctrlKey: true });
 
-      expect(screen.queryByTestId("submit-review-modal")).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.queryByTestId("submit-review-modal")).not.toBeInTheDocument();
+      });
+      expect(messaging.submitPullRequestReview).toHaveBeenCalledWith(
+        { owner: "acme", repo: "widgets", number: 1 },
+        "General feedback",
+        "COMMENT",
+        [],
+      );
       expect(useReviewStore.getState().isOpen).toBe(true);
     });
 

--- a/src/content/overlay/Overlay.test.tsx
+++ b/src/content/overlay/Overlay.test.tsx
@@ -587,7 +587,7 @@ describe("Overlay", () => {
       expect(useReviewStore.getState().isOpen).toBe(false);
     });
 
-    it("submits a review to GitHub and closes the modal on success", async () => {
+    it("submits a review to GitHub and shows the success modal", async () => {
       seedReadyReview(0);
       useReviewStore.setState({
         draftComments: [
@@ -614,6 +614,10 @@ describe("Overlay", () => {
       await waitFor(() => {
         expect(screen.queryByTestId("submit-review-modal")).not.toBeInTheDocument();
       });
+      expect(screen.getByTestId("review-submitted-modal")).toBeInTheDocument();
+      expect(screen.getByTestId("review-submitted-summary")).toHaveTextContent(
+        "You approved this pull request and left 1 comment.",
+      );
       expect(messaging.submitPullRequestReview).toHaveBeenCalledWith(
         { owner: "acme", repo: "widgets", number: 1 },
         "Looks good",
@@ -629,6 +633,76 @@ describe("Overlay", () => {
       );
       expect(useReviewStore.getState().draftComments).toHaveLength(0);
       expect(useReviewStore.getState().isOpen).toBe(true);
+    });
+
+    it("exits guided review from the success modal and navigates to conversation", async () => {
+      const assign = vi.fn();
+      const originalLocation = window.location;
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: { pathname: "/acme/widgets/pull/1/files", assign },
+      });
+
+      seedReadyReview(0);
+      render(<Overlay />);
+
+      fireEvent.click(screen.getByTestId("submit-review-button"));
+      fireEvent.click(screen.getByTestId("submit-review-event-APPROVE"));
+      fireEvent.change(screen.getByTestId("submit-review-body"), {
+        target: { value: "Looks good" },
+      });
+      fireEvent.click(screen.getByTestId("submit-review-confirm"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("review-submitted-modal")).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId("review-submitted-exit"));
+
+      expect(useReviewStore.getState().isOpen).toBe(false);
+      expect(assign).toHaveBeenCalledWith(
+        "https://github.com/acme/widgets/pull/1",
+      );
+      expect(screen.queryByTestId("review-submitted-modal")).not.toBeInTheDocument();
+
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: originalLocation,
+      });
+    });
+
+    it("exits guided review with Enter while the success modal is open", async () => {
+      const assign = vi.fn();
+      const originalLocation = window.location;
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: { pathname: "/acme/widgets/pull/1", assign },
+      });
+
+      seedReadyReview(0);
+      render(<Overlay />);
+
+      fireEvent.click(screen.getByTestId("submit-review-button"));
+      fireEvent.click(screen.getByTestId("submit-review-event-APPROVE"));
+      fireEvent.change(screen.getByTestId("submit-review-body"), {
+        target: { value: "Looks good" },
+      });
+      fireEvent.click(screen.getByTestId("submit-review-confirm"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("review-submitted-modal")).toBeInTheDocument();
+      });
+
+      fireEvent.keyDown(window, { key: "Enter" });
+
+      expect(useReviewStore.getState().isOpen).toBe(false);
+      expect(assign).not.toHaveBeenCalled();
+      expect(screen.queryByTestId("review-submitted-modal")).not.toBeInTheDocument();
+
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: originalLocation,
+      });
     });
 
     it("keeps the modal open and shows an error when submit fails", async () => {
@@ -683,6 +757,7 @@ describe("Overlay", () => {
       await waitFor(() => {
         expect(screen.queryByTestId("submit-review-modal")).not.toBeInTheDocument();
       });
+      expect(screen.getByTestId("review-submitted-modal")).toBeInTheDocument();
       expect(messaging.submitPullRequestReview).toHaveBeenCalledWith(
         { owner: "acme", repo: "widgets", number: 1 },
         "Approved via shortcut",
@@ -706,6 +781,10 @@ describe("Overlay", () => {
       await waitFor(() => {
         expect(screen.queryByTestId("submit-review-modal")).not.toBeInTheDocument();
       });
+      expect(screen.getByTestId("review-submitted-modal")).toBeInTheDocument();
+      expect(screen.getByTestId("review-submitted-summary")).toHaveTextContent(
+        "You submitted a comment review.",
+      );
       expect(messaging.submitPullRequestReview).toHaveBeenCalledWith(
         { owner: "acme", repo: "widgets", number: 1 },
         "General feedback",

--- a/src/content/overlay/Overlay.test.tsx
+++ b/src/content/overlay/Overlay.test.tsx
@@ -7,6 +7,7 @@ import { PR_DESCRIPTION_UNIT_TITLE } from "./displayUnits";
 import { VIEW_CHORD_WINDOW_MS } from "./viewModeChord";
 import type { ParsedDiff, PRContext, ReviewPlan } from "../../lib/types";
 import * as messaging from "../../lib/messaging";
+import * as oauthConfig from "../../lib/github/oauthConfig";
 
 const sampleAuth = {
   accessToken: "gho_test",
@@ -20,6 +21,12 @@ vi.mock("../../lib/messaging", () => ({
   getGitHubAuthStatus: vi.fn(),
   startGitHubDeviceAuth: vi.fn(),
   pollGitHubDeviceAuth: vi.fn(),
+}));
+
+// CI has no .env with VITE_GITHUB_CLIENT_ID; mock configured so the connect
+// prompt/button render (same pattern as ConnectGitHubModal.test.tsx).
+vi.mock("../../lib/github/oauthConfig", () => ({
+  isGitHubOAuthConfigured: vi.fn(() => true),
 }));
 
 function diffFixture(): ParsedDiff {
@@ -112,6 +119,7 @@ describe("Overlay", () => {
     Element.prototype.scrollTo = vi.fn();
     // jsdom does not implement scrollBy; ArrowDown scrolls the code column.
     Element.prototype.scrollBy = vi.fn();
+    vi.mocked(oauthConfig.isGitHubOAuthConfigured).mockReturnValue(true);
     vi.mocked(messaging.submitPullRequestReview).mockReset();
     vi.mocked(messaging.submitPullRequestReview).mockResolvedValue({
       ok: true,

--- a/src/content/overlay/Overlay.tsx
+++ b/src/content/overlay/Overlay.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { submitPullRequestReview } from "../../lib/messaging";
 import { useReviewStore, persistSession } from "./store";
 import { resolveUnitFiles } from "./selectors";
 import { buildDisplayUnits, displayUnitCount } from "./displayUnits";
 import { buildSelectableLines } from "./buildSelectableLines";
 import { recordViewChordKey, type ViewChordPending } from "./viewModeChord";
 import type { ReviewSubmission } from "./commentTypes";
+import { mapDraftsToReviewComments } from "./mapDraftComments";
 import { ProgressHeader } from "./components/ProgressHeader";
 import { Sidebar } from "./components/Sidebar";
 import { DiffPane } from "./components/DiffPane";
@@ -66,24 +68,96 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
   /** Pending `v` leader for view-mode chords (`v+u` / `v+s`). */
   const viewChordRef = useRef<ViewChordPending>(null);
   const [submitReviewOpen, setSubmitReviewOpen] = useState(false);
+  const [submittingReview, setSubmittingReview] = useState(false);
+  const [submitReviewError, setSubmitReviewError] = useState<string | null>(
+    null,
+  );
   /** Latest submit action from the open Submit Review modal (for ⌘/Ctrl+Enter). */
   const submitReviewActionRef = useRef<(() => void) | null>(null);
   /** Choose-step keys (↑/↓/Enter) for the open Submit Review modal. */
   const submitReviewKeyRef = useRef<((e: KeyboardEvent) => boolean) | null>(
     null,
   );
+  /** Ignore stale submit responses after the modal is closed or a newer submit. */
+  const submitGenerationRef = useRef(0);
 
   const handleExit = () => {
     onRequestClose?.();
     close();
   };
 
-  const handleSubmitReview = (_submission: ReviewSubmission) => {
-    // API integration later — UI only closes the modal for now.
-    setSubmitReviewOpen(false);
-  };
-
   const draftComments = useReviewStore((s) => s.draftComments);
+  const clearDraftComments = useReviewStore((s) => s.clearDraftComments);
+
+  const closeSubmitReviewModal = useCallback(() => {
+    if (submittingReview) return;
+    setSubmitReviewOpen(false);
+    setSubmitReviewError(null);
+  }, [submittingReview]);
+
+  const handleSubmitReview = useCallback(
+    async (submission: ReviewSubmission) => {
+      if (submittingReview) return;
+
+      const trimmedBody = submission.body.trim();
+      if (
+        (submission.event === "COMMENT" ||
+          submission.event === "REQUEST_CHANGES") &&
+        trimmedBody.length === 0
+      ) {
+        setSubmitReviewError(
+          submission.event === "COMMENT"
+            ? "Add a review comment before submitting."
+            : "Add a summary explaining the requested changes before submitting.",
+        );
+        return;
+      }
+
+      const pr = prContext;
+      if (!pr) {
+        setSubmitReviewError(
+          "Missing pull request context. Close the review and try again from the PR page.",
+        );
+        return;
+      }
+
+      const generation = ++submitGenerationRef.current;
+      setSubmittingReview(true);
+      setSubmitReviewError(null);
+
+      try {
+        const result = await submitPullRequestReview(
+          { owner: pr.owner, repo: pr.repo, number: pr.number },
+          trimmedBody,
+          submission.event,
+          mapDraftsToReviewComments(draftComments),
+        );
+
+        if (generation !== submitGenerationRef.current) return;
+
+        if (!result.ok) {
+          setSubmitReviewError(result.error);
+          return;
+        }
+
+        clearDraftComments();
+        setSubmitReviewOpen(false);
+        setSubmitReviewError(null);
+      } catch (error: unknown) {
+        if (generation !== submitGenerationRef.current) return;
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Something went wrong while submitting the review.";
+        setSubmitReviewError(message);
+      } finally {
+        if (generation === submitGenerationRef.current) {
+          setSubmittingReview(false);
+        }
+      }
+    },
+    [submittingReview, prContext, draftComments, clearDraftComments],
+  );
 
   useEffect(() => {
     if (status === "ready") void persistSession();
@@ -163,7 +237,10 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
         viewChordRef.current = null;
         if (event.key === "Escape") {
           event.preventDefault();
-          setSubmitReviewOpen(false);
+          if (!submittingReview) {
+            setSubmitReviewOpen(false);
+            setSubmitReviewError(null);
+          }
           return;
         }
         if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
@@ -208,6 +285,7 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
       if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
         event.preventDefault();
         viewChordRef.current = null;
+        setSubmitReviewError(null);
         setSubmitReviewOpen(true);
         return;
       }
@@ -327,7 +405,13 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
     selectableForUnit,
     currentUnitId,
     submitReviewOpen,
+    submittingReview,
   ]);
+
+  function openSubmitReviewModal(): void {
+    setSubmitReviewError(null);
+    setSubmitReviewOpen(true);
+  }
 
   if (!isOpen) return null;
 
@@ -337,7 +421,7 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
         prContext={prContext}
         diff={diff}
         onExit={handleExit}
-        onSubmitReview={() => setSubmitReviewOpen(true)}
+        onSubmitReview={openSubmitReviewModal}
       />
 
       <div className="flex min-h-0 flex-1">
@@ -393,8 +477,12 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
 
       <SubmitReviewModal
         open={submitReviewOpen}
-        onClose={() => setSubmitReviewOpen(false)}
-        onSubmit={handleSubmitReview}
+        onClose={closeSubmitReviewModal}
+        onSubmit={(submission) => {
+          void handleSubmitReview(submission);
+        }}
+        submitting={submittingReview}
+        error={submitReviewError}
         submitActionRef={submitReviewActionRef}
         keyActionRef={submitReviewKeyRef}
       />

--- a/src/content/overlay/Overlay.tsx
+++ b/src/content/overlay/Overlay.tsx
@@ -1,5 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { submitPullRequestReview } from "../../lib/messaging";
+import {
+  getGitHubAuthStatus,
+  submitPullRequestReview,
+} from "../../lib/messaging";
 import { useReviewStore, persistSession } from "./store";
 import { resolveUnitFiles } from "./selectors";
 import { buildDisplayUnits, displayUnitCount } from "./displayUnits";
@@ -14,6 +17,7 @@ import { DiffPane } from "./components/DiffPane";
 import { DescriptionPane } from "./components/DescriptionPane";
 import { ContextPanel } from "./components/ContextPanel";
 import { FooterNav } from "./components/FooterNav";
+import { ConnectGitHubModal } from "./components/ConnectGitHubModal";
 import { SubmitReviewModal } from "./components/SubmitReviewModal";
 import { ReviewSubmittedModal } from "./components/ReviewSubmittedModal";
 
@@ -75,6 +79,7 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
   /** Pending `v` leader for view-mode chords (`v+u` / `v+s`). */
   const viewChordRef = useRef<ViewChordPending>(null);
   const [submitReviewOpen, setSubmitReviewOpen] = useState(false);
+  const [connectGitHubOpen, setConnectGitHubOpen] = useState(false);
   const [submittingReview, setSubmittingReview] = useState(false);
   const [submitReviewError, setSubmitReviewError] = useState<string | null>(
     null,
@@ -88,8 +93,12 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
   const submitReviewKeyRef = useRef<((e: KeyboardEvent) => boolean) | null>(
     null,
   );
+  /** Primary Connect / Try again action from the open Connect GitHub modal. */
+  const connectGitHubActionRef = useRef<(() => void) | null>(null);
   /** Ignore stale submit responses after the modal is closed or a newer submit. */
   const submitGenerationRef = useRef(0);
+  /** Prevent double-open while auth status is in flight. */
+  const authCheckInFlightRef = useRef(false);
 
   const handleExit = useCallback(() => {
     onRequestClose?.();
@@ -112,6 +121,53 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
     setSubmitReviewOpen(false);
     setSubmitReviewError(null);
   }, [submittingReview]);
+
+  const closeConnectGitHubModal = useCallback(() => {
+    setConnectGitHubOpen(false);
+  }, []);
+
+  const openSubmitReviewModalAfterAuth = useCallback(() => {
+    setConnectGitHubOpen(false);
+    setSubmitReviewError(null);
+    setSubmitReviewOpen(true);
+  }, []);
+
+  /**
+   * Gate Submit Review on a stored GitHub token. Missing auth → connect modal;
+   * after successful device OAuth the connect modal re-opens submit.
+   */
+  const requestOpenSubmitReview = useCallback(async () => {
+    if (
+      authCheckInFlightRef.current ||
+      submitReviewOpen ||
+      connectGitHubOpen ||
+      submittingReview ||
+      submitSuccess !== null
+    ) {
+      return;
+    }
+
+    authCheckInFlightRef.current = true;
+    try {
+      const status = await getGitHubAuthStatus();
+      if (status.ok && status.auth) {
+        setSubmitReviewError(null);
+        setSubmitReviewOpen(true);
+        return;
+      }
+      setConnectGitHubOpen(true);
+    } catch {
+      // Treat network/messaging failures as unauthenticated so the user can connect.
+      setConnectGitHubOpen(true);
+    } finally {
+      authCheckInFlightRef.current = false;
+    }
+  }, [
+    submitReviewOpen,
+    connectGitHubOpen,
+    submittingReview,
+    submitSuccess,
+  ]);
 
   const handleSubmitReview = useCallback(
     async (submission: ReviewSubmission) => {
@@ -271,6 +327,26 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
         return;
       }
 
+      // Connect GitHub modal: Esc closes; Enter runs Connect / Try again / open GitHub.
+      if (connectGitHubOpen) {
+        viewChordRef.current = null;
+        if (event.key === "Escape") {
+          event.preventDefault();
+          setConnectGitHubOpen(false);
+          return;
+        }
+        if (
+          event.key === "Enter" &&
+          !event.metaKey &&
+          !event.ctrlKey &&
+          !event.altKey
+        ) {
+          event.preventDefault();
+          connectGitHubActionRef.current?.();
+        }
+        return;
+      }
+
       // Submit-review modal: Esc closes the dialog only (not the whole overlay).
       // ⌘/Ctrl+Enter submits on the compose step; ↑/↓/Enter drive the choose step.
       // Handled here because capture stopPropagation blocks element React handlers.
@@ -322,12 +398,11 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
         return;
       }
 
-      // ⌘/Ctrl+Enter opens the Submit Review modal (when not typing in a field).
+      // ⌘/Ctrl+Enter opens Submit Review (or Connect GitHub if unauthenticated).
       if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
         event.preventDefault();
         viewChordRef.current = null;
-        setSubmitReviewError(null);
-        setSubmitReviewOpen(true);
+        void requestOpenSubmitReview();
         return;
       }
 
@@ -446,15 +521,12 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
     selectableForUnit,
     currentUnitId,
     submitReviewOpen,
+    connectGitHubOpen,
     submittingReview,
     submitSuccess,
     exitAfterSubmit,
+    requestOpenSubmitReview,
   ]);
-
-  function openSubmitReviewModal(): void {
-    setSubmitReviewError(null);
-    setSubmitReviewOpen(true);
-  }
 
   if (!isOpen) return null;
 
@@ -464,7 +536,9 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
         prContext={prContext}
         diff={diff}
         onExit={handleExit}
-        onSubmitReview={openSubmitReviewModal}
+        onSubmitReview={() => {
+          void requestOpenSubmitReview();
+        }}
       />
 
       <div className="flex min-h-0 flex-1">
@@ -516,6 +590,13 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
         total={total}
         onPrev={goPrev}
         onNext={goNext}
+      />
+
+      <ConnectGitHubModal
+        open={connectGitHubOpen}
+        onClose={closeConnectGitHubModal}
+        onAuthenticated={openSubmitReviewModalAfterAuth}
+        connectActionRef={connectGitHubActionRef}
       />
 
       <SubmitReviewModal

--- a/src/content/overlay/Overlay.tsx
+++ b/src/content/overlay/Overlay.tsx
@@ -5,8 +5,9 @@ import { resolveUnitFiles } from "./selectors";
 import { buildDisplayUnits, displayUnitCount } from "./displayUnits";
 import { buildSelectableLines } from "./buildSelectableLines";
 import { recordViewChordKey, type ViewChordPending } from "./viewModeChord";
-import type { ReviewSubmission } from "./commentTypes";
+import type { ReviewEvent, ReviewSubmission } from "./commentTypes";
 import { mapDraftsToReviewComments } from "./mapDraftComments";
+import { navigateToPrConversation } from "./prConversationUrl";
 import { ProgressHeader } from "./components/ProgressHeader";
 import { Sidebar } from "./components/Sidebar";
 import { DiffPane } from "./components/DiffPane";
@@ -14,6 +15,12 @@ import { DescriptionPane } from "./components/DescriptionPane";
 import { ContextPanel } from "./components/ContextPanel";
 import { FooterNav } from "./components/FooterNav";
 import { SubmitReviewModal } from "./components/SubmitReviewModal";
+import { ReviewSubmittedModal } from "./components/ReviewSubmittedModal";
+
+interface SubmitSuccessInfo {
+  event: ReviewEvent;
+  commentCount: number;
+}
 
 interface OverlayProps {
   /** Invoked when the user exits so any in-flight stream can be cancelled. */
@@ -72,6 +79,9 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
   const [submitReviewError, setSubmitReviewError] = useState<string | null>(
     null,
   );
+  const [submitSuccess, setSubmitSuccess] = useState<SubmitSuccessInfo | null>(
+    null,
+  );
   /** Latest submit action from the open Submit Review modal (for ⌘/Ctrl+Enter). */
   const submitReviewActionRef = useRef<(() => void) | null>(null);
   /** Choose-step keys (↑/↓/Enter) for the open Submit Review modal. */
@@ -81,10 +91,18 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
   /** Ignore stale submit responses after the modal is closed or a newer submit. */
   const submitGenerationRef = useRef(0);
 
-  const handleExit = () => {
+  const handleExit = useCallback(() => {
     onRequestClose?.();
     close();
-  };
+  }, [onRequestClose, close]);
+
+  const exitAfterSubmit = useCallback(() => {
+    setSubmitSuccess(null);
+    if (prContext) {
+      navigateToPrConversation(prContext);
+    }
+    handleExit();
+  }, [prContext, handleExit]);
 
   const draftComments = useReviewStore((s) => s.draftComments);
   const clearDraftComments = useReviewStore((s) => s.clearDraftComments);
@@ -140,9 +158,11 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
           return;
         }
 
+        const commentCount = mapDraftsToReviewComments(draftComments).length;
         clearDraftComments();
         setSubmitReviewOpen(false);
         setSubmitReviewError(null);
+        setSubmitSuccess({ event: submission.event, commentCount });
       } catch (error: unknown) {
         if (generation !== submitGenerationRef.current) return;
         const message =
@@ -229,6 +249,27 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
     // the key (so typing into the comment composer still inserts characters).
     function onKeyDown(event: KeyboardEvent): void {
       event.stopPropagation();
+
+      // Success modal: Enter / Esc exit guided review (single CTA dialog).
+      if (submitSuccess) {
+        viewChordRef.current = null;
+        if (
+          event.key === "Enter" &&
+          !event.metaKey &&
+          !event.ctrlKey &&
+          !event.altKey
+        ) {
+          event.preventDefault();
+          exitAfterSubmit();
+          return;
+        }
+        if (event.key === "Escape") {
+          event.preventDefault();
+          exitAfterSubmit();
+          return;
+        }
+        return;
+      }
 
       // Submit-review modal: Esc closes the dialog only (not the whole overlay).
       // ⌘/Ctrl+Enter submits on the compose step; ↑/↓/Enter drive the choose step.
@@ -406,6 +447,8 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
     currentUnitId,
     submitReviewOpen,
     submittingReview,
+    submitSuccess,
+    exitAfterSubmit,
   ]);
 
   function openSubmitReviewModal(): void {
@@ -485,6 +528,13 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
         error={submitReviewError}
         submitActionRef={submitReviewActionRef}
         keyActionRef={submitReviewKeyRef}
+      />
+
+      <ReviewSubmittedModal
+        open={submitSuccess !== null}
+        event={submitSuccess?.event ?? "COMMENT"}
+        commentCount={submitSuccess?.commentCount ?? 0}
+        onExit={exitAfterSubmit}
       />
     </div>
   );

--- a/src/content/overlay/commentTypes.ts
+++ b/src/content/overlay/commentTypes.ts
@@ -1,8 +1,11 @@
 /**
  * Local draft review-comment types for the overlay.
- * Kept out of `src/lib/types.ts` until a GitHub post path exists.
+ * Shared submit-API shapes (`ReviewEvent`, `ReviewCommentInput`) live in `src/lib/types.ts`.
  */
 
+import type { ReviewEvent } from "../../lib/types";
+
+export type { ReviewEvent };
 export type DiffSide = "LEFT" | "RIGHT";
 
 /** One keyboard-selectable line anchor in the current unit's code pane. */
@@ -43,9 +46,6 @@ export interface DraftComment {
 }
 
 export type UiMode = "navigate" | "comment";
-
-/** GitHub pull request review event (API names; ready for a later post path). */
-export type ReviewEvent = "COMMENT" | "APPROVE" | "REQUEST_CHANGES";
 
 /** Summary body + event chosen in the Submit Review modal. */
 export interface ReviewSubmission {

--- a/src/content/overlay/components/ConnectGitHubModal.test.tsx
+++ b/src/content/overlay/components/ConnectGitHubModal.test.tsx
@@ -1,0 +1,188 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConnectGitHubModal } from "./ConnectGitHubModal";
+import * as messaging from "../../../lib/messaging";
+import * as oauthConfig from "../../../lib/github/oauthConfig";
+import * as deviceAuth from "../../../lib/github/useGitHubDeviceAuth";
+
+vi.mock("../../../lib/messaging", () => ({
+  startGitHubDeviceAuth: vi.fn(),
+  pollGitHubDeviceAuth: vi.fn(),
+}));
+
+vi.mock("../../../lib/github/oauthConfig", () => ({
+  isGitHubOAuthConfigured: vi.fn(() => true),
+}));
+
+const DEVICE_START = {
+  ok: true as const,
+  userCode: "WDJB-MJHT",
+  verificationUri: "https://github.com/login/device",
+  deviceCode: "device-1",
+  interval: 60,
+  expiresIn: 900,
+};
+
+async function startAwaitingFlow(user: ReturnType<typeof userEvent.setup>) {
+  vi.mocked(messaging.startGitHubDeviceAuth).mockResolvedValue(DEVICE_START);
+  vi.mocked(messaging.pollGitHubDeviceAuth).mockResolvedValue({
+    ok: true,
+    status: "pending",
+  });
+
+  render(
+    <ConnectGitHubModal open onClose={vi.fn()} onAuthenticated={vi.fn()} />,
+  );
+  await user.click(screen.getByTestId("connect-github-connect"));
+  expect(await screen.findByTestId("connect-github-user-code")).toHaveTextContent(
+    "WDJB-MJHT",
+  );
+}
+
+describe("ConnectGitHubModal", () => {
+  let openVerificationUriSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.mocked(oauthConfig.isGitHubOAuthConfigured).mockReturnValue(true);
+    vi.mocked(messaging.startGitHubDeviceAuth).mockReset();
+    vi.mocked(messaging.pollGitHubDeviceAuth).mockReset();
+    openVerificationUriSpy = vi
+      .spyOn(deviceAuth, "openVerificationUri")
+      .mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    openVerificationUriSpy.mockRestore();
+  });
+
+  it("renders nothing when closed", () => {
+    const { container } = render(
+      <ConnectGitHubModal open={false} onClose={vi.fn()} onAuthenticated={vi.fn()} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the auth prompt, brand logo, and Connect button with Enter hint", () => {
+    render(
+      <ConnectGitHubModal open onClose={vi.fn()} onAuthenticated={vi.fn()} />,
+    );
+
+    expect(screen.getByTestId("connect-github-modal")).toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: "Connect GitHub" })).toBeInTheDocument();
+    expect(screen.getByTestId("connect-github-logo")).toBeInTheDocument();
+    expect(screen.getByTestId("connect-github-prompt")).toHaveTextContent(
+      /authenticate via GitHub to submit your reviews/i,
+    );
+    const connect = screen.getByTestId("connect-github-connect");
+    expect(connect).toBeInTheDocument();
+    expect(connect).toHaveTextContent(/Connect GitHub/);
+    expect(connect.querySelector("kbd")).toHaveTextContent("Enter");
+  });
+
+  it("shows a setup message when OAuth is not configured", () => {
+    vi.mocked(oauthConfig.isGitHubOAuthConfigured).mockReturnValue(false);
+    render(
+      <ConnectGitHubModal open onClose={vi.fn()} onAuthenticated={vi.fn()} />,
+    );
+
+    expect(screen.getByText(/isn’t configured in this build/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /connect github/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("starts device flow, shows the user code, and does not open GitHub yet", async () => {
+    const user = userEvent.setup();
+    await startAwaitingFlow(user);
+
+    expect(screen.getByText(/Waiting for authorization/i)).toBeInTheDocument();
+    expect(screen.getByTestId("connect-github-copy-hint")).toHaveTextContent(
+      /Copy this code, then paste it on the GitHub tab/i,
+    );
+    expect(screen.getByTestId("connect-github-enter-code")).toHaveTextContent(
+      /Enter Code On Github/,
+    );
+    expect(
+      screen.getByTestId("connect-github-enter-code").querySelector("kbd"),
+    ).toHaveTextContent("Enter");
+    expect(openVerificationUriSpy).not.toHaveBeenCalled();
+  });
+
+  it("opens GitHub when Enter Code On Github is clicked", async () => {
+    const user = userEvent.setup();
+    await startAwaitingFlow(user);
+
+    await user.click(screen.getByTestId("connect-github-enter-code"));
+    expect(openVerificationUriSpy).toHaveBeenCalledTimes(1);
+    expect(openVerificationUriSpy).toHaveBeenCalledWith(
+      "https://github.com/login/device",
+    );
+  });
+
+  it("calls onAuthenticated after a successful poll", async () => {
+    const user = userEvent.setup();
+    const onAuthenticated = vi.fn();
+
+    vi.mocked(messaging.startGitHubDeviceAuth).mockResolvedValue({
+      ok: true,
+      userCode: "ABCD-EFGH",
+      verificationUri: "https://github.com/login/device",
+      deviceCode: "device-2",
+      interval: 0,
+      expiresIn: 900,
+    });
+    vi.mocked(messaging.pollGitHubDeviceAuth).mockResolvedValue({
+      ok: true,
+      status: "authorized",
+      auth: {
+        accessToken: "gho_ok",
+        tokenType: "bearer",
+        scope: "repo,read:user",
+        login: "monalisa",
+      },
+    });
+
+    render(
+      <ConnectGitHubModal
+        open
+        onClose={vi.fn()}
+        onAuthenticated={onAuthenticated}
+      />,
+    );
+    await user.click(screen.getByTestId("connect-github-connect"));
+
+    await waitFor(() => {
+      expect(onAuthenticated).toHaveBeenCalled();
+    });
+  });
+
+  it("shows an error and allows retry", async () => {
+    const user = userEvent.setup();
+    vi.mocked(messaging.startGitHubDeviceAuth).mockResolvedValueOnce({
+      ok: false,
+      error: "Device code request failed.",
+    });
+
+    render(
+      <ConnectGitHubModal open onClose={vi.fn()} onAuthenticated={vi.fn()} />,
+    );
+    await user.click(screen.getByTestId("connect-github-connect"));
+
+    expect(await screen.findByTestId("connect-github-error")).toHaveTextContent(
+      /Device code request failed/i,
+    );
+    expect(screen.getByTestId("connect-github-retry")).toBeInTheDocument();
+  });
+
+  it("calls onClose when Cancel is clicked", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <ConnectGitHubModal open onClose={onClose} onAuthenticated={vi.fn()} />,
+    );
+
+    await user.click(screen.getByTestId("connect-github-cancel"));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/content/overlay/components/ConnectGitHubModal.tsx
+++ b/src/content/overlay/components/ConnectGitHubModal.tsx
@@ -1,0 +1,331 @@
+import {
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type MutableRefObject,
+} from "react";
+import { isGitHubOAuthConfigured } from "../../../lib/github/oauthConfig";
+import {
+  openVerificationUri,
+  useGitHubDeviceAuth,
+} from "../../../lib/github/useGitHubDeviceAuth";
+import { Kbd } from "./Kbd";
+import { Spinner } from "./Spinner";
+
+export interface ConnectGitHubModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** Fired after device flow succeeds and the token is stored in the background. */
+  onAuthenticated: () => void;
+  /**
+   * Bound to the latest primary action (Connect / Try again / open GitHub) so
+   * the overlay capture keydown can fire Enter without relying on element React handlers.
+   */
+  connectActionRef?: MutableRefObject<(() => void) | null>;
+}
+
+const primaryBtn =
+  "inline-flex cursor-pointer items-center gap-2 rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-[13px] font-medium text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover disabled:cursor-not-allowed disabled:opacity-60 [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit";
+
+const secondaryBtn =
+  "inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-[13px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text disabled:cursor-not-allowed disabled:opacity-50";
+
+/** Official GitHub mark (Octocat) — filled via currentColor. */
+function GitHubLogo({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      width="40"
+      height="40"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      data-testid="connect-github-logo"
+    >
+      <path
+        fillRule="evenodd"
+        d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Prompt + device OAuth flow when the user tries to submit a review without a
+ * stored GitHub token. On success, parent closes this and opens Submit Review.
+ */
+export function ConnectGitHubModal({
+  open,
+  onClose,
+  onAuthenticated,
+  connectActionRef,
+}: ConnectGitHubModalProps) {
+  const titleId = useId();
+  const configured = isGitHubOAuthConfigured();
+  const [copied, setCopied] = useState(false);
+  const connectButtonRef = useRef<HTMLButtonElement>(null);
+
+  const { flow, busy, startConnect, cancel, reset } = useGitHubDeviceAuth({
+    enabled: configured && open,
+    onAuthorized: () => {
+      onAuthenticated();
+    },
+  });
+
+  // Reset flow when the modal closes so a later open starts at the prompt.
+  useEffect(() => {
+    if (!open) {
+      reset();
+      setCopied(false);
+    }
+  }, [open, reset]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (flow.kind === "idle" && !busy) {
+      connectButtonRef.current?.focus();
+    }
+  }, [open, flow.kind, busy]);
+
+  const canStartConnect =
+    configured && !busy && (flow.kind === "idle" || flow.kind === "error");
+  const awaitingUri =
+    flow.kind === "awaiting" ? flow.verificationUri : null;
+
+  useEffect(() => {
+    if (!connectActionRef) return;
+    if (!open) {
+      connectActionRef.current = null;
+      return;
+    }
+    if (canStartConnect) {
+      connectActionRef.current = () => {
+        void startConnect();
+      };
+      return () => {
+        connectActionRef.current = null;
+      };
+    }
+    if (awaitingUri) {
+      connectActionRef.current = () => {
+        void openVerificationUri(awaitingUri);
+      };
+      return () => {
+        connectActionRef.current = null;
+      };
+    }
+    connectActionRef.current = null;
+    return () => {
+      connectActionRef.current = null;
+    };
+  }, [open, canStartConnect, awaitingUri, startConnect, connectActionRef]);
+
+  if (!open) return null;
+
+  const onCancel = () => {
+    cancel();
+    setCopied(false);
+    onClose();
+  };
+
+  const onCopyCode = async (code: string) => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <div
+      className="absolute inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      data-testid="connect-github-scrim"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !busy && flow.kind !== "awaiting") {
+          onClose();
+        }
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        data-testid="connect-github-modal"
+        data-flow={flow.kind}
+        className="flex w-full max-w-[480px] flex-col rounded-lg border border-gr-border bg-gr-chrome shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-end border-b border-gr-border px-4 py-3">
+          <button
+            type="button"
+            className="inline-flex cursor-pointer items-center justify-center rounded-md border border-gr-border bg-gr-bg p-1.5 text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+            onClick={onCancel}
+            aria-label="Close"
+            data-testid="connect-github-close"
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 16 16"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+            >
+              <path
+                d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div className="flex flex-col items-center gap-4 px-6 py-6 text-center">
+          <div
+            className="flex h-16 w-16 items-center justify-center rounded-full bg-gr-accent-subtle text-gr-accent"
+            aria-hidden="true"
+          >
+            <GitHubLogo />
+          </div>
+
+          <h2
+            id={titleId}
+            className="m-0 w-full text-center text-[16px] font-semibold text-gr-text"
+          >
+            Connect GitHub
+          </h2>
+
+          {!configured ? (
+            <p
+              className="m-0 w-full text-center text-[13px] leading-relaxed text-gr-muted"
+              role="status"
+            >
+              GitHub connection isn’t configured in this build. Set{" "}
+              <code className="rounded bg-gr-bg px-1 py-0.5 text-[12px] text-gr-text">
+                VITE_GITHUB_CLIENT_ID
+              </code>{" "}
+              and rebuild.
+            </p>
+          ) : flow.kind === "error" ? (
+            <p
+              className="m-0 w-full rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-left text-[13px] leading-snug text-red-200"
+              role="alert"
+              data-testid="connect-github-error"
+            >
+              {flow.message}
+            </p>
+          ) : flow.kind === "awaiting" ? (
+            <div
+              className="w-full space-y-3 text-left"
+              data-testid="connect-github-awaiting"
+            >
+              <div className="flex flex-wrap items-center justify-center gap-2 my-4">
+                <code
+                  className="rounded-md border border-gr-border bg-gr-bg px-3 py-2 font-mono text-lg tracking-widest text-gr-text"
+                  data-testid="connect-github-user-code"
+                >
+                  {flow.userCode}
+                </code>
+                <button
+                  type="button"
+                  className={secondaryBtn}
+                  onClick={() => void onCopyCode(flow.userCode)}
+                  data-testid="connect-github-copy-code"
+                >
+                  {copied ? "Copied" : "Copy code"}
+                </button>
+              </div>
+              <p
+                className="m-0 text-center text-[13px] leading-relaxed text-gr-muted"
+                data-testid="connect-github-copy-hint"
+              >
+                Copy this code, then paste it on the GitHub tab.
+              </p>
+              <span
+                className="flex items-center justify-center gap-2 text-[13px] text-gr-muted"
+                role="status"
+              >
+                <Spinner label="Waiting for GitHub authorization" size={16} />
+                Waiting for authorization…
+              </span>
+            </div>
+          ) : (
+            <p
+              className="m-0 w-full text-center text-[13.5px] leading-relaxed text-gr-muted"
+              data-testid="connect-github-prompt"
+            >
+              You need to authenticate via GitHub to submit your reviews.
+            </p>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 border-t border-gr-border px-4 py-3">
+          <button
+            type="button"
+            className={secondaryBtn}
+            onClick={onCancel}
+            data-testid="connect-github-cancel"
+          >
+            Cancel
+            <Kbd>Esc</Kbd>
+          </button>
+          {configured && flow.kind === "error" ? (
+            <button
+              type="button"
+              className={primaryBtn}
+              onClick={() => void startConnect()}
+              disabled={busy}
+              data-testid="connect-github-retry"
+            >
+              {busy ? (
+                <>
+                  <Spinner label="Connecting to GitHub" size={14} />
+                  Connecting…
+                </>
+              ) : (
+                <>
+                  Try again
+                  <Kbd>Enter</Kbd>
+                </>
+              )}
+            </button>
+          ) : configured && flow.kind === "awaiting" ? (
+            <button
+              type="button"
+              className={primaryBtn}
+              onClick={() => void openVerificationUri(flow.verificationUri)}
+              data-testid="connect-github-enter-code"
+            >
+              Enter Code On Github
+              <Kbd>Enter</Kbd>
+            </button>
+          ) : configured ? (
+            <button
+              ref={connectButtonRef}
+              type="button"
+              className={primaryBtn}
+              onClick={() => void startConnect()}
+              disabled={busy}
+              data-testid="connect-github-connect"
+            >
+              {busy ? (
+                <>
+                  <Spinner label="Connecting to GitHub" size={14} />
+                  Connecting…
+                </>
+              ) : (
+                <>
+                  Connect GitHub
+                  <Kbd>Enter</Kbd>
+                </>
+              )}
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/content/overlay/components/ReviewSubmittedModal.test.tsx
+++ b/src/content/overlay/components/ReviewSubmittedModal.test.tsx
@@ -1,0 +1,147 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ReviewSubmittedModal } from "./ReviewSubmittedModal";
+
+describe("ReviewSubmittedModal", () => {
+  it("renders nothing when closed", () => {
+    const { container } = render(
+      <ReviewSubmittedModal
+        open={false}
+        event="APPROVE"
+        commentCount={0}
+        onExit={vi.fn()}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the success title and check icon", () => {
+    render(
+      <ReviewSubmittedModal
+        open
+        event="APPROVE"
+        commentCount={0}
+        onExit={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("dialog", { name: "Review submitted successfully" }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("review-submitted-icon")).toBeInTheDocument();
+    expect(screen.getByTestId("review-submitted-modal")).toHaveAttribute(
+      "data-event",
+      "APPROVE",
+    );
+  });
+
+  it("summarizes an approval without line comments", () => {
+    render(
+      <ReviewSubmittedModal
+        open
+        event="APPROVE"
+        commentCount={0}
+        onExit={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("review-submitted-summary")).toHaveTextContent(
+      "You approved this pull request.",
+    );
+  });
+
+  it("summarizes approval with a singular comment count", () => {
+    render(
+      <ReviewSubmittedModal
+        open
+        event="APPROVE"
+        commentCount={1}
+        onExit={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("review-submitted-summary")).toHaveTextContent(
+      "You approved this pull request and left 1 comment.",
+    );
+  });
+
+  it("summarizes a comment review with plural comments", () => {
+    render(
+      <ReviewSubmittedModal
+        open
+        event="COMMENT"
+        commentCount={3}
+        onExit={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("review-submitted-summary")).toHaveTextContent(
+      "You submitted a comment review and left 3 comments.",
+    );
+  });
+
+  it("summarizes requested changes without comments", () => {
+    render(
+      <ReviewSubmittedModal
+        open
+        event="REQUEST_CHANGES"
+        commentCount={0}
+        onExit={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("review-submitted-summary")).toHaveTextContent(
+      "You requested changes.",
+    );
+  });
+
+  it("summarizes requested changes with comments", () => {
+    render(
+      <ReviewSubmittedModal
+        open
+        event="REQUEST_CHANGES"
+        commentCount={2}
+        onExit={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("review-submitted-summary")).toHaveTextContent(
+      "You requested changes and left 2 comments.",
+    );
+  });
+
+  it("calls onExit from the primary button", () => {
+    const onExit = vi.fn();
+    render(
+      <ReviewSubmittedModal
+        open
+        event="APPROVE"
+        commentCount={0}
+        onExit={onExit}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("review-submitted-exit"));
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it("focuses the exit button when opened", () => {
+    render(
+      <ReviewSubmittedModal
+        open
+        event="APPROVE"
+        commentCount={0}
+        onExit={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("review-submitted-exit")).toHaveFocus();
+  });
+
+  it("does not call onExit when clicking the scrim", () => {
+    const onExit = vi.fn();
+    render(
+      <ReviewSubmittedModal
+        open
+        event="APPROVE"
+        commentCount={0}
+        onExit={onExit}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("review-submitted-scrim"));
+    expect(onExit).not.toHaveBeenCalled();
+  });
+});

--- a/src/content/overlay/components/ReviewSubmittedModal.tsx
+++ b/src/content/overlay/components/ReviewSubmittedModal.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useId, useRef } from "react";
+import type { ReviewEvent } from "../commentTypes";
+import { Kbd } from "./Kbd";
+
+export interface ReviewSubmittedModalProps {
+  open: boolean;
+  event: ReviewEvent;
+  /** Number of line comments included in the submitted review. */
+  commentCount: number;
+  onExit: () => void;
+}
+
+function eventSummary(event: ReviewEvent, commentCount: number): string {
+  const commentClause =
+    commentCount > 0
+      ? ` and left ${commentCount} comment${commentCount === 1 ? "" : "s"}`
+      : "";
+
+  switch (event) {
+    case "APPROVE":
+      return `You approved this pull request${commentClause}.`;
+    case "REQUEST_CHANGES":
+      return `You requested changes${commentClause}.`;
+    case "COMMENT":
+    default:
+      return `You submitted a comment review${commentClause}.`;
+  }
+}
+
+/**
+ * Post-submit confirmation: success icon, what was submitted, single exit CTA.
+ */
+export function ReviewSubmittedModal({
+  open,
+  event,
+  commentCount,
+  onExit,
+}: ReviewSubmittedModalProps) {
+  const titleId = useId();
+  const exitButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    exitButtonRef.current?.focus();
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="absolute inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      data-testid="review-submitted-scrim"
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        data-testid="review-submitted-modal"
+        data-event={event}
+        data-comment-count={commentCount}
+        className="flex w-full max-w-[420px] flex-col items-center rounded-lg border border-gr-border bg-gr-chrome px-6 py-8 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div
+          className="mb-5 flex h-14 w-14 items-center justify-center rounded-full bg-gr-accent text-gr-accent-on"
+          data-testid="review-submitted-icon"
+          aria-hidden="true"
+        >
+          <svg
+            width="28"
+            height="28"
+            viewBox="0 0 16 16"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 0 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+
+        <h2
+          id={titleId}
+          className="m-0 text-center text-[16px] font-semibold text-gr-text"
+        >
+          Review submitted successfully
+        </h2>
+
+        <p
+          className="mt-2 mb-0 text-center text-[13.5px] leading-relaxed text-gr-muted"
+          data-testid="review-submitted-summary"
+        >
+          {eventSummary(event, commentCount)}
+        </p>
+
+        <button
+          ref={exitButtonRef}
+          type="button"
+          className="mt-7 inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-4 py-2 text-[13px] font-medium text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
+          onClick={onExit}
+          data-testid="review-submitted-exit"
+        >
+          Exit Guided Review
+          <Kbd>Enter</Kbd>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/content/overlay/components/SubmitReviewModal.test.tsx
+++ b/src/content/overlay/components/SubmitReviewModal.test.tsx
@@ -270,6 +270,30 @@ describe("SubmitReviewModal", () => {
     expect(screen.queryByRole("radio")).not.toBeInTheDocument();
   });
 
+  it("shows an error and disables submit while submitting", () => {
+    const onSubmit = vi.fn();
+    render(
+      <SubmitReviewModal
+        open
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+        submitting
+        error="Connect GitHub first."
+      />,
+    );
+
+    selectCommentAndCompose();
+    expect(screen.getByTestId("submit-review-error")).toHaveTextContent(
+      "Connect GitHub first.",
+    );
+    expect(screen.getByTestId("submit-review-confirm")).toBeDisabled();
+    expect(screen.getByTestId("submit-review-confirm")).toHaveTextContent(
+      "Submitting…",
+    );
+    fireEvent.click(screen.getByTestId("submit-review-confirm"));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
   it("resets to choose step when reopened", () => {
     const { rerender } = render(
       <SubmitReviewModal open onClose={vi.fn()} onSubmit={vi.fn()} />,

--- a/src/content/overlay/components/SubmitReviewModal.tsx
+++ b/src/content/overlay/components/SubmitReviewModal.tsx
@@ -14,6 +14,10 @@ interface SubmitReviewModalProps {
   open: boolean;
   onClose: () => void;
   onSubmit: (submission: ReviewSubmission) => void;
+  /** True while the GitHub API request is in flight. */
+  submitting?: boolean;
+  /** User-facing error from the last submit attempt. */
+  error?: string | null;
   /**
    * Bound to the latest submit action so the overlay capture keydown can
    * fire ⌘/Ctrl+Enter (React handlers on the textarea do not see real keys
@@ -58,12 +62,14 @@ function eventIndex(event: ReviewEvent): number {
 
 /**
  * GitHub-style submit-review dialog: pick event type, then summary comment.
- * UI only — parent decides what to do with the submission (API later).
+ * Parent posts the submission to GitHub via the background worker.
  */
 export function SubmitReviewModal({
   open,
   onClose,
   onSubmit,
+  submitting = false,
+  error = null,
   submitActionRef,
   keyActionRef,
 }: SubmitReviewModalProps) {
@@ -114,10 +120,10 @@ export function SubmitReviewModal({
   }, [open, step]);
 
   // Keep the overlay capture path pointed at the current form values.
-  // Submit only available on the compose step.
+  // Submit only available on the compose step while not in-flight.
   useEffect(() => {
     if (!submitActionRef) return;
-    if (!open || step !== "compose") {
+    if (!open || step !== "compose" || submitting) {
       submitActionRef.current = null;
       return;
     }
@@ -125,7 +131,7 @@ export function SubmitReviewModal({
     return () => {
       submitActionRef.current = null;
     };
-  }, [open, step, body, event, onSubmit, submitActionRef]);
+  }, [open, step, body, event, onSubmit, submitActionRef, submitting]);
 
   // Choose-step keys via overlay capture (real keystrokes never reach React handlers).
   // highlightIndexRef keeps Enter accurate across sequential keys before re-render.
@@ -162,6 +168,7 @@ export function SubmitReviewModal({
   if (!open) return null;
 
   function handleSubmit(): void {
+    if (submitting) return;
     onSubmit({ body, event });
   }
 
@@ -169,7 +176,7 @@ export function SubmitReviewModal({
     if (e.key === "Escape") {
       e.preventDefault();
       e.stopPropagation();
-      onClose();
+      if (!submitting) onClose();
       return;
     }
     if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
@@ -219,7 +226,7 @@ export function SubmitReviewModal({
       className="absolute inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
       data-testid="submit-review-scrim"
       onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
+        if (e.target === e.currentTarget && !submitting) onClose();
       }}
     >
       <div
@@ -237,8 +244,9 @@ export function SubmitReviewModal({
           </h2>
           <button
             type="button"
-            className="inline-flex cursor-pointer items-center justify-center rounded-md border border-gr-border bg-gr-bg p-1.5 text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+            className="inline-flex cursor-pointer items-center justify-center rounded-md border border-gr-border bg-gr-bg p-1.5 text-gr-muted hover:bg-gr-subtle hover:text-gr-text disabled:cursor-not-allowed disabled:opacity-50"
             onClick={onClose}
+            disabled={submitting}
             aria-label="Close"
             data-testid="submit-review-close"
           >
@@ -330,11 +338,12 @@ export function SubmitReviewModal({
             <div className="flex flex-col gap-4 px-4 py-4">
               <textarea
                 ref={textareaRef}
-                className="min-h-[100px] w-full resize-y rounded-md border border-gr-border bg-gr-bg px-3 py-2 font-sans text-[14px] leading-relaxed text-gr-text outline-none placeholder:text-gr-faint focus:border-gr-accent"
+                className="min-h-[100px] w-full resize-y rounded-md border border-gr-border bg-gr-bg px-3 py-2 font-sans text-[14px] leading-relaxed text-gr-text outline-none placeholder:text-gr-faint focus:border-gr-accent disabled:opacity-60"
                 placeholder="Leave a comment"
                 value={body}
                 onChange={(e) => setBody(e.target.value)}
                 onKeyDown={handleTextareaKeyDown}
+                disabled={submitting}
                 aria-label="Review comment"
                 data-testid="submit-review-body"
               />
@@ -351,13 +360,24 @@ export function SubmitReviewModal({
                   {selectedOpt.description}
                 </div>
               </div>
+
+              {error ? (
+                <p
+                  className="m-0 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-[13px] leading-snug text-red-200"
+                  role="alert"
+                  data-testid="submit-review-error"
+                >
+                  {error}
+                </p>
+              ) : null}
             </div>
 
             <div className="flex items-center justify-between gap-2 border-t border-gr-border px-4 py-3">
               <button
                 type="button"
-                className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-[13px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+                className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-[13px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text disabled:cursor-not-allowed disabled:opacity-50"
                 onClick={goBack}
+                disabled={submitting}
                 data-testid="submit-review-back"
               >
                 Back
@@ -365,8 +385,9 @@ export function SubmitReviewModal({
               <div className="flex items-center gap-2">
                 <button
                   type="button"
-                  className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-[13px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+                  className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-[13px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text disabled:cursor-not-allowed disabled:opacity-50"
                   onClick={onClose}
+                  disabled={submitting}
                   data-testid="submit-review-cancel"
                 >
                   Cancel
@@ -374,12 +395,13 @@ export function SubmitReviewModal({
                 </button>
                 <button
                   type="button"
-                  className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-[13px] font-medium text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
+                  className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-[13px] font-medium text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover disabled:cursor-not-allowed disabled:opacity-60 [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
                   onClick={handleSubmit}
+                  disabled={submitting}
                   data-testid="submit-review-confirm"
                 >
-                  Submit Review
-                  <ModEnterChord />
+                  {submitting ? "Submitting…" : "Submit Review"}
+                  {!submitting ? <ModEnterChord /> : null}
                 </button>
               </div>
             </div>

--- a/src/content/overlay/mapDraftComments.test.ts
+++ b/src/content/overlay/mapDraftComments.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { DraftComment } from "./commentTypes";
+import { mapDraftsToReviewComments } from "./mapDraftComments";
+
+const base: Omit<DraftComment, "startLine" | "endLine" | "side"> = {
+  id: "d1",
+  filePath: "src/app.ts",
+  lineIds: ["h#0:1:RIGHT"],
+  body: "Looks off",
+};
+
+describe("mapDraftsToReviewComments", () => {
+  it("maps a single-line comment without start_line fields", () => {
+    const drafts: DraftComment[] = [
+      { ...base, side: "RIGHT", startLine: 10, endLine: 10 },
+    ];
+    expect(mapDraftsToReviewComments(drafts)).toEqual([
+      {
+        path: "src/app.ts",
+        body: "Looks off",
+        side: "RIGHT",
+        line: 10,
+      },
+    ]);
+  });
+
+  it("maps a multi-line range with startLine and startSide", () => {
+    const drafts: DraftComment[] = [
+      {
+        ...base,
+        id: "d2",
+        side: "LEFT",
+        startLine: 3,
+        endLine: 7,
+        body: "Range",
+      },
+    ];
+    expect(mapDraftsToReviewComments(drafts)).toEqual([
+      {
+        path: "src/app.ts",
+        body: "Range",
+        side: "LEFT",
+        line: 7,
+        startLine: 3,
+        startSide: "LEFT",
+      },
+    ]);
+  });
+
+  it("returns an empty list for no drafts", () => {
+    expect(mapDraftsToReviewComments([])).toEqual([]);
+  });
+});

--- a/src/content/overlay/mapDraftComments.ts
+++ b/src/content/overlay/mapDraftComments.ts
@@ -1,0 +1,21 @@
+import type { ReviewCommentInput } from "../../lib/types";
+import type { DraftComment } from "./commentTypes";
+
+/** Map local draft comments to GitHub create-review `comments[]` payloads. */
+export function mapDraftsToReviewComments(
+  drafts: DraftComment[],
+): ReviewCommentInput[] {
+  return drafts.map((draft) => {
+    const comment: ReviewCommentInput = {
+      path: draft.filePath,
+      body: draft.body,
+      side: draft.side,
+      line: draft.endLine,
+    };
+    if (draft.startLine !== draft.endLine) {
+      comment.startLine = draft.startLine;
+      comment.startSide = draft.side;
+    }
+    return comment;
+  });
+}

--- a/src/content/overlay/prConversationUrl.test.ts
+++ b/src/content/overlay/prConversationUrl.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  isPrConversationPath,
+  navigateToPrConversation,
+  prConversationUrl,
+} from "./prConversationUrl";
+
+describe("prConversationUrl", () => {
+  it("builds the conversation URL", () => {
+    expect(prConversationUrl({ owner: "acme", repo: "widgets", number: 42 })).toBe(
+      "https://github.com/acme/widgets/pull/42",
+    );
+  });
+});
+
+describe("isPrConversationPath", () => {
+  const pr = { owner: "acme", repo: "widgets", number: 1 };
+
+  it("matches the conversation path", () => {
+    expect(isPrConversationPath("/acme/widgets/pull/1", pr)).toBe(true);
+    expect(isPrConversationPath("/acme/widgets/pull/1/", pr)).toBe(true);
+  });
+
+  it("rejects other PR tabs", () => {
+    expect(isPrConversationPath("/acme/widgets/pull/1/files", pr)).toBe(false);
+    expect(isPrConversationPath("/acme/widgets/pull/1/commits", pr)).toBe(false);
+    expect(isPrConversationPath("/acme/widgets/pull/1/checks", pr)).toBe(false);
+  });
+
+  it("rejects other PRs", () => {
+    expect(isPrConversationPath("/acme/widgets/pull/2", pr)).toBe(false);
+    expect(isPrConversationPath("/other/widgets/pull/1", pr)).toBe(false);
+  });
+});
+
+describe("navigateToPrConversation", () => {
+  const originalLocation = window.location;
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("does not navigate when already on the conversation tab", () => {
+    const assign = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { pathname: "/acme/widgets/pull/1", assign },
+    });
+    navigateToPrConversation({ owner: "acme", repo: "widgets", number: 1 });
+    expect(assign).not.toHaveBeenCalled();
+  });
+
+  it("navigates from the files tab", () => {
+    const assign = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { pathname: "/acme/widgets/pull/1/files", assign },
+    });
+    navigateToPrConversation({ owner: "acme", repo: "widgets", number: 1 });
+    expect(assign).toHaveBeenCalledWith(
+      "https://github.com/acme/widgets/pull/1",
+    );
+  });
+});

--- a/src/content/overlay/prConversationUrl.ts
+++ b/src/content/overlay/prConversationUrl.ts
@@ -1,0 +1,35 @@
+/** Conversation (default) tab URL for a PR. */
+export function prConversationUrl(pr: {
+  owner: string;
+  repo: string;
+  number: number;
+}): string {
+  return `https://github.com/${pr.owner}/${pr.repo}/pull/${pr.number}`;
+}
+
+/**
+ * True when `pathname` is already the PR conversation tab
+ * (not /files, /commits, /checks, etc.).
+ */
+export function isPrConversationPath(
+  pathname: string,
+  pr: { owner: string; repo: string; number: number },
+): boolean {
+  const normalized = pathname.replace(/\/+$/, "") || "/";
+  const expected = `/${pr.owner}/${pr.repo}/pull/${pr.number}`;
+  return normalized === expected;
+}
+
+/**
+ * Navigate to the conversation tab if the user is on another PR tab.
+ * No-op when already on conversation. Uses a full navigation so GitHub's
+ * SPA shell reliably shows the default PR surface after overlay exit.
+ */
+export function navigateToPrConversation(pr: {
+  owner: string;
+  repo: string;
+  number: number;
+}): void {
+  if (isPrConversationPath(window.location.pathname, pr)) return;
+  window.location.assign(prConversationUrl(pr));
+}

--- a/src/content/overlay/store.test.ts
+++ b/src/content/overlay/store.test.ts
@@ -503,6 +503,11 @@ describe("useReviewStore", () => {
 
       useReviewStore.getState().removeDraftComment(drafts[0].id);
       expect(useReviewStore.getState().draftComments).toHaveLength(0);
+
+      useReviewStore.getState().saveDraftComment("again");
+      expect(useReviewStore.getState().draftComments).toHaveLength(1);
+      useReviewStore.getState().clearDraftComments();
+      expect(useReviewStore.getState().draftComments).toHaveLength(0);
     });
 
     it("goNext / goToUnit exit comment mode but keep drafts", () => {

--- a/src/content/overlay/store.ts
+++ b/src/content/overlay/store.ts
@@ -115,6 +115,7 @@ interface ReviewState {
   saveDraftComment: (body: string, unitId?: string) => void;
   updateDraftComment: (id: string, body: string) => void;
   removeDraftComment: (id: string) => void;
+  clearDraftComments: () => void;
 }
 
 /**
@@ -409,6 +410,8 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
       draftComments: state.draftComments.filter((d) => d.id !== id),
     }));
   },
+
+  clearDraftComments: () => set({ draftComments: [] }),
 }));
 
 /** Bumped when the user sets a mode so pending storage reads are dropped. */

--- a/src/lib/github/authStorage.test.ts
+++ b/src/lib/github/authStorage.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { clearGitHubAuth, getGitHubAuth, setGitHubAuth } from "./authStorage";
+import type { GitHubAuthState } from "../types";
+
+const sample: GitHubAuthState = {
+  accessToken: "gho_test",
+  tokenType: "bearer",
+  scope: "repo,read:user",
+  login: "octocat",
+  avatarUrl: "https://avatars.example/o",
+  name: "Octocat",
+};
+
+describe("authStorage", () => {
+  it("returns null when nothing is stored", async () => {
+    await expect(getGitHubAuth()).resolves.toBeNull();
+  });
+
+  it("round-trips a full auth state", async () => {
+    await setGitHubAuth(sample);
+    await expect(getGitHubAuth()).resolves.toEqual(sample);
+  });
+
+  it("clears stored auth", async () => {
+    await setGitHubAuth(sample);
+    await clearGitHubAuth();
+    await expect(getGitHubAuth()).resolves.toBeNull();
+  });
+
+  it("ignores invalid stored shapes", async () => {
+    await chrome.storage.local.set({
+      "guidedReview.githubAuth": { accessToken: "x" },
+    });
+    await expect(getGitHubAuth()).resolves.toBeNull();
+  });
+});

--- a/src/lib/github/authStorage.ts
+++ b/src/lib/github/authStorage.ts
@@ -1,0 +1,39 @@
+import type { GitHubAuthState } from "../types";
+
+const STORAGE_KEY = "guidedReview.githubAuth";
+
+function isGitHubAuthState(value: unknown): value is GitHubAuthState {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.accessToken === "string" &&
+    v.accessToken.length > 0 &&
+    typeof v.tokenType === "string" &&
+    typeof v.scope === "string" &&
+    typeof v.login === "string" &&
+    v.login.length > 0
+  );
+}
+
+/** Read the stored GitHub OAuth session, or null if none / invalid. */
+export async function getGitHubAuth(): Promise<GitHubAuthState | null> {
+  const result = await chrome.storage.local.get(STORAGE_KEY);
+  const stored = result[STORAGE_KEY];
+  if (!isGitHubAuthState(stored)) return null;
+  return {
+    accessToken: stored.accessToken,
+    tokenType: stored.tokenType,
+    scope: stored.scope,
+    login: stored.login,
+    ...(typeof stored.avatarUrl === "string" ? { avatarUrl: stored.avatarUrl } : {}),
+    ...(typeof stored.name === "string" ? { name: stored.name } : {}),
+  };
+}
+
+export async function setGitHubAuth(auth: GitHubAuthState): Promise<void> {
+  await chrome.storage.local.set({ [STORAGE_KEY]: auth });
+}
+
+export async function clearGitHubAuth(): Promise<void> {
+  await chrome.storage.local.remove(STORAGE_KEY);
+}

--- a/src/lib/github/deviceOAuth.test.ts
+++ b/src/lib/github/deviceOAuth.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchGitHubUser, pollAccessToken, requestDeviceCode } from "./deviceOAuth";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("requestDeviceCode", () => {
+  it("posts client_id and scope and maps a successful response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        device_code: "device-abc",
+        user_code: "WDJB-MJHT",
+        verification_uri: "https://github.com/login/device",
+        expires_in: 900,
+        interval: 5,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await requestDeviceCode("client-123", "repo read:user");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://github.com/login/device/code",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ client_id: "client-123", scope: "repo read:user" }),
+      }),
+    );
+    expect(result).toEqual({
+      deviceCode: "device-abc",
+      userCode: "WDJB-MJHT",
+      verificationUri: "https://github.com/login/device",
+      expiresIn: 900,
+      interval: 5,
+    });
+  });
+
+  it("throws a user-facing error on HTTP failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse({ error: "incorrect_client_credentials", error_description: "Bad client" }, 401),
+      ),
+    );
+
+    await expect(requestDeviceCode("bad", "repo")).rejects.toThrow(/Bad client/);
+  });
+
+  it("throws on incomplete success payloads", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ device_code: "only" })));
+
+    await expect(requestDeviceCode("c", "repo")).rejects.toThrow(/incomplete/i);
+  });
+});
+
+describe("pollAccessToken", () => {
+  it("returns authorized when access_token is present", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse({
+          access_token: "gho_token",
+          token_type: "bearer",
+          scope: "repo,read:user",
+        }),
+      ),
+    );
+
+    await expect(pollAccessToken("client", "device")).resolves.toEqual({
+      status: "authorized",
+      accessToken: "gho_token",
+      tokenType: "bearer",
+      scope: "repo,read:user",
+    });
+  });
+
+  it("maps authorization_pending", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ error: "authorization_pending" })),
+    );
+
+    await expect(pollAccessToken("c", "d")).resolves.toEqual({ status: "pending" });
+  });
+
+  it("maps slow_down with interval", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ error: "slow_down", interval: 10 })),
+    );
+
+    await expect(pollAccessToken("c", "d")).resolves.toEqual({
+      status: "slow_down",
+      interval: 10,
+    });
+  });
+
+  it("maps expired_token and access_denied", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ error: "expired_token" })));
+    await expect(pollAccessToken("c", "d")).resolves.toEqual({ status: "expired" });
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ error: "access_denied" })));
+    await expect(pollAccessToken("c", "d")).resolves.toEqual({ status: "denied" });
+  });
+
+  it("maps device_flow_disabled to a clear error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ error: "device_flow_disabled" })),
+    );
+
+    const result = await pollAccessToken("c", "d");
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.message).toMatch(/Device flow is not enabled/i);
+    }
+  });
+});
+
+describe("fetchGitHubUser", () => {
+  it("maps login, avatar, and name", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        login: "octocat",
+        avatar_url: "https://avatars.example/octocat",
+        name: "The Octocat",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const user = await fetchGitHubUser("gho_token");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.github.com/user",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer gho_token",
+        }),
+      }),
+    );
+    expect(user).toEqual({
+      login: "octocat",
+      avatarUrl: "https://avatars.example/octocat",
+      name: "The Octocat",
+    });
+  });
+
+  it("throws when login is missing", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ id: 1 })));
+    await expect(fetchGitHubUser("t")).rejects.toThrow(/username/i);
+  });
+});

--- a/src/lib/github/deviceOAuth.ts
+++ b/src/lib/github/deviceOAuth.ts
@@ -1,0 +1,259 @@
+/**
+ * GitHub OAuth 2.0 device authorization grant (RFC 8628).
+ * Pure HTTP helpers — no Chrome APIs; storage and messaging live elsewhere.
+ *
+ * @see https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow
+ */
+
+export interface DeviceCodeResponse {
+  deviceCode: string;
+  userCode: string;
+  verificationUri: string;
+  expiresIn: number;
+  interval: number;
+}
+
+export type PollTokenResult =
+  | { status: "pending" }
+  | { status: "slow_down"; interval: number }
+  | { status: "authorized"; accessToken: string; tokenType: string; scope: string }
+  | { status: "expired" }
+  | { status: "denied" }
+  | { status: "error"; message: string };
+
+export interface GitHubUserInfo {
+  login: string;
+  avatarUrl?: string;
+  name?: string;
+}
+
+const DEVICE_CODE_URL = "https://github.com/login/device/code";
+const ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
+const USER_URL = "https://api.github.com/user";
+const GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
+
+const JSON_HEADERS = {
+  Accept: "application/json",
+  "Content-Type": "application/json",
+} as const;
+
+function networkError(action: string, error: unknown): Error {
+  const detail = error instanceof Error ? error.message : String(error);
+  return new Error(`Network error while ${action}: ${detail}`);
+}
+
+/**
+ * Step 1: request device + user verification codes from GitHub.
+ */
+export async function requestDeviceCode(
+  clientId: string,
+  scope: string,
+): Promise<DeviceCodeResponse> {
+  let response: Response;
+  try {
+    response = await fetch(DEVICE_CODE_URL, {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ client_id: clientId, scope }),
+    });
+  } catch (error) {
+    throw networkError("requesting a GitHub device code", error);
+  }
+
+  const body = (await response.json().catch(() => null)) as Record<string, unknown> | null;
+
+  if (!response.ok) {
+    const message = githubErrorMessage(body) ?? `Could not start GitHub sign-in (HTTP ${response.status}).`;
+    throw new Error(message);
+  }
+
+  if (!body) {
+    throw new Error("GitHub returned an empty response when starting device sign-in.");
+  }
+
+  const deviceCode = stringField(body, "device_code");
+  const userCode = stringField(body, "user_code");
+  const verificationUri = stringField(body, "verification_uri");
+  const expiresIn = numberField(body, "expires_in");
+  const interval = numberField(body, "interval");
+
+  if (!deviceCode || !userCode || !verificationUri || expiresIn === undefined || interval === undefined) {
+    throw new Error("GitHub returned an incomplete device code response.");
+  }
+
+  return {
+    deviceCode,
+    userCode,
+    verificationUri,
+    expiresIn,
+    interval: Math.max(1, interval),
+  };
+}
+
+/**
+ * Step 3: poll for the access token (or a pending/error status).
+ */
+export async function pollAccessToken(
+  clientId: string,
+  deviceCode: string,
+): Promise<PollTokenResult> {
+  let response: Response;
+  try {
+    response = await fetch(ACCESS_TOKEN_URL, {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({
+        client_id: clientId,
+        device_code: deviceCode,
+        grant_type: GRANT_TYPE,
+      }),
+    });
+  } catch (error) {
+    return {
+      status: "error",
+      message: networkError("checking GitHub authorization", error).message,
+    };
+  }
+
+  const body = (await response.json().catch(() => null)) as Record<string, unknown> | null;
+  if (!body) {
+    return {
+      status: "error",
+      message: `GitHub returned an empty token response (HTTP ${response.status}).`,
+    };
+  }
+
+  // Successful token responses are typically 200; error payloads also use 200 with `error`.
+  const errorCode = stringField(body, "error");
+  if (errorCode) {
+    return mapDeviceError(errorCode, body);
+  }
+
+  const accessToken = stringField(body, "access_token");
+  if (!accessToken) {
+    if (!response.ok) {
+      return {
+        status: "error",
+        message: githubErrorMessage(body) ?? `Token request failed (HTTP ${response.status}).`,
+      };
+    }
+    return { status: "error", message: "GitHub returned a token response without an access token." };
+  }
+
+  return {
+    status: "authorized",
+    accessToken,
+    tokenType: stringField(body, "token_type") ?? "bearer",
+    scope: stringField(body, "scope") ?? "",
+  };
+}
+
+/**
+ * After authorization, load the authenticated user for the Options UI.
+ */
+export async function fetchGitHubUser(accessToken: string): Promise<GitHubUserInfo> {
+  let response: Response;
+  try {
+    response = await fetch(USER_URL, {
+      method: "GET",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${accessToken}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+  } catch (error) {
+    throw networkError("loading your GitHub profile", error);
+  }
+
+  const body = (await response.json().catch(() => null)) as Record<string, unknown> | null;
+
+  if (!response.ok) {
+    const message =
+      githubErrorMessage(body) ??
+      `Could not load your GitHub profile (HTTP ${response.status}).`;
+    throw new Error(message);
+  }
+
+  const login = stringField(body, "login");
+  if (!login) {
+    throw new Error("GitHub profile response was missing a username.");
+  }
+
+  const avatarUrl = stringField(body, "avatar_url");
+  const name = stringField(body, "name");
+
+  return {
+    login,
+    ...(avatarUrl ? { avatarUrl } : {}),
+    ...(name ? { name } : {}),
+  };
+}
+
+function mapDeviceError(errorCode: string, body: Record<string, unknown>): PollTokenResult {
+  switch (errorCode) {
+    case "authorization_pending":
+      return { status: "pending" };
+    case "slow_down": {
+      const interval = numberField(body, "interval");
+      return {
+        status: "slow_down",
+        // GitHub adds 5s on slow_down; prefer server value when present.
+        interval: interval !== undefined ? Math.max(1, interval) : 10,
+      };
+    }
+    case "expired_token":
+      return { status: "expired" };
+    case "access_denied":
+      return { status: "denied" };
+    case "device_flow_disabled":
+      return {
+        status: "error",
+        message:
+          "Device flow is not enabled for this GitHub OAuth App. Enable it in the app settings.",
+      };
+    case "incorrect_client_credentials":
+      return {
+        status: "error",
+        message: "Invalid GitHub OAuth client ID. Check VITE_GITHUB_CLIENT_ID and rebuild.",
+      };
+    case "incorrect_device_code":
+      return {
+        status: "error",
+        message: "The device code is no longer valid. Start the connection again.",
+      };
+    case "unsupported_grant_type":
+      return {
+        status: "error",
+        message: "GitHub rejected the device grant type. Try connecting again.",
+      };
+    default:
+      return {
+        status: "error",
+        message:
+          githubErrorMessage(body) ??
+          `GitHub authorization failed (${errorCode}).`,
+      };
+  }
+}
+
+function githubErrorMessage(body: Record<string, unknown> | null): string | undefined {
+  if (!body) return undefined;
+  const description = stringField(body, "error_description");
+  if (description) return description;
+  const message = stringField(body, "message");
+  if (message) return message;
+  return undefined;
+}
+
+function stringField(body: Record<string, unknown> | null, key: string): string | undefined {
+  if (!body) return undefined;
+  const value = body[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberField(body: Record<string, unknown> | null, key: string): number | undefined {
+  if (!body) return undefined;
+  const value = body[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}

--- a/src/lib/github/oauthConfig.ts
+++ b/src/lib/github/oauthConfig.ts
@@ -1,0 +1,15 @@
+/**
+ * GitHub OAuth App configuration for the device authorization grant.
+ * Client ID is public by design (device flow does not use a client secret).
+ * Set VITE_GITHUB_CLIENT_ID at build time.
+ */
+
+export const GITHUB_OAUTH_CLIENT_ID: string =
+  (import.meta.env.VITE_GITHUB_CLIENT_ID as string | undefined)?.trim() ?? "";
+
+/** Classic OAuth scopes: private/public repo access + profile for connected UI. */
+export const GITHUB_OAUTH_SCOPES = "repo read:user";
+
+export function isGitHubOAuthConfigured(): boolean {
+  return GITHUB_OAUTH_CLIENT_ID.length > 0;
+}

--- a/src/lib/github/submitReview.test.ts
+++ b/src/lib/github/submitReview.test.ts
@@ -1,0 +1,364 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { submitPullRequestReview } from "./submitReview";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const pr = { owner: "acme", repo: "widget", number: 42 };
+const headSha = "abc123def456";
+
+function mockHeadThen(post: Response): ReturnType<typeof vi.fn> {
+  return vi
+    .fn()
+    .mockResolvedValueOnce(jsonResponse({ head: { sha: headSha } }))
+    .mockResolvedValueOnce(post);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("submitPullRequestReview", () => {
+  it("rejects empty body for COMMENT", async () => {
+    const result = await submitPullRequestReview({
+      accessToken: "tok",
+      pr,
+      body: "   ",
+      event: "COMMENT",
+      comments: [],
+    });
+    expect(result).toEqual({
+      ok: false,
+      code: "validation",
+      error: "Add a review comment before submitting.",
+    });
+  });
+
+  it("rejects empty body for REQUEST_CHANGES", async () => {
+    const result = await submitPullRequestReview({
+      accessToken: "tok",
+      pr,
+      body: "",
+      event: "REQUEST_CHANGES",
+      comments: [],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe("validation");
+  });
+
+  it("always fetches head sha and posts commit_id even without comments", async () => {
+    const fetchMock = mockHeadThen(
+      jsonResponse({
+        id: 99,
+        html_url: "https://github.com/acme/widget/pull/42#pullrequestreview-99",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await submitPullRequestReview({
+      accessToken: "gho_token",
+      pr,
+      body: "LGTM",
+      event: "APPROVE",
+      comments: [],
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      reviewId: 99,
+      htmlUrl: "https://github.com/acme/widget/pull/42#pullrequestreview-99",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://api.github.com/repos/acme/widget/pulls/42",
+    );
+    const [url, init] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(url).toBe("https://api.github.com/repos/acme/widget/pulls/42/reviews");
+    expect(init.method).toBe("POST");
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer gho_token");
+    expect(JSON.parse(init.body as string)).toEqual({
+      event: "APPROVE",
+      body: "LGTM",
+      commit_id: headSha,
+      comments: [],
+    });
+  });
+
+  it("allows empty body for APPROVE", async () => {
+    const fetchMock = mockHeadThen(
+      jsonResponse({
+        id: 1,
+        html_url: "https://github.com/acme/widget/pull/42#pullrequestreview-1",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await submitPullRequestReview({
+      accessToken: "tok",
+      pr,
+      body: "",
+      event: "APPROVE",
+      comments: [],
+    });
+
+    expect(result.ok).toBe(true);
+    const body = JSON.parse(
+      (fetchMock.mock.calls[1] as [string, RequestInit])[1].body as string,
+    );
+    expect(body).toEqual({
+      event: "APPROVE",
+      commit_id: headSha,
+      comments: [],
+    });
+    expect(body.body).toBeUndefined();
+  });
+
+  it("fetches head sha and posts multi-line comments", async () => {
+    const fetchMock = mockHeadThen(
+      jsonResponse({
+        id: 7,
+        html_url: "https://github.com/acme/widget/pull/42#pullrequestreview-7",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await submitPullRequestReview({
+      accessToken: "tok",
+      pr,
+      body: "Please fix",
+      event: "REQUEST_CHANGES",
+      comments: [
+        {
+          path: "src/a.ts",
+          body: "nit",
+          side: "RIGHT",
+          line: 20,
+          startLine: 18,
+          startSide: "RIGHT",
+        },
+        {
+          path: "src/b.ts",
+          body: "single",
+          side: "LEFT",
+          line: 5,
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      reviewId: 7,
+      htmlUrl: "https://github.com/acme/widget/pull/42#pullrequestreview-7",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const postBody = JSON.parse(
+      (fetchMock.mock.calls[1] as [string, RequestInit])[1].body as string,
+    );
+    expect(postBody).toEqual({
+      event: "REQUEST_CHANGES",
+      body: "Please fix",
+      commit_id: headSha,
+      comments: [
+        {
+          path: "src/a.ts",
+          body: "nit",
+          line: 20,
+          side: "RIGHT",
+          start_line: 18,
+          start_side: "RIGHT",
+        },
+        {
+          path: "src/b.ts",
+          body: "single",
+          line: 5,
+          side: "LEFT",
+        },
+      ],
+    });
+  });
+
+  it("maps 401 to not_authenticated with PR context", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ message: "Bad credentials" }, 401)),
+    );
+
+    const result = await submitPullRequestReview({
+      accessToken: "bad",
+      pr,
+      body: "x",
+      event: "COMMENT",
+      comments: [],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("not_authenticated");
+      expect(result.error).toContain("HTTP 401");
+      expect(result.error).toContain("acme/widget#42");
+      expect(result.error).toContain("Bad credentials");
+      expect(result.error).toMatch(/Reconnect GitHub/i);
+    }
+  });
+
+  it("maps 403 with API message and status", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse({ message: "Resource not accessible by integration" }, 403),
+      ),
+    );
+
+    const result = await submitPullRequestReview({
+      accessToken: "tok",
+      pr,
+      body: "x",
+      event: "COMMENT",
+      comments: [],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("forbidden");
+      expect(result.error).toContain("HTTP 403");
+      expect(result.error).toContain("Resource not accessible by integration");
+      expect(result.error).toContain("acme/widget#42");
+    }
+  });
+
+  it("maps 404 to not_found with detail, not bare Not Found", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse(
+          {
+            message: "Not Found",
+            documentation_url:
+              "https://docs.github.com/rest/pulls/pulls#get-a-pull-request",
+          },
+          404,
+        ),
+      ),
+    );
+
+    const result = await submitPullRequestReview({
+      accessToken: "tok",
+      pr,
+      body: "x",
+      event: "COMMENT",
+      comments: [],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("not_found");
+      expect(result.error).not.toBe("Not Found");
+      expect(result.error).toContain("HTTP 404");
+      expect(result.error).toContain("acme/widget#42");
+      expect(result.error).toContain("Not Found");
+      expect(result.error).toContain("Docs:");
+      expect(result.error).toMatch(/SSO|reconnect|repo access/i);
+    }
+  });
+
+  it("maps 404 on POST after successful head fetch", async () => {
+    const fetchMock = mockHeadThen(
+      jsonResponse({ message: "Not Found" }, 404),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await submitPullRequestReview({
+      accessToken: "tok",
+      pr,
+      body: "x",
+      event: "COMMENT",
+      comments: [],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("not_found");
+      expect(result.error).toContain("submitting the review");
+      expect(result.error).toContain("HTTP 404");
+    }
+  });
+
+  it("maps 422 with nested errors and documentation_url", async () => {
+    const fetchMock = mockHeadThen(
+      jsonResponse(
+        {
+          message: "Unprocessable Entity",
+          errors: [
+            { message: "line must be part of the diff" },
+            { message: "path is invalid" },
+          ],
+          documentation_url:
+            "https://docs.github.com/rest/pulls/reviews#create-a-review-for-a-pull-request",
+        },
+        422,
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await submitPullRequestReview({
+      accessToken: "tok",
+      pr,
+      body: "x",
+      event: "COMMENT",
+      comments: [],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("validation");
+      expect(result.error).toContain("HTTP 422");
+      expect(result.error).toContain("line must be part of the diff");
+      expect(result.error).toContain("path is invalid");
+      expect(result.error).toContain("Docs:");
+    }
+  });
+
+  it("returns network error when fetch throws", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+
+    const result = await submitPullRequestReview({
+      accessToken: "tok",
+      pr,
+      body: "x",
+      event: "COMMENT",
+      comments: [],
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "network",
+      error: expect.stringContaining("offline"),
+    });
+  });
+
+  it("fails when head sha is missing", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ head: {} })));
+
+    const result = await submitPullRequestReview({
+      accessToken: "tok",
+      pr,
+      body: "x",
+      event: "COMMENT",
+      comments: [
+        { path: "a.ts", body: "c", side: "RIGHT", line: 1 },
+      ],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("unknown");
+      expect(result.error).toContain("acme/widget#42");
+    }
+  });
+});

--- a/src/lib/github/submitReview.ts
+++ b/src/lib/github/submitReview.ts
@@ -1,0 +1,318 @@
+/**
+ * Create a submitted pull request review via the GitHub REST API.
+ * Pure HTTP — auth token is provided by the caller (background worker).
+ *
+ * @see https://docs.github.com/en/rest/pulls/reviews#create-a-review-for-a-pull-request
+ */
+
+import type {
+  ReviewCommentInput,
+  ReviewEvent,
+  SubmitReviewResponse,
+} from "../types";
+
+type SubmitReviewFailure = Extract<SubmitReviewResponse, { ok: false }>;
+
+type PRIdentity = { owner: string; repo: string; number: number };
+
+const API_VERSION = "2022-11-28";
+const ACCEPT = "application/vnd.github+json";
+
+export interface SubmitPullRequestReviewParams {
+  accessToken: string;
+  pr: PRIdentity;
+  body: string;
+  event: ReviewEvent;
+  comments: ReviewCommentInput[];
+}
+
+/**
+ * POST a review (with optional inline comments) and submit it in one call
+ * by setting `event` to COMMENT | APPROVE | REQUEST_CHANGES.
+ *
+ * Always preflights with GET pull (OAuth token) to verify access and obtain
+ * head.sha for `commit_id`.
+ */
+export async function submitPullRequestReview(
+  params: SubmitPullRequestReviewParams,
+): Promise<SubmitReviewResponse> {
+  const { accessToken, pr, event, comments } = params;
+  const body = params.body.trim();
+
+  if ((event === "COMMENT" || event === "REQUEST_CHANGES") && body.length === 0) {
+    return {
+      ok: false,
+      code: "validation",
+      error:
+        event === "COMMENT"
+          ? "Add a review comment before submitting."
+          : "Add a summary explaining the requested changes before submitting.",
+    };
+  }
+
+  const head = await fetchPullHeadSha(accessToken, pr);
+  if (!head.ok) return head;
+
+  const url = `https://api.github.com/repos/${pr.owner}/${pr.repo}/pulls/${pr.number}/reviews`;
+  const payload: Record<string, unknown> = {
+    event,
+    commit_id: head.sha,
+    comments: comments.map(toApiComment),
+  };
+  if (body.length > 0) payload.body = body;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: githubApiHeaders(accessToken),
+      body: JSON.stringify(payload),
+    });
+  } catch (error) {
+    return {
+      ok: false,
+      code: "network",
+      error: networkMessage("submitting the review", error),
+    };
+  }
+
+  const responseBody = (await response.json().catch(() => null)) as Record<
+    string,
+    unknown
+  > | null;
+
+  if (!response.ok) {
+    return mapHttpError(response.status, responseBody, {
+      action: "submitting the review",
+      pr,
+    });
+  }
+
+  const reviewId = numberField(responseBody, "id");
+  const htmlUrl = stringField(responseBody, "html_url");
+  if (reviewId === undefined || !htmlUrl) {
+    return {
+      ok: false,
+      code: "unknown",
+      error: "GitHub accepted the review but returned an unexpected response.",
+    };
+  }
+
+  return { ok: true, reviewId, htmlUrl };
+}
+
+async function fetchPullHeadSha(
+  accessToken: string,
+  pr: PRIdentity,
+): Promise<{ ok: true; sha: string } | SubmitReviewFailure> {
+  const url = `https://api.github.com/repos/${pr.owner}/${pr.repo}/pulls/${pr.number}`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "GET",
+      headers: githubApiHeaders(accessToken),
+    });
+  } catch (error) {
+    return {
+      ok: false,
+      code: "network",
+      error: networkMessage("loading the pull request", error),
+    };
+  }
+
+  const body = (await response.json().catch(() => null)) as Record<
+    string,
+    unknown
+  > | null;
+
+  if (!response.ok) {
+    return mapHttpError(response.status, body, {
+      action: "loading the pull request",
+      pr,
+    });
+  }
+
+  const head = body?.head;
+  const sha =
+    head && typeof head === "object" && head !== null
+      ? stringField(head as Record<string, unknown>, "sha")
+      : undefined;
+
+  if (!sha) {
+    return {
+      ok: false,
+      code: "unknown",
+      error: `Could not determine the head commit for ${formatPr(pr)} to attach the review.`,
+    };
+  }
+
+  return { ok: true, sha };
+}
+
+function toApiComment(comment: ReviewCommentInput): Record<string, unknown> {
+  const api: Record<string, unknown> = {
+    path: comment.path,
+    body: comment.body,
+    line: comment.line,
+    side: comment.side,
+  };
+  if (
+    comment.startLine !== undefined &&
+    comment.startLine !== comment.line
+  ) {
+    api.start_line = comment.startLine;
+    api.start_side = comment.startSide ?? comment.side;
+  }
+  return api;
+}
+
+function githubApiHeaders(accessToken: string): Record<string, string> {
+  return {
+    Accept: ACCEPT,
+    Authorization: `Bearer ${accessToken}`,
+    "X-GitHub-Api-Version": API_VERSION,
+    "Content-Type": "application/json",
+  };
+}
+
+function mapHttpError(
+  status: number,
+  body: Record<string, unknown> | null,
+  ctx: { action: string; pr: PRIdentity },
+): SubmitReviewFailure {
+  const apiDetail = githubErrorDetail(body);
+  const prLabel = formatPr(ctx.pr);
+
+  if (status === 401) {
+    return {
+      ok: false,
+      code: "not_authenticated",
+      error: composeError(
+        `GitHub rejected the token while ${ctx.action} for ${prLabel} (HTTP 401).`,
+        apiDetail,
+        "Reconnect GitHub in the extension options.",
+      ),
+    };
+  }
+
+  if (status === 403) {
+    return {
+      ok: false,
+      code: "forbidden",
+      error: composeError(
+        `Permission denied while ${ctx.action} for ${prLabel} (HTTP 403).`,
+        apiDetail,
+        "You don’t have permission to review this pull request, or the OAuth app lacks the required scope.",
+      ),
+    };
+  }
+
+  if (status === 404) {
+    return {
+      ok: false,
+      code: "not_found",
+      error: composeError(
+        `Could not access ${prLabel} while ${ctx.action} (HTTP 404).`,
+        apiDetail,
+        "Confirm the PR still exists and that your connected GitHub account can open it. For private org repos, authorize SSO for the Guided Review token (GitHub → Settings → Applications) or reconnect GitHub with repo access in Options.",
+      ),
+    };
+  }
+
+  if (status === 422) {
+    return {
+      ok: false,
+      code: "validation",
+      error: composeError(
+        `GitHub rejected the review for ${prLabel} (HTTP 422).`,
+        apiDetail,
+        "Check that line comments still match the current diff.",
+      ),
+    };
+  }
+
+  return {
+    ok: false,
+    code: "unknown",
+    error: composeError(
+      `Could not finish ${ctx.action} for ${prLabel} (HTTP ${status}).`,
+      apiDetail,
+    ),
+  };
+}
+
+/**
+ * Build a multi-clause user-facing error. Never returns a bare one-word API
+ * message like "Not Found" without status / action context.
+ */
+function composeError(
+  lead: string,
+  apiDetail?: string,
+  hint?: string,
+): string {
+  const parts = [lead];
+  if (apiDetail && apiDetail !== lead) {
+    // Avoid repeating an identical lead; still attach GitHub's detail.
+    parts.push(apiDetail);
+  }
+  if (hint) parts.push(hint);
+  return parts.join(" ");
+}
+
+/** GitHub `message` + all `errors[]` + optional `documentation_url`. */
+function githubErrorDetail(body: Record<string, unknown> | null): string | undefined {
+  if (!body) return undefined;
+
+  const message = stringField(body, "message");
+  const errorParts: string[] = [];
+
+  const errors = body.errors;
+  if (Array.isArray(errors)) {
+    for (const entry of errors) {
+      if (typeof entry === "string" && entry.length > 0) {
+        errorParts.push(entry);
+        continue;
+      }
+      if (entry && typeof entry === "object") {
+        const errMsg = stringField(entry as Record<string, unknown>, "message");
+        if (errMsg) errorParts.push(errMsg);
+      }
+    }
+  }
+
+  const docs = stringField(body, "documentation_url");
+
+  const segments: string[] = [];
+  if (message) {
+    segments.push(
+      errorParts.length > 0 ? `${message}: ${errorParts.join("; ")}` : message,
+    );
+  } else if (errorParts.length > 0) {
+    segments.push(errorParts.join("; "));
+  }
+  if (docs) segments.push(`Docs: ${docs}`);
+
+  return segments.length > 0 ? segments.join(" ") : undefined;
+}
+
+function formatPr(pr: PRIdentity): string {
+  return `${pr.owner}/${pr.repo}#${pr.number}`;
+}
+
+function networkMessage(action: string, error: unknown): string {
+  const detail = error instanceof Error ? error.message : String(error);
+  return `Network error while ${action}: ${detail}`;
+}
+
+function stringField(body: Record<string, unknown> | null, key: string): string | undefined {
+  if (!body) return undefined;
+  const value = body[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberField(body: Record<string, unknown> | null, key: string): number | undefined {
+  if (!body) return undefined;
+  const value = body[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}

--- a/src/lib/github/useGitHubDeviceAuth.ts
+++ b/src/lib/github/useGitHubDeviceAuth.ts
@@ -1,0 +1,177 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { GitHubAuthState } from "../types";
+import { pollGitHubDeviceAuth, startGitHubDeviceAuth } from "../messaging";
+
+/** In-progress device OAuth UI state owned by the caller’s poll loop. */
+export type DeviceAuthFlowView =
+  | { kind: "idle" }
+  | {
+      kind: "awaiting";
+      userCode: string;
+      verificationUri: string;
+      deviceCode: string;
+    }
+  | { kind: "error"; message: string };
+
+export interface UseGitHubDeviceAuthOptions {
+  /** When false, connect is a no-op (OAuth client not configured). */
+  enabled?: boolean;
+  /** Called after the background worker persists the token. */
+  onAuthorized?: (auth: GitHubAuthState) => void;
+}
+
+/**
+ * Open GitHub’s device verification page. Prefers chrome.tabs (extension pages);
+ * falls back to window.open for content scripts.
+ */
+export async function openVerificationUri(uri: string): Promise<void> {
+  try {
+    if (typeof chrome !== "undefined" && chrome.tabs?.create) {
+      await chrome.tabs.create({ url: uri });
+      return;
+    }
+  } catch {
+    // Missing tabs permission / popup block — try window.open next.
+  }
+  try {
+    window.open(uri, "_blank", "noopener,noreferrer");
+  } catch {
+    // Caller still shows a verification link the user can click.
+  }
+}
+
+/**
+ * Device OAuth connect + poll loop (MV3-friendly: timer lives in the UI context).
+ * Shared by Options and the overlay Connect GitHub modal.
+ */
+export function useGitHubDeviceAuth(
+  options: UseGitHubDeviceAuthOptions = {},
+): {
+  flow: DeviceAuthFlowView;
+  busy: boolean;
+  startConnect: () => Promise<void>;
+  cancel: () => void;
+  reset: () => void;
+} {
+  const { enabled = true, onAuthorized } = options;
+  const [flow, setFlow] = useState<DeviceAuthFlowView>({ kind: "idle" });
+  const [busy, setBusy] = useState(false);
+
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pollGenerationRef = useRef(0);
+  const onAuthorizedRef = useRef(onAuthorized);
+  onAuthorizedRef.current = onAuthorized;
+
+  const stopPolling = useCallback(() => {
+    pollGenerationRef.current += 1;
+    if (pollTimerRef.current !== null) {
+      clearTimeout(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => stopPolling();
+  }, [stopPolling]);
+
+  const schedulePoll = useCallback(
+    (deviceCode: string, intervalSec: number, generation: number) => {
+      if (pollTimerRef.current !== null) {
+        clearTimeout(pollTimerRef.current);
+      }
+      pollTimerRef.current = setTimeout(() => {
+        void (async () => {
+          if (generation !== pollGenerationRef.current) return;
+
+          try {
+            const result = await pollGitHubDeviceAuth(deviceCode);
+            if (generation !== pollGenerationRef.current) return;
+
+            if (result.ok && result.status === "pending") {
+              schedulePoll(deviceCode, intervalSec, generation);
+              return;
+            }
+
+            if (result.ok && result.status === "slow_down") {
+              schedulePoll(deviceCode, result.interval, generation);
+              return;
+            }
+
+            if (result.ok && result.status === "authorized") {
+              stopPolling();
+              setBusy(false);
+              setFlow({ kind: "idle" });
+              onAuthorizedRef.current?.(result.auth);
+              return;
+            }
+
+            stopPolling();
+            setBusy(false);
+            const message = !result.ok
+              ? result.error
+              : "GitHub authorization failed. Try connecting again.";
+            setFlow({ kind: "error", message });
+          } catch (error) {
+            if (generation !== pollGenerationRef.current) return;
+            stopPolling();
+            setBusy(false);
+            const message =
+              error instanceof Error
+                ? error.message
+                : "GitHub authorization failed unexpectedly.";
+            setFlow({ kind: "error", message });
+          }
+        })();
+      }, Math.max(0, intervalSec) * 1000);
+    },
+    [stopPolling],
+  );
+
+  const startConnect = useCallback(async () => {
+    if (!enabled || busy) return;
+    stopPolling();
+    setBusy(true);
+    setFlow({ kind: "idle" });
+
+    try {
+      const start = await startGitHubDeviceAuth();
+      if (!start.ok) {
+        setBusy(false);
+        setFlow({ kind: "error", message: start.error });
+        return;
+      }
+
+      setFlow({
+        kind: "awaiting",
+        userCode: start.userCode,
+        verificationUri: start.verificationUri,
+        deviceCode: start.deviceCode,
+      });
+
+      // Caller shows the user code and opens verificationUri when ready
+      // (primary button or auto-open after copy).
+
+      const generation = pollGenerationRef.current;
+      schedulePoll(start.deviceCode, start.interval, generation);
+    } catch (error) {
+      setBusy(false);
+      const message =
+        error instanceof Error ? error.message : "Could not start GitHub sign-in.";
+      setFlow({ kind: "error", message });
+    }
+  }, [busy, enabled, schedulePoll, stopPolling]);
+
+  const cancel = useCallback(() => {
+    stopPolling();
+    setBusy(false);
+    setFlow({ kind: "idle" });
+  }, [stopPolling]);
+
+  return {
+    flow,
+    busy,
+    startConnect,
+    cancel,
+    reset: cancel,
+  };
+}

--- a/src/lib/messaging.test.ts
+++ b/src/lib/messaging.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
-import { requestPRDiff, streamReviewPlan, testConnection } from "./messaging";
+import {
+  clearGitHubAuthSession,
+  getGitHubAuthStatus,
+  pollGitHubDeviceAuth,
+  requestPRDiff,
+  startGitHubDeviceAuth,
+  streamReviewPlan,
+  testConnection,
+} from "./messaging";
 import type { ParsedDiff, PRContext, ReviewUnit } from "./types";
 import type { MockPort } from "../test/chromeMock";
 
@@ -102,5 +110,41 @@ describe("messaging", () => {
 
     expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ type: "TEST_CONNECTION", settings });
     expect(result).toEqual(response);
+  });
+
+  it("startGitHubDeviceAuth sends GITHUB_DEVICE_START", async () => {
+    const response = {
+      ok: true as const,
+      userCode: "ABCD-EFGH",
+      verificationUri: "https://github.com/login/device",
+      deviceCode: "dev",
+      interval: 5,
+      expiresIn: 900,
+    };
+    vi.mocked(chrome.runtime.sendMessage).mockResolvedValueOnce(response);
+
+    await expect(startGitHubDeviceAuth()).resolves.toEqual(response);
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ type: "GITHUB_DEVICE_START" });
+  });
+
+  it("pollGitHubDeviceAuth sends GITHUB_DEVICE_POLL with deviceCode", async () => {
+    const response = { ok: true as const, status: "pending" as const };
+    vi.mocked(chrome.runtime.sendMessage).mockResolvedValueOnce(response);
+
+    await expect(pollGitHubDeviceAuth("device-xyz")).resolves.toEqual(response);
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
+      type: "GITHUB_DEVICE_POLL",
+      deviceCode: "device-xyz",
+    });
+  });
+
+  it("getGitHubAuthStatus and clearGitHubAuthSession send the expected types", async () => {
+    vi.mocked(chrome.runtime.sendMessage).mockResolvedValueOnce({ ok: true, auth: null });
+    await expect(getGitHubAuthStatus()).resolves.toEqual({ ok: true, auth: null });
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ type: "GITHUB_AUTH_GET" });
+
+    vi.mocked(chrome.runtime.sendMessage).mockResolvedValueOnce({ ok: true });
+    await expect(clearGitHubAuthSession()).resolves.toEqual({ ok: true });
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ type: "GITHUB_AUTH_CLEAR" });
   });
 });

--- a/src/lib/messaging.test.ts
+++ b/src/lib/messaging.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   clearGitHubAuthSession,
   getGitHubAuthStatus,
+  submitPullRequestReview,
   pollGitHubDeviceAuth,
   requestPRDiff,
   startGitHubDeviceAuth,
@@ -146,5 +147,29 @@ describe("messaging", () => {
     vi.mocked(chrome.runtime.sendMessage).mockResolvedValueOnce({ ok: true });
     await expect(clearGitHubAuthSession()).resolves.toEqual({ ok: true });
     expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ type: "GITHUB_AUTH_CLEAR" });
+  });
+
+  it("submitPullRequestReview sends SUBMIT_REVIEW with payload", async () => {
+    const response = {
+      ok: true as const,
+      reviewId: 1,
+      htmlUrl: "https://github.com/o/r/pull/1#pullrequestreview-1",
+    };
+    vi.mocked(chrome.runtime.sendMessage).mockResolvedValueOnce(response);
+
+    const pr = { owner: "o", repo: "r", number: 1 };
+    const comments = [
+      { path: "a.ts", body: "c", side: "RIGHT" as const, line: 3 },
+    ];
+    await expect(
+      submitPullRequestReview(pr, "Looks good", "APPROVE", comments),
+    ).resolves.toEqual(response);
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
+      type: "SUBMIT_REVIEW",
+      pr,
+      body: "Looks good",
+      event: "APPROVE",
+      comments,
+    });
   });
 });

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -6,6 +6,14 @@ import type {
   FetchDiffRequest,
   FetchDiffResponse,
   FetchDiffError,
+  GitHubAuthClearRequest,
+  GitHubAuthClearResponse,
+  GitHubAuthGetRequest,
+  GitHubAuthGetResponse,
+  GitHubDevicePollRequest,
+  GitHubDevicePollResponse,
+  GitHubDeviceStartRequest,
+  GitHubDeviceStartResponse,
   ParsedDiff,
   PRContext,
   ProviderSettings,
@@ -113,5 +121,31 @@ export async function requestPRDiff(
   pr: FetchDiffRequest["pr"],
 ): Promise<FetchDiffResponse | FetchDiffError> {
   const request: FetchDiffRequest = { type: "FETCH_DIFF", pr };
+  return chrome.runtime.sendMessage(request);
+}
+
+/** Options: begin GitHub device OAuth (returns user_code for the user to enter). */
+export async function startGitHubDeviceAuth(): Promise<GitHubDeviceStartResponse> {
+  const request: GitHubDeviceStartRequest = { type: "GITHUB_DEVICE_START" };
+  return chrome.runtime.sendMessage(request);
+}
+
+/** Options: one poll tick while waiting for the user to authorize. */
+export async function pollGitHubDeviceAuth(
+  deviceCode: string,
+): Promise<GitHubDevicePollResponse> {
+  const request: GitHubDevicePollRequest = { type: "GITHUB_DEVICE_POLL", deviceCode };
+  return chrome.runtime.sendMessage(request);
+}
+
+/** Options: load the stored GitHub session (or null). */
+export async function getGitHubAuthStatus(): Promise<GitHubAuthGetResponse> {
+  const request: GitHubAuthGetRequest = { type: "GITHUB_AUTH_GET" };
+  return chrome.runtime.sendMessage(request);
+}
+
+/** Options: disconnect and forget the stored GitHub token. */
+export async function clearGitHubAuthSession(): Promise<GitHubAuthClearResponse> {
+  const request: GitHubAuthClearRequest = { type: "GITHUB_AUTH_CLEAR" };
   return chrome.runtime.sendMessage(request);
 }

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -17,9 +17,13 @@ import type {
   ParsedDiff,
   PRContext,
   ProviderSettings,
+  ReviewCommentInput,
   ReviewErrorInfo,
+  ReviewEvent,
   ReviewPlan,
   ReviewUnit,
+  SubmitReviewRequest,
+  SubmitReviewResponse,
 } from "./types";
 
 const ANNOTATE_PORT_NAME = "annotate-review";
@@ -147,5 +151,25 @@ export async function getGitHubAuthStatus(): Promise<GitHubAuthGetResponse> {
 /** Options: disconnect and forget the stored GitHub token. */
 export async function clearGitHubAuthSession(): Promise<GitHubAuthClearResponse> {
   const request: GitHubAuthClearRequest = { type: "GITHUB_AUTH_CLEAR" };
+  return chrome.runtime.sendMessage(request);
+}
+
+/**
+ * Content-script-side helper: submit a PR review (summary + optional line
+ * comments) through the background worker, which holds the OAuth token.
+ */
+export async function submitPullRequestReview(
+  pr: SubmitReviewRequest["pr"],
+  body: string,
+  event: ReviewEvent,
+  comments: ReviewCommentInput[],
+): Promise<SubmitReviewResponse> {
+  const request: SubmitReviewRequest = {
+    type: "SUBMIT_REVIEW",
+    pr,
+    body,
+    event,
+    comments,
+  };
   return chrome.runtime.sendMessage(request);
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -211,6 +211,43 @@ export interface GitHubAuthClearResponse {
   ok: true;
 }
 
+// ---- Submit pull request review ---------------------------------------------
+
+/** GitHub pull request review event (create-review API). */
+export type ReviewEvent = "COMMENT" | "APPROVE" | "REQUEST_CHANGES";
+
+/** Inline comment payload for GitHub create-review `comments[]`. */
+export interface ReviewCommentInput {
+  path: string;
+  body: string;
+  side: "LEFT" | "RIGHT";
+  /** End line (file coordinates on `side`). */
+  line: number;
+  /** Start line when multi-line; omit when single-line. */
+  startLine?: number;
+  startSide?: "LEFT" | "RIGHT";
+}
+
+export interface SubmitReviewRequest {
+  type: "SUBMIT_REVIEW";
+  pr: { owner: string; repo: string; number: number };
+  body: string;
+  event: ReviewEvent;
+  comments: ReviewCommentInput[];
+}
+
+export type SubmitReviewErrorCode =
+  | "not_authenticated"
+  | "forbidden"
+  | "not_found"
+  | "validation"
+  | "network"
+  | "unknown";
+
+export type SubmitReviewResponse =
+  | { ok: true; reviewId: number; htmlUrl: string }
+  | { ok: false; error: string; code?: SubmitReviewErrorCode };
+
 /** One-shot request/response messages (annotate uses a port instead). */
 export type BackgroundRequest =
   | TestConnectionRequest
@@ -218,7 +255,8 @@ export type BackgroundRequest =
   | GitHubDeviceStartRequest
   | GitHubDevicePollRequest
   | GitHubAuthGetRequest
-  | GitHubAuthClearRequest;
+  | GitHubAuthClearRequest
+  | SubmitReviewRequest;
 
 // ---- Messaging protocol (background → content) -----------------------------
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -97,6 +97,19 @@ export interface ProviderSettings {
   apiKey: string;
 }
 
+// ---- GitHub OAuth (device flow) ----------------------------------------------
+
+/** Persisted after a successful device authorization. */
+export interface GitHubAuthState {
+  accessToken: string;
+  tokenType: string;
+  scope: string;
+  /** From GET /user after connect. */
+  login: string;
+  avatarUrl?: string;
+  name?: string;
+}
+
 // ---- Messaging protocol (content <-> background) -----------------------------
 
 /** First message on the `annotate-review` port from content → background. */
@@ -152,8 +165,60 @@ export interface FetchDiffError {
   error: string;
 }
 
+// ---- GitHub device OAuth messaging ------------------------------------------
+
+export interface GitHubDeviceStartRequest {
+  type: "GITHUB_DEVICE_START";
+}
+
+export type GitHubDeviceStartResponse =
+  | {
+      ok: true;
+      userCode: string;
+      verificationUri: string;
+      deviceCode: string;
+      interval: number;
+      expiresIn: number;
+    }
+  | { ok: false; error: string };
+
+export interface GitHubDevicePollRequest {
+  type: "GITHUB_DEVICE_POLL";
+  deviceCode: string;
+}
+
+/** Discriminated outcomes for the Options-owned poll loop. */
+export type GitHubDevicePollResponse =
+  | { ok: true; status: "pending" }
+  | { ok: true; status: "slow_down"; interval: number }
+  | { ok: true; status: "authorized"; auth: GitHubAuthState }
+  | { ok: false; status: "expired" | "denied" | "error"; error: string };
+
+export interface GitHubAuthGetRequest {
+  type: "GITHUB_AUTH_GET";
+}
+
+export interface GitHubAuthGetResponse {
+  ok: true;
+  auth: GitHubAuthState | null;
+}
+
+export interface GitHubAuthClearRequest {
+  type: "GITHUB_AUTH_CLEAR";
+}
+
+export interface GitHubAuthClearResponse {
+  ok: true;
+}
+
 /** One-shot request/response messages (annotate uses a port instead). */
-export type BackgroundRequest = TestConnectionRequest | FetchDiffRequest;
+export type BackgroundRequest =
+  | TestConnectionRequest
+  | FetchDiffRequest
+  | GitHubDeviceStartRequest
+  | GitHubDevicePollRequest
+  | GitHubAuthGetRequest
+  | GitHubAuthClearRequest;
 
 // ---- Messaging protocol (background → content) -----------------------------
 

--- a/src/options/About.tsx
+++ b/src/options/About.tsx
@@ -56,12 +56,14 @@ export function About() {
       <section className="mb-6">
         <h2 className={sectionTitle}>Privacy</h2>
         <p className={bodyText}>
-          Your API key is stored only in this browser via{" "}
+          Your AI API key and optional GitHub OAuth token are stored only in this browser via{" "}
           <code className="rounded bg-opt-subtle px-1 py-0.5 text-[12px] text-opt-text">
             chrome.storage.local
           </code>
-          . Diffs and prompts go only to the provider you choose (Anthropic, OpenAI, or xAI).
-          There is no Guided Review backend in the middle.
+          . Diffs and prompts go only to the AI provider you choose (Anthropic, OpenAI, or xAI).
+          Connecting GitHub uses device sign-in so you can authorize API actions (such as
+          submitting reviews) without pasting a personal access token. There is no Guided Review
+          backend in the middle.
         </p>
       </section>
 

--- a/src/options/GitHubAuthSection.test.tsx
+++ b/src/options/GitHubAuthSection.test.tsx
@@ -1,9 +1,10 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GitHubAuthSection } from "./GitHubAuthSection";
 import * as messaging from "../lib/messaging";
 import * as oauthConfig from "../lib/github/oauthConfig";
+import * as deviceAuth from "../lib/github/useGitHubDeviceAuth";
 
 vi.mock("../lib/messaging", () => ({
   getGitHubAuthStatus: vi.fn(),
@@ -17,13 +18,22 @@ vi.mock("../lib/github/oauthConfig", () => ({
 }));
 
 describe("GitHubAuthSection", () => {
+  let openVerificationUriSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     vi.mocked(oauthConfig.isGitHubOAuthConfigured).mockReturnValue(true);
     vi.mocked(messaging.getGitHubAuthStatus).mockResolvedValue({ ok: true, auth: null });
     vi.mocked(messaging.startGitHubDeviceAuth).mockReset();
     vi.mocked(messaging.pollGitHubDeviceAuth).mockReset();
     vi.mocked(messaging.clearGitHubAuthSession).mockReset();
+    openVerificationUriSpy = vi
+      .spyOn(deviceAuth, "openVerificationUri")
+      .mockResolvedValue(undefined);
     vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    openVerificationUriSpy.mockRestore();
   });
 
   it("shows a setup message when OAuth is not configured", async () => {
@@ -58,7 +68,7 @@ describe("GitHubAuthSection", () => {
     expect(screen.getByRole("button", { name: /disconnect/i })).toBeInTheDocument();
   });
 
-  it("starts device flow and shows the user code", async () => {
+  it("starts device flow, shows the user code, and does not open GitHub yet", async () => {
     const user = userEvent.setup();
     vi.mocked(messaging.startGitHubDeviceAuth).mockResolvedValue({
       ok: true,
@@ -69,7 +79,6 @@ describe("GitHubAuthSection", () => {
       expiresIn: 900,
     });
     vi.mocked(messaging.pollGitHubDeviceAuth).mockResolvedValue({ ok: true, status: "pending" });
-    vi.mocked(chrome.tabs.create).mockResolvedValue({} as chrome.tabs.Tab);
 
     render(<GitHubAuthSection />);
     await screen.findByRole("button", { name: /connect github/i });
@@ -77,9 +86,37 @@ describe("GitHubAuthSection", () => {
 
     expect(await screen.findByTestId("github-user-code")).toHaveTextContent("WDJB-MJHT");
     expect(screen.getByText(/Waiting for authorization/i)).toBeInTheDocument();
-    expect(chrome.tabs.create).toHaveBeenCalledWith({
-      url: "https://github.com/login/device",
+    expect(screen.getByTestId("github-copy-hint")).toHaveTextContent(
+      /Copy this code, then paste it on the GitHub tab/i,
+    );
+    expect(screen.getByTestId("github-enter-code")).toHaveTextContent(
+      /Enter Code On Github/,
+    );
+    expect(openVerificationUriSpy).not.toHaveBeenCalled();
+  });
+
+  it("opens GitHub when Enter Code On Github is clicked", async () => {
+    const user = userEvent.setup();
+    vi.mocked(messaging.startGitHubDeviceAuth).mockResolvedValue({
+      ok: true,
+      userCode: "WDJB-MJHT",
+      verificationUri: "https://github.com/login/device",
+      deviceCode: "device-1",
+      interval: 60,
+      expiresIn: 900,
     });
+    vi.mocked(messaging.pollGitHubDeviceAuth).mockResolvedValue({ ok: true, status: "pending" });
+
+    render(<GitHubAuthSection />);
+    await screen.findByRole("button", { name: /connect github/i });
+    await user.click(screen.getByRole("button", { name: /connect github/i }));
+    await screen.findByTestId("github-user-code");
+
+    await user.click(screen.getByTestId("github-enter-code"));
+    expect(openVerificationUriSpy).toHaveBeenCalledTimes(1);
+    expect(openVerificationUriSpy).toHaveBeenCalledWith(
+      "https://github.com/login/device",
+    );
   });
 
   it("shows connected state after a successful poll", async () => {
@@ -104,7 +141,6 @@ describe("GitHubAuthSection", () => {
         login: "monalisa",
       },
     });
-    vi.mocked(chrome.tabs.create).mockResolvedValue({} as chrome.tabs.Tab);
 
     render(<GitHubAuthSection />);
     await screen.findByRole("button", { name: /connect github/i });

--- a/src/options/GitHubAuthSection.test.tsx
+++ b/src/options/GitHubAuthSection.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GitHubAuthSection } from "./GitHubAuthSection";
+import * as messaging from "../lib/messaging";
+import * as oauthConfig from "../lib/github/oauthConfig";
+
+vi.mock("../lib/messaging", () => ({
+  getGitHubAuthStatus: vi.fn(),
+  startGitHubDeviceAuth: vi.fn(),
+  pollGitHubDeviceAuth: vi.fn(),
+  clearGitHubAuthSession: vi.fn(),
+}));
+
+vi.mock("../lib/github/oauthConfig", () => ({
+  isGitHubOAuthConfigured: vi.fn(() => true),
+}));
+
+describe("GitHubAuthSection", () => {
+  beforeEach(() => {
+    vi.mocked(oauthConfig.isGitHubOAuthConfigured).mockReturnValue(true);
+    vi.mocked(messaging.getGitHubAuthStatus).mockResolvedValue({ ok: true, auth: null });
+    vi.mocked(messaging.startGitHubDeviceAuth).mockReset();
+    vi.mocked(messaging.pollGitHubDeviceAuth).mockReset();
+    vi.mocked(messaging.clearGitHubAuthSession).mockReset();
+    vi.useRealTimers();
+  });
+
+  it("shows a setup message when OAuth is not configured", async () => {
+    vi.mocked(oauthConfig.isGitHubOAuthConfigured).mockReturnValue(false);
+    render(<GitHubAuthSection />);
+
+    expect(await screen.findByText(/isn’t configured in this build/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /connect github/i })).not.toBeInTheDocument();
+  });
+
+  it("shows Connect when disconnected", async () => {
+    render(<GitHubAuthSection />);
+    expect(await screen.findByRole("button", { name: /connect github/i })).toBeInTheDocument();
+  });
+
+  it("shows the connected account when auth is stored", async () => {
+    vi.mocked(messaging.getGitHubAuthStatus).mockResolvedValue({
+      ok: true,
+      auth: {
+        accessToken: "gho_x",
+        tokenType: "bearer",
+        scope: "repo",
+        login: "octocat",
+        name: "The Octocat",
+      },
+    });
+
+    render(<GitHubAuthSection />);
+
+    expect(await screen.findByText("@octocat")).toBeInTheDocument();
+    expect(screen.getByText("The Octocat")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /disconnect/i })).toBeInTheDocument();
+  });
+
+  it("starts device flow and shows the user code", async () => {
+    const user = userEvent.setup();
+    vi.mocked(messaging.startGitHubDeviceAuth).mockResolvedValue({
+      ok: true,
+      userCode: "WDJB-MJHT",
+      verificationUri: "https://github.com/login/device",
+      deviceCode: "device-1",
+      interval: 60,
+      expiresIn: 900,
+    });
+    vi.mocked(messaging.pollGitHubDeviceAuth).mockResolvedValue({ ok: true, status: "pending" });
+    vi.mocked(chrome.tabs.create).mockResolvedValue({} as chrome.tabs.Tab);
+
+    render(<GitHubAuthSection />);
+    await screen.findByRole("button", { name: /connect github/i });
+    await user.click(screen.getByRole("button", { name: /connect github/i }));
+
+    expect(await screen.findByTestId("github-user-code")).toHaveTextContent("WDJB-MJHT");
+    expect(screen.getByText(/Waiting for authorization/i)).toBeInTheDocument();
+    expect(chrome.tabs.create).toHaveBeenCalledWith({
+      url: "https://github.com/login/device",
+    });
+  });
+
+  it("shows connected state after a successful poll", async () => {
+    const user = userEvent.setup();
+
+    vi.mocked(messaging.startGitHubDeviceAuth).mockResolvedValue({
+      ok: true,
+      userCode: "ABCD-EFGH",
+      verificationUri: "https://github.com/login/device",
+      deviceCode: "device-2",
+      // 0 so the first poll runs on the next timer tick without fake timers.
+      interval: 0,
+      expiresIn: 900,
+    });
+    vi.mocked(messaging.pollGitHubDeviceAuth).mockResolvedValue({
+      ok: true,
+      status: "authorized",
+      auth: {
+        accessToken: "gho_ok",
+        tokenType: "bearer",
+        scope: "repo,read:user",
+        login: "monalisa",
+      },
+    });
+    vi.mocked(chrome.tabs.create).mockResolvedValue({} as chrome.tabs.Tab);
+
+    render(<GitHubAuthSection />);
+    await screen.findByRole("button", { name: /connect github/i });
+    await user.click(screen.getByRole("button", { name: /connect github/i }));
+
+    // interval 0 polls immediately; may skip the awaiting UI if poll resolves fast.
+    await waitFor(() => {
+      expect(screen.getByText("@monalisa")).toBeInTheDocument();
+    });
+    expect(messaging.pollGitHubDeviceAuth).toHaveBeenCalledWith("device-2");
+  });
+
+  it("disconnects and returns to Connect", async () => {
+    const user = userEvent.setup();
+    vi.mocked(messaging.getGitHubAuthStatus).mockResolvedValue({
+      ok: true,
+      auth: {
+        accessToken: "gho_x",
+        tokenType: "bearer",
+        scope: "repo",
+        login: "octocat",
+      },
+    });
+    vi.mocked(messaging.clearGitHubAuthSession).mockResolvedValue({ ok: true });
+
+    render(<GitHubAuthSection />);
+    await screen.findByText("@octocat");
+    await user.click(screen.getByRole("button", { name: /disconnect/i }));
+
+    expect(messaging.clearGitHubAuthSession).toHaveBeenCalled();
+    expect(await screen.findByRole("button", { name: /connect github/i })).toBeInTheDocument();
+  });
+});

--- a/src/options/GitHubAuthSection.tsx
+++ b/src/options/GitHubAuthSection.tsx
@@ -1,26 +1,21 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import type { GitHubAuthState } from "../lib/types";
 import { isGitHubOAuthConfigured } from "../lib/github/oauthConfig";
 import {
+  openVerificationUri,
+  useGitHubDeviceAuth,
+} from "../lib/github/useGitHubDeviceAuth";
+import {
   clearGitHubAuthSession,
   getGitHubAuthStatus,
-  pollGitHubDeviceAuth,
-  startGitHubDeviceAuth,
 } from "../lib/messaging";
 import { ActionSpinner } from "./components/ActionSpinner";
 import { cn } from "../lib/cn";
 
-type ViewState =
+type SessionState =
   | { kind: "loading" }
   | { kind: "disconnected" }
-  | {
-      kind: "awaiting";
-      userCode: string;
-      verificationUri: string;
-      deviceCode: string;
-    }
-  | { kind: "connected"; auth: GitHubAuthState }
-  | { kind: "error"; message: string };
+  | { kind: "connected"; auth: GitHubAuthState };
 
 const primaryBtn =
   "inline-flex cursor-pointer items-center gap-2 rounded-md border border-opt-accent bg-opt-accent px-4 py-2 text-[13px] font-semibold text-opt-accent-on enabled:hover:border-opt-accent-hover enabled:hover:bg-opt-accent-hover disabled:cursor-default disabled:opacity-60";
@@ -30,32 +25,25 @@ const secondaryBtn =
 
 /**
  * Options section: GitHub device OAuth connect / disconnect.
- * Polling is owned here so the MV3 service worker does not need a long-lived timer.
+ * Device poll loop lives in useGitHubDeviceAuth (shared with the overlay modal).
  */
 export function GitHubAuthSection() {
   const configured = isGitHubOAuthConfigured();
-  const [view, setView] = useState<ViewState>({ kind: "loading" });
-  const [busy, setBusy] = useState(false);
+  const [session, setSession] = useState<SessionState>({ kind: "loading" });
+  const [disconnectBusy, setDisconnectBusy] = useState(false);
+  const [disconnectError, setDisconnectError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
 
-  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const pollGenerationRef = useRef(0);
-
-  const stopPolling = useCallback(() => {
-    pollGenerationRef.current += 1;
-    if (pollTimerRef.current !== null) {
-      clearTimeout(pollTimerRef.current);
-      pollTimerRef.current = null;
-    }
-  }, []);
-
-  useEffect(() => {
-    return () => stopPolling();
-  }, [stopPolling]);
+  const { flow, busy: connectBusy, startConnect, cancel } = useGitHubDeviceAuth({
+    enabled: configured,
+    onAuthorized: (auth) => {
+      setSession({ kind: "connected", auth });
+    },
+  });
 
   useEffect(() => {
     if (!configured) {
-      setView({ kind: "disconnected" });
+      setSession({ kind: "disconnected" });
       return;
     }
 
@@ -64,13 +52,13 @@ export function GitHubAuthSection() {
       .then((res) => {
         if (cancelled) return;
         if (res.ok && res.auth) {
-          setView({ kind: "connected", auth: res.auth });
+          setSession({ kind: "connected", auth: res.auth });
         } else {
-          setView({ kind: "disconnected" });
+          setSession({ kind: "disconnected" });
         }
       })
       .catch(() => {
-        if (!cancelled) setView({ kind: "disconnected" });
+        if (!cancelled) setSession({ kind: "disconnected" });
       });
 
     return () => {
@@ -78,119 +66,24 @@ export function GitHubAuthSection() {
     };
   }, [configured]);
 
-  const schedulePoll = useCallback(
-    (deviceCode: string, intervalSec: number, generation: number) => {
-      if (pollTimerRef.current !== null) {
-        clearTimeout(pollTimerRef.current);
-      }
-      pollTimerRef.current = setTimeout(() => {
-        void (async () => {
-          if (generation !== pollGenerationRef.current) return;
-
-          try {
-            const result = await pollGitHubDeviceAuth(deviceCode);
-            if (generation !== pollGenerationRef.current) return;
-
-            if (result.ok && result.status === "pending") {
-              schedulePoll(deviceCode, intervalSec, generation);
-              return;
-            }
-
-            if (result.ok && result.status === "slow_down") {
-              schedulePoll(deviceCode, result.interval, generation);
-              return;
-            }
-
-            if (result.ok && result.status === "authorized") {
-              stopPolling();
-              setBusy(false);
-              setView({ kind: "connected", auth: result.auth });
-              return;
-            }
-
-            // Failure terminal states
-            stopPolling();
-            setBusy(false);
-            const message =
-              !result.ok
-                ? result.error
-                : "GitHub authorization failed. Try connecting again.";
-            setView({ kind: "error", message });
-          } catch (error) {
-            if (generation !== pollGenerationRef.current) return;
-            stopPolling();
-            setBusy(false);
-            const message =
-              error instanceof Error
-                ? error.message
-                : "GitHub authorization failed unexpectedly.";
-            setView({ kind: "error", message });
-          }
-        })();
-      }, Math.max(0, intervalSec) * 1000);
-    },
-    [stopPolling],
-  );
-
-  const onConnect = async () => {
-    if (!configured || busy) return;
-    stopPolling();
-    setBusy(true);
-    setCopied(false);
-    setView({ kind: "disconnected" });
-
-    try {
-      const start = await startGitHubDeviceAuth();
-      if (!start.ok) {
-        setBusy(false);
-        setView({ kind: "error", message: start.error });
-        return;
-      }
-
-      setView({
-        kind: "awaiting",
-        userCode: start.userCode,
-        verificationUri: start.verificationUri,
-        deviceCode: start.deviceCode,
-      });
-
-      // Open the verification page for the user.
-      try {
-        await chrome.tabs.create({ url: start.verificationUri });
-      } catch {
-        // Popup blockers / missing tabs permission — user can still click the link.
-      }
-
-      const generation = pollGenerationRef.current;
-      // First poll after the server-recommended interval.
-      schedulePoll(start.deviceCode, start.interval, generation);
-    } catch (error) {
-      setBusy(false);
-      const message =
-        error instanceof Error ? error.message : "Could not start GitHub sign-in.";
-      setView({ kind: "error", message });
-    }
-  };
-
   const onCancel = () => {
-    stopPolling();
-    setBusy(false);
+    cancel();
     setCopied(false);
-    setView({ kind: "disconnected" });
   };
 
   const onDisconnect = async () => {
-    if (busy) return;
-    setBusy(true);
+    if (disconnectBusy || connectBusy) return;
+    setDisconnectBusy(true);
+    setDisconnectError(null);
     try {
       await clearGitHubAuthSession();
-      setView({ kind: "disconnected" });
+      setSession({ kind: "disconnected" });
     } catch (error) {
       const message =
         error instanceof Error ? error.message : "Could not disconnect GitHub.";
-      setView({ kind: "error", message });
+      setDisconnectError(message);
     } finally {
-      setBusy(false);
+      setDisconnectBusy(false);
     }
   };
 
@@ -203,6 +96,9 @@ export function GitHubAuthSection() {
       setCopied(false);
     }
   };
+
+  const busy = connectBusy || disconnectBusy;
+  const showError = flow.kind === "error" ? flow.message : disconnectError;
 
   return (
     <section className="mb-8 border-b border-opt-border pb-8" data-testid="github-auth-section">
@@ -222,57 +118,58 @@ export function GitHubAuthSection() {
         </p>
       )}
 
-      {configured && view.kind === "loading" && (
+      {configured && session.kind === "loading" && flow.kind === "idle" && !showError && (
         <p className="flex items-center gap-2 text-[13px] text-opt-muted" role="status">
           <ActionSpinner label="Loading GitHub connection" />
           Loading…
         </p>
       )}
 
-      {configured && view.kind === "disconnected" && (
-        <div className="flex flex-wrap items-center gap-2.5">
-          <button
-            type="button"
-            className={primaryBtn}
-            onClick={() => void onConnect()}
-            disabled={busy}
-          >
-            {busy && <ActionSpinner label="Connecting to GitHub" />}
-            {busy ? "Connecting…" : "Connect GitHub"}
-          </button>
-          <span className="text-xs text-opt-muted">Requests repo and read:user access.</span>
-        </div>
-      )}
-
-      {configured && view.kind === "awaiting" && (
-        <div className="space-y-3" data-testid="github-auth-awaiting">
-          <p className="m-0 text-[13px] text-opt-muted">
-            Enter this code at{" "}
-            <a
-              href={view.verificationUri}
-              target="_blank"
-              rel="noreferrer"
-              className="font-semibold text-opt-text underline"
+      {configured &&
+        session.kind === "disconnected" &&
+        flow.kind === "idle" &&
+        !showError && (
+          <div className="flex flex-wrap items-center gap-2.5">
+            <button
+              type="button"
+              className={primaryBtn}
+              onClick={() => {
+                setDisconnectError(null);
+                void startConnect();
+              }}
+              disabled={busy}
             >
-              {view.verificationUri.replace(/^https?:\/\//, "")}
-            </a>
-            , then keep this page open until authorization finishes.
-          </p>
+              {busy && <ActionSpinner label="Connecting to GitHub" />}
+              {busy ? "Connecting…" : "Connect GitHub"}
+            </button>
+            <span className="text-xs text-opt-muted">Requests repo and read:user access.</span>
+          </div>
+        )}
+
+      {configured && flow.kind === "awaiting" && (
+        <div className="space-y-3" data-testid="github-auth-awaiting">
           <div className="flex flex-wrap items-center gap-2">
             <code
               className="rounded-md border border-opt-border bg-opt-subtle px-3 py-2 font-mono text-lg tracking-widest text-opt-text"
               data-testid="github-user-code"
             >
-              {view.userCode}
+              {flow.userCode}
             </code>
             <button
               type="button"
               className={secondaryBtn}
-              onClick={() => void onCopyCode(view.userCode)}
+              onClick={() => void onCopyCode(flow.userCode)}
+              data-testid="github-copy-code"
             >
               {copied ? "Copied" : "Copy code"}
             </button>
           </div>
+          <p
+            className="m-0 text-[13px] text-opt-muted"
+            data-testid="github-copy-hint"
+          >
+            Copy this code, then paste it on the GitHub tab.
+          </p>
           <div className="flex flex-wrap items-center gap-2.5">
             <span className="flex items-center gap-2 text-[13px] text-opt-muted" role="status">
               <ActionSpinner label="Waiting for GitHub authorization" />
@@ -281,19 +178,27 @@ export function GitHubAuthSection() {
             <button type="button" className={secondaryBtn} onClick={onCancel}>
               Cancel
             </button>
+            <button
+              type="button"
+              className={primaryBtn}
+              onClick={() => void openVerificationUri(flow.verificationUri)}
+              data-testid="github-enter-code"
+            >
+              Enter Code On Github
+            </button>
           </div>
         </div>
       )}
 
-      {configured && view.kind === "connected" && (
+      {configured && session.kind === "connected" && flow.kind === "idle" && !showError && (
         <div
           className="flex flex-wrap items-center justify-between gap-3"
           data-testid="github-auth-connected"
         >
           <div className="flex min-w-0 items-center gap-3">
-            {view.auth.avatarUrl ? (
+            {session.auth.avatarUrl ? (
               <img
-                src={view.auth.avatarUrl}
+                src={session.auth.avatarUrl}
                 alt=""
                 width={36}
                 height={36}
@@ -304,15 +209,15 @@ export function GitHubAuthSection() {
                 className="flex h-9 w-9 items-center justify-center rounded-full border border-opt-border bg-opt-subtle text-xs font-semibold text-opt-muted"
                 aria-hidden
               >
-                {view.auth.login.slice(0, 1).toUpperCase()}
+                {session.auth.login.slice(0, 1).toUpperCase()}
               </div>
             )}
             <div className="min-w-0">
               <p className="m-0 truncate text-[13px] font-semibold text-opt-text">
-                @{view.auth.login}
+                @{session.auth.login}
               </p>
-              {view.auth.name ? (
-                <p className="m-0 truncate text-xs text-opt-muted">{view.auth.name}</p>
+              {session.auth.name ? (
+                <p className="m-0 truncate text-xs text-opt-muted">{session.auth.name}</p>
               ) : (
                 <p className="m-0 text-xs text-opt-ok">Connected</p>
               )}
@@ -324,19 +229,22 @@ export function GitHubAuthSection() {
             onClick={() => void onDisconnect()}
             disabled={busy}
           >
-            {busy && <ActionSpinner label="Disconnecting" />}
+            {disconnectBusy && <ActionSpinner label="Disconnecting" />}
             Disconnect
           </button>
         </div>
       )}
 
-      {configured && view.kind === "error" && (
+      {configured && showError && (
         <div className="space-y-3" role="alert">
-          <p className={cn("m-0 text-[13px] text-opt-error")}>{view.message}</p>
+          <p className={cn("m-0 text-[13px] text-opt-error")}>{showError}</p>
           <button
             type="button"
             className={primaryBtn}
-            onClick={() => void onConnect()}
+            onClick={() => {
+              setDisconnectError(null);
+              void startConnect();
+            }}
             disabled={busy}
           >
             Try again

--- a/src/options/GitHubAuthSection.tsx
+++ b/src/options/GitHubAuthSection.tsx
@@ -1,0 +1,348 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { GitHubAuthState } from "../lib/types";
+import { isGitHubOAuthConfigured } from "../lib/github/oauthConfig";
+import {
+  clearGitHubAuthSession,
+  getGitHubAuthStatus,
+  pollGitHubDeviceAuth,
+  startGitHubDeviceAuth,
+} from "../lib/messaging";
+import { ActionSpinner } from "./components/ActionSpinner";
+import { cn } from "../lib/cn";
+
+type ViewState =
+  | { kind: "loading" }
+  | { kind: "disconnected" }
+  | {
+      kind: "awaiting";
+      userCode: string;
+      verificationUri: string;
+      deviceCode: string;
+    }
+  | { kind: "connected"; auth: GitHubAuthState }
+  | { kind: "error"; message: string };
+
+const primaryBtn =
+  "inline-flex cursor-pointer items-center gap-2 rounded-md border border-opt-accent bg-opt-accent px-4 py-2 text-[13px] font-semibold text-opt-accent-on enabled:hover:border-opt-accent-hover enabled:hover:bg-opt-accent-hover disabled:cursor-default disabled:opacity-60";
+
+const secondaryBtn =
+  "inline-flex cursor-pointer items-center gap-2 rounded-md border border-opt-border bg-opt-subtle px-4 py-2 text-[13px] font-semibold text-opt-text disabled:cursor-default disabled:opacity-60";
+
+/**
+ * Options section: GitHub device OAuth connect / disconnect.
+ * Polling is owned here so the MV3 service worker does not need a long-lived timer.
+ */
+export function GitHubAuthSection() {
+  const configured = isGitHubOAuthConfigured();
+  const [view, setView] = useState<ViewState>({ kind: "loading" });
+  const [busy, setBusy] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pollGenerationRef = useRef(0);
+
+  const stopPolling = useCallback(() => {
+    pollGenerationRef.current += 1;
+    if (pollTimerRef.current !== null) {
+      clearTimeout(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => stopPolling();
+  }, [stopPolling]);
+
+  useEffect(() => {
+    if (!configured) {
+      setView({ kind: "disconnected" });
+      return;
+    }
+
+    let cancelled = false;
+    void getGitHubAuthStatus()
+      .then((res) => {
+        if (cancelled) return;
+        if (res.ok && res.auth) {
+          setView({ kind: "connected", auth: res.auth });
+        } else {
+          setView({ kind: "disconnected" });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setView({ kind: "disconnected" });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [configured]);
+
+  const schedulePoll = useCallback(
+    (deviceCode: string, intervalSec: number, generation: number) => {
+      if (pollTimerRef.current !== null) {
+        clearTimeout(pollTimerRef.current);
+      }
+      pollTimerRef.current = setTimeout(() => {
+        void (async () => {
+          if (generation !== pollGenerationRef.current) return;
+
+          try {
+            const result = await pollGitHubDeviceAuth(deviceCode);
+            if (generation !== pollGenerationRef.current) return;
+
+            if (result.ok && result.status === "pending") {
+              schedulePoll(deviceCode, intervalSec, generation);
+              return;
+            }
+
+            if (result.ok && result.status === "slow_down") {
+              schedulePoll(deviceCode, result.interval, generation);
+              return;
+            }
+
+            if (result.ok && result.status === "authorized") {
+              stopPolling();
+              setBusy(false);
+              setView({ kind: "connected", auth: result.auth });
+              return;
+            }
+
+            // Failure terminal states
+            stopPolling();
+            setBusy(false);
+            const message =
+              !result.ok
+                ? result.error
+                : "GitHub authorization failed. Try connecting again.";
+            setView({ kind: "error", message });
+          } catch (error) {
+            if (generation !== pollGenerationRef.current) return;
+            stopPolling();
+            setBusy(false);
+            const message =
+              error instanceof Error
+                ? error.message
+                : "GitHub authorization failed unexpectedly.";
+            setView({ kind: "error", message });
+          }
+        })();
+      }, Math.max(0, intervalSec) * 1000);
+    },
+    [stopPolling],
+  );
+
+  const onConnect = async () => {
+    if (!configured || busy) return;
+    stopPolling();
+    setBusy(true);
+    setCopied(false);
+    setView({ kind: "disconnected" });
+
+    try {
+      const start = await startGitHubDeviceAuth();
+      if (!start.ok) {
+        setBusy(false);
+        setView({ kind: "error", message: start.error });
+        return;
+      }
+
+      setView({
+        kind: "awaiting",
+        userCode: start.userCode,
+        verificationUri: start.verificationUri,
+        deviceCode: start.deviceCode,
+      });
+
+      // Open the verification page for the user.
+      try {
+        await chrome.tabs.create({ url: start.verificationUri });
+      } catch {
+        // Popup blockers / missing tabs permission — user can still click the link.
+      }
+
+      const generation = pollGenerationRef.current;
+      // First poll after the server-recommended interval.
+      schedulePoll(start.deviceCode, start.interval, generation);
+    } catch (error) {
+      setBusy(false);
+      const message =
+        error instanceof Error ? error.message : "Could not start GitHub sign-in.";
+      setView({ kind: "error", message });
+    }
+  };
+
+  const onCancel = () => {
+    stopPolling();
+    setBusy(false);
+    setCopied(false);
+    setView({ kind: "disconnected" });
+  };
+
+  const onDisconnect = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await clearGitHubAuthSession();
+      setView({ kind: "disconnected" });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Could not disconnect GitHub.";
+      setView({ kind: "error", message });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onCopyCode = async (code: string) => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <section className="mb-8 border-b border-opt-border pb-8" data-testid="github-auth-section">
+      <h2 className="mb-1.5 text-[13px] font-semibold text-opt-text">GitHub account</h2>
+      <p className="mb-4 text-[13px] text-opt-muted">
+        Connect GitHub so Guided Review can act on your behalf (for example, submitting reviews).
+        Uses device sign-in — no password is stored here. Token stays in this browser only.
+      </p>
+
+      {!configured && (
+        <p className="text-[13px] text-opt-muted" role="status">
+          GitHub connection isn’t configured in this build. Set{" "}
+          <code className="rounded bg-opt-subtle px-1 py-0.5 text-[12px] text-opt-text">
+            VITE_GITHUB_CLIENT_ID
+          </code>{" "}
+          and rebuild.
+        </p>
+      )}
+
+      {configured && view.kind === "loading" && (
+        <p className="flex items-center gap-2 text-[13px] text-opt-muted" role="status">
+          <ActionSpinner label="Loading GitHub connection" />
+          Loading…
+        </p>
+      )}
+
+      {configured && view.kind === "disconnected" && (
+        <div className="flex flex-wrap items-center gap-2.5">
+          <button
+            type="button"
+            className={primaryBtn}
+            onClick={() => void onConnect()}
+            disabled={busy}
+          >
+            {busy && <ActionSpinner label="Connecting to GitHub" />}
+            {busy ? "Connecting…" : "Connect GitHub"}
+          </button>
+          <span className="text-xs text-opt-muted">Requests repo and read:user access.</span>
+        </div>
+      )}
+
+      {configured && view.kind === "awaiting" && (
+        <div className="space-y-3" data-testid="github-auth-awaiting">
+          <p className="m-0 text-[13px] text-opt-muted">
+            Enter this code at{" "}
+            <a
+              href={view.verificationUri}
+              target="_blank"
+              rel="noreferrer"
+              className="font-semibold text-opt-text underline"
+            >
+              {view.verificationUri.replace(/^https?:\/\//, "")}
+            </a>
+            , then keep this page open until authorization finishes.
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <code
+              className="rounded-md border border-opt-border bg-opt-subtle px-3 py-2 font-mono text-lg tracking-widest text-opt-text"
+              data-testid="github-user-code"
+            >
+              {view.userCode}
+            </code>
+            <button
+              type="button"
+              className={secondaryBtn}
+              onClick={() => void onCopyCode(view.userCode)}
+            >
+              {copied ? "Copied" : "Copy code"}
+            </button>
+          </div>
+          <div className="flex flex-wrap items-center gap-2.5">
+            <span className="flex items-center gap-2 text-[13px] text-opt-muted" role="status">
+              <ActionSpinner label="Waiting for GitHub authorization" />
+              Waiting for authorization…
+            </span>
+            <button type="button" className={secondaryBtn} onClick={onCancel}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {configured && view.kind === "connected" && (
+        <div
+          className="flex flex-wrap items-center justify-between gap-3"
+          data-testid="github-auth-connected"
+        >
+          <div className="flex min-w-0 items-center gap-3">
+            {view.auth.avatarUrl ? (
+              <img
+                src={view.auth.avatarUrl}
+                alt=""
+                width={36}
+                height={36}
+                className="h-9 w-9 rounded-full border border-opt-border"
+              />
+            ) : (
+              <div
+                className="flex h-9 w-9 items-center justify-center rounded-full border border-opt-border bg-opt-subtle text-xs font-semibold text-opt-muted"
+                aria-hidden
+              >
+                {view.auth.login.slice(0, 1).toUpperCase()}
+              </div>
+            )}
+            <div className="min-w-0">
+              <p className="m-0 truncate text-[13px] font-semibold text-opt-text">
+                @{view.auth.login}
+              </p>
+              {view.auth.name ? (
+                <p className="m-0 truncate text-xs text-opt-muted">{view.auth.name}</p>
+              ) : (
+                <p className="m-0 text-xs text-opt-ok">Connected</p>
+              )}
+            </div>
+          </div>
+          <button
+            type="button"
+            className={secondaryBtn}
+            onClick={() => void onDisconnect()}
+            disabled={busy}
+          >
+            {busy && <ActionSpinner label="Disconnecting" />}
+            Disconnect
+          </button>
+        </div>
+      )}
+
+      {configured && view.kind === "error" && (
+        <div className="space-y-3" role="alert">
+          <p className={cn("m-0 text-[13px] text-opt-error")}>{view.message}</p>
+          <button
+            type="button"
+            className={primaryBtn}
+            onClick={() => void onConnect()}
+            disabled={busy}
+          >
+            Try again
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/options/Options.test.tsx
+++ b/src/options/Options.test.tsx
@@ -93,7 +93,16 @@ describe("Options", () => {
 
   it("shows a success status when the connection test succeeds", async () => {
     const user = userEvent.setup();
-    vi.mocked(chrome.runtime.sendMessage).mockResolvedValueOnce({ ok: true });
+    // GitHubAuthSection also messages on mount (GITHUB_AUTH_GET); route by type.
+    vi.mocked(chrome.runtime.sendMessage).mockImplementation(async (message) => {
+      const type =
+        message && typeof message === "object" && "type" in message
+          ? (message as { type: string }).type
+          : "";
+      if (type === "GITHUB_AUTH_GET") return { ok: true, auth: null };
+      if (type === "TEST_CONNECTION") return { ok: true };
+      return undefined;
+    });
     render(<Options />);
 
     await screen.findByRole("combobox", { name: /provider/i });
@@ -105,9 +114,14 @@ describe("Options", () => {
 
   it("shows the error message when the connection test fails", async () => {
     const user = userEvent.setup();
-    vi.mocked(chrome.runtime.sendMessage).mockResolvedValueOnce({
-      ok: false,
-      error: "Invalid API key",
+    vi.mocked(chrome.runtime.sendMessage).mockImplementation(async (message) => {
+      const type =
+        message && typeof message === "object" && "type" in message
+          ? (message as { type: string }).type
+          : "";
+      if (type === "GITHUB_AUTH_GET") return { ok: true, auth: null };
+      if (type === "TEST_CONNECTION") return { ok: false, error: "Invalid API key" };
+      return undefined;
     });
     render(<Options />);
 
@@ -120,9 +134,17 @@ describe("Options", () => {
 
   it("shows an error when the connection test throws", async () => {
     const user = userEvent.setup();
-    vi.mocked(chrome.runtime.sendMessage).mockRejectedValueOnce(
-      new Error("Extension context invalidated"),
-    );
+    vi.mocked(chrome.runtime.sendMessage).mockImplementation(async (message) => {
+      const type =
+        message && typeof message === "object" && "type" in message
+          ? (message as { type: string }).type
+          : "";
+      if (type === "GITHUB_AUTH_GET") return { ok: true, auth: null };
+      if (type === "TEST_CONNECTION") {
+        throw new Error("Extension context invalidated");
+      }
+      return undefined;
+    });
     render(<Options />);
 
     await screen.findByRole("combobox", { name: /provider/i });

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -12,6 +12,7 @@ import { Select, type SelectOption } from "./components/Select";
 import { ProviderIcon } from "./components/ProviderIcon";
 import { ActionSpinner } from "./components/ActionSpinner";
 import { BrandHeader } from "./BrandHeader";
+import { GitHubAuthSection } from "./GitHubAuthSection";
 import { cn } from "../lib/cn";
 
 type ActionStatus =
@@ -128,9 +129,12 @@ export function Options() {
     <div className="mx-auto max-w-[480px] px-6 py-8">
       <BrandHeader />
       <p className="mb-6 text-[13px] text-opt-muted">
-        Choose an AI provider and paste your own API key. The key is stored only in this
-        browser and is used solely to annotate PR diffs you open.
+        Connect GitHub and choose an AI provider. Keys and tokens stay in this browser only.
       </p>
+
+      <GitHubAuthSection />
+
+      <h2 className="mb-4 text-[13px] font-semibold text-opt-text">AI provider</h2>
 
       <div className="mb-4">
         <label className="mb-1.5 block text-[13px] font-semibold" id="provider-label" htmlFor="provider">


### PR DESCRIPTION
## Summary
- Add GitHub **device OAuth** so users can connect their account from Options (token stored via `chrome.storage`, scoped for PR reviews).
- Wire **submit review** through the background service worker (`SUBMIT_REVIEW`) calling the GitHub API with draft comments mapped to review comments.
- Show a **review submitted** success state in the overlay, including a link back to the PR conversation.

## Test plan
- [ ] Set `VITE_GITHUB_CLIENT_ID` and rebuild; confirm Options → GitHub connection shows device code flow and completes successfully
- [ ] Disconnect/reconnect GitHub from Options; confirm auth clears and re-auth works
- [ ] On a real PR, leave draft comments in the guided review overlay and submit (Approve / Request changes / Comment)
- [ ] Confirm submitted review appears on the PR Conversation tab and the success modal links correctly
- [ ] Confirm unauthenticated submit prompts connect-to-GitHub rather than a cryptic API error
- [ ] `npm test` and `npm run build` pass locally