### PR TITLE
Use consistent type scale tokens instead of hardcoded font sizes

### DIFF
--- a/src/content/overlay/Overlay.tsx
+++ b/src/content/overlay/Overlay.tsx
@@ -531,7 +531,7 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-[2147483000] flex flex-col bg-gr-bg font-sans text-sm text-gr-text antialiased [color-scheme:dark] [text-rendering:optimizeLegibility]">
+    <div className="fixed inset-0 z-[2147483000] flex flex-col bg-gr-bg font-sans text-base text-gr-text antialiased [color-scheme:dark] [text-rendering:optimizeLegibility]">
       <ProgressHeader
         prContext={prContext}
         diff={diff}

--- a/src/content/overlay/components/CommentComposer.test.tsx
+++ b/src/content/overlay/components/CommentComposer.test.tsx
@@ -20,7 +20,7 @@ describe("CommentComposer", () => {
     const input = screen.getByTestId("comment-composer-input");
     expect(input).toHaveFocus();
     expect(input.className).toMatch(/font-sans/);
-    expect(input.className).toMatch(/text-\[14px\]/);
+    expect(input.className).toMatch(/\btext-base\b/);
   });
 
   it("saves with Ctrl+Enter when body is non-empty", () => {

--- a/src/content/overlay/components/CommentComposer.tsx
+++ b/src/content/overlay/components/CommentComposer.tsx
@@ -52,12 +52,12 @@ export function CommentComposer({
       role="form"
       aria-label="Draft review comment"
     >
-      <div className="mb-2 font-mono text-[12px] text-gr-muted">
+      <div className="mb-2 font-mono text-sm text-gr-muted">
         {formatLineRangeLabel(filePath, startLine, endLine)}
       </div>
       <textarea
         ref={textareaRef}
-        className="min-h-[88px] w-full resize-y rounded-md border border-gr-border bg-gr-bg px-3 py-2 font-sans text-[14px] leading-relaxed text-gr-text outline-none placeholder:text-gr-faint focus:border-gr-accent"
+        className="min-h-[88px] w-full resize-y rounded-md border border-gr-border bg-gr-bg px-3 py-2 font-sans text-base leading-relaxed text-gr-text outline-none placeholder:text-gr-faint focus:border-gr-accent"
         placeholder="Leave a review comment (markdown supported)…"
         value={body}
         onChange={(e) => setBody(e.target.value)}
@@ -68,7 +68,7 @@ export function CommentComposer({
       <div className="mt-2 flex flex-wrap items-center justify-end gap-2">
         <button
           type="button"
-          className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-[13px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+          className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-base text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
           onClick={onCancel}
         >
           Cancel
@@ -76,7 +76,7 @@ export function CommentComposer({
         </button>
         <button
           type="button"
-          className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-[13px] font-medium text-gr-accent-on enabled:hover:border-gr-accent-hover enabled:hover:bg-gr-accent-hover disabled:cursor-not-allowed disabled:opacity-40 [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
+          className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-base font-medium text-gr-accent-on enabled:hover:border-gr-accent-hover enabled:hover:bg-gr-accent-hover disabled:cursor-not-allowed disabled:opacity-40 [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
           disabled={!canSave}
           onClick={() => {
             if (canSave) onSave(body);

--- a/src/content/overlay/components/CommentComposer.tsx
+++ b/src/content/overlay/components/CommentComposer.tsx
@@ -68,7 +68,7 @@ export function CommentComposer({
       <div className="mt-2 flex flex-wrap items-center justify-end gap-2">
         <button
           type="button"
-          className="inline-flex min-h-11 cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-2 text-base text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+          className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-base text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
           onClick={onCancel}
         >
           Cancel
@@ -76,7 +76,7 @@ export function CommentComposer({
         </button>
         <button
           type="button"
-          className="inline-flex min-h-11 cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-3 py-2 text-base font-medium text-gr-accent-on enabled:hover:border-gr-accent-hover enabled:hover:bg-gr-accent-hover disabled:cursor-not-allowed disabled:opacity-40 [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
+          className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-base font-medium text-gr-accent-on enabled:hover:border-gr-accent-hover enabled:hover:bg-gr-accent-hover disabled:cursor-not-allowed disabled:opacity-40 [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
           disabled={!canSave}
           onClick={() => {
             if (canSave) onSave(body);

--- a/src/content/overlay/components/ConnectGitHubModal.tsx
+++ b/src/content/overlay/components/ConnectGitHubModal.tsx
@@ -26,10 +26,10 @@ export interface ConnectGitHubModalProps {
 }
 
 const primaryBtn =
-  "inline-flex cursor-pointer items-center gap-2 rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-[13px] font-medium text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover disabled:cursor-not-allowed disabled:opacity-60 [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit";
+  "inline-flex cursor-pointer items-center gap-2 rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-base font-medium text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover disabled:cursor-not-allowed disabled:opacity-60 [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit";
 
 const secondaryBtn =
-  "inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-[13px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text disabled:cursor-not-allowed disabled:opacity-50";
+  "inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-base text-gr-muted hover:bg-gr-subtle hover:text-gr-text disabled:cursor-not-allowed disabled:opacity-50";
 
 /** Official GitHub mark (Octocat) — filled via currentColor. */
 function GitHubLogo({ className }: { className?: string }) {
@@ -193,25 +193,25 @@ export function ConnectGitHubModal({
 
           <h2
             id={titleId}
-            className="m-0 w-full text-center text-[16px] font-semibold text-gr-text"
+            className="m-0 w-full text-center text-lg font-semibold text-gr-text"
           >
             Connect GitHub
           </h2>
 
           {!configured ? (
             <p
-              className="m-0 w-full text-center text-[13px] leading-relaxed text-gr-muted"
+              className="m-0 w-full text-center text-base leading-relaxed text-gr-muted"
               role="status"
             >
               GitHub connection isn’t configured in this build. Set{" "}
-              <code className="rounded bg-gr-bg px-1 py-0.5 text-[12px] text-gr-text">
+              <code className="rounded bg-gr-bg px-1 py-0.5 text-sm text-gr-text">
                 VITE_GITHUB_CLIENT_ID
               </code>{" "}
               and rebuild.
             </p>
           ) : flow.kind === "error" ? (
             <p
-              className="m-0 w-full rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-left text-[13px] leading-snug text-red-200"
+              className="m-0 w-full rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-left text-base leading-snug text-red-200"
               role="alert"
               data-testid="connect-github-error"
             >
@@ -239,13 +239,13 @@ export function ConnectGitHubModal({
                 </button>
               </div>
               <p
-                className="m-0 text-center text-[13px] leading-relaxed text-gr-muted"
+                className="m-0 text-center text-base leading-relaxed text-gr-muted"
                 data-testid="connect-github-copy-hint"
               >
                 Copy this code, then paste it on the GitHub tab.
               </p>
               <span
-                className="flex items-center justify-center gap-2 text-[13px] text-gr-muted"
+                className="flex items-center justify-center gap-2 text-base text-gr-muted"
                 role="status"
               >
                 <Spinner label="Waiting for GitHub authorization" size={16} />
@@ -254,7 +254,7 @@ export function ConnectGitHubModal({
             </div>
           ) : (
             <p
-              className="m-0 w-full text-center text-[13.5px] leading-relaxed text-gr-muted"
+              className="m-0 w-full text-center text-base leading-relaxed text-gr-muted"
               data-testid="connect-github-prompt"
             >
               You need to authenticate via GitHub to submit your reviews.

--- a/src/content/overlay/components/ContextPanel.tsx
+++ b/src/content/overlay/components/ContextPanel.tsx
@@ -42,7 +42,10 @@ export function ContextPanel({
             {error.statusCode !== undefined && (
               <>
                 <dt className="m-0 font-medium text-gr-muted">HTTP status</dt>
-                <dd className="m-0 font-mono text-gr-danger" data-testid="error-status-code">
+                <dd
+                  className="m-0 font-mono text-gr-danger"
+                  data-testid="error-status-code"
+                >
                   {error.statusCode}
                 </dd>
               </>
@@ -50,7 +53,10 @@ export function ContextPanel({
             {error.code && (
               <>
                 <dt className="m-0 font-medium text-gr-muted">Error code</dt>
-                <dd className="m-0 font-mono break-all text-gr-danger" data-testid="error-code">
+                <dd
+                  className="m-0 font-mono break-all text-gr-danger"
+                  data-testid="error-code"
+                >
                   {error.code}
                 </dd>
               </>
@@ -67,7 +73,7 @@ export function ContextPanel({
             <button
               type="button"
               onClick={onRetry}
-              className="inline-flex min-h-11 cursor-pointer items-center rounded-md border border-gr-accent bg-gr-accent px-3 py-2 text-base font-medium text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover"
+              className="inline-flex cursor-pointer items-center rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-base font-medium text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover"
             >
               Retry
             </button>
@@ -85,13 +91,18 @@ export function ContextPanel({
 
     return (
       <div className="rounded-none border-0 bg-transparent px-0 py-0.5 pb-1">
-        <div className="text-base leading-[1.7] text-gr-text" data-testid="context-panel-body">
+        <div
+          className="text-lg leading-[1.7] text-gr-text"
+          data-testid="context-panel-body"
+        >
           {hint}
         </div>
         {loading ? (
           <div className="mt-4 flex items-center gap-2.5 border-t border-gr-border-muted pt-3">
             <Spinner label="Building the rest of the walkthrough" />
-            <p className="m-0 text-base text-gr-muted">Building the rest of the walkthrough…</p>
+            <p className="m-0 text-base text-gr-muted">
+              Building the rest of the walkthrough…
+            </p>
           </div>
         ) : (
           <KeyboardShortcuts />
@@ -102,7 +113,10 @@ export function ContextPanel({
 
   return (
     <div className="rounded-none border-0 bg-transparent px-0 py-0.5 pb-1">
-      <div className="text-base leading-[1.7] text-gr-text" data-testid="context-panel-body">
+      <div
+        className="text-base leading-[1.7] text-gr-text"
+        data-testid="context-panel-body"
+      >
         {unit.context}
       </div>
     </div>

--- a/src/content/overlay/components/ContextPanel.tsx
+++ b/src/content/overlay/components/ContextPanel.tsx
@@ -34,7 +34,7 @@ export function ContextPanel({
         </div>
 
         {(error.statusCode !== undefined || error.code) && (
-          <dl className="mb-2 m-0 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-[12.5px] leading-normal">
+          <dl className="mb-2 m-0 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-sm leading-normal">
             {error.statusCode !== undefined && (
               <>
                 <dt className="m-0 font-medium text-gr-muted">HTTP status</dt>
@@ -54,7 +54,7 @@ export function ContextPanel({
           </dl>
         )}
 
-        <pre className="m-0 max-h-[40vh] overflow-x-auto overflow-y-auto rounded-md border border-gr-danger bg-gr-danger-subtle p-3 text-left font-mono text-[12.5px] leading-normal break-words whitespace-pre-wrap text-gr-danger">
+        <pre className="m-0 max-h-[40vh] overflow-x-auto overflow-y-auto rounded-md border border-gr-danger bg-gr-danger-subtle p-3 text-left font-mono text-sm leading-normal break-words whitespace-pre-wrap text-gr-danger">
           <code data-testid="error-message">{error.message}</code>
         </pre>
 
@@ -64,7 +64,7 @@ export function ContextPanel({
               type="button"
               onClick={onRetry}
               aria-label="Retry building the guided review"
-              className="inline-flex cursor-pointer items-center rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-[13px] font-medium text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover"
+              className="inline-flex cursor-pointer items-center rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-base font-medium text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover"
             >
               Retry
             </button>
@@ -88,7 +88,7 @@ export function ContextPanel({
         {loading ? (
           <div className="mt-4 flex items-center gap-2.5 border-t border-gr-border-muted pt-3">
             <Spinner label="Building the rest of the walkthrough" />
-            <p className="m-0 text-[13px] text-gr-muted">Building the rest of the walkthrough…</p>
+            <p className="m-0 text-base text-gr-muted">Building the rest of the walkthrough…</p>
           </div>
         ) : (
           <KeyboardShortcuts />

--- a/src/content/overlay/components/DiffPane.tsx
+++ b/src/content/overlay/components/DiffPane.tsx
@@ -462,7 +462,7 @@ function DiffViewToggle({
         <button
           type="button"
           className={cn(
-            "inline-flex min-h-11 cursor-pointer items-center gap-1.5 px-3 py-2 text-base transition-colors",
+            "inline-flex cursor-pointer items-center gap-1.5 px-3 py-1.5 text-base transition-colors",
             mode === "unified"
               ? "bg-gr-subtle text-gr-text"
               : "bg-transparent text-gr-muted hover:bg-gr-subtle hover:text-gr-text",
@@ -478,7 +478,7 @@ function DiffViewToggle({
         <button
           type="button"
           className={cn(
-            "inline-flex min-h-11 cursor-pointer items-center gap-1.5 border-l border-gr-border px-3 py-2 text-base transition-colors",
+            "inline-flex cursor-pointer items-center gap-1.5 border-l border-gr-border px-3 py-1.5 text-base transition-colors",
             mode === "split"
               ? "bg-gr-subtle text-gr-text"
               : "bg-transparent text-gr-muted hover:bg-gr-subtle hover:text-gr-text",
@@ -521,7 +521,7 @@ function AddCommentButton({
     <button
       type="button"
       className={cn(
-        "inline-flex min-h-11 shrink-0 items-center gap-1.5 rounded-md border border-gr-border px-3 py-2 text-base transition-colors",
+        "inline-flex shrink-0 items-center gap-1.5 rounded-md border border-gr-border px-3 py-1.5 text-base transition-colors",
         disabled
           ? "cursor-not-allowed bg-gr-bg text-gr-faint opacity-60"
           : "cursor-pointer bg-gr-bg text-gr-text hover:bg-gr-subtle",

--- a/src/content/overlay/components/DiffPane.tsx
+++ b/src/content/overlay/components/DiffPane.tsx
@@ -197,7 +197,7 @@ function UnifiedHunk({
 
   return (
     <div
-      className="overflow-x-hidden font-mono text-[12px] leading-relaxed"
+      className="overflow-x-hidden font-mono text-sm leading-relaxed"
       data-testid="diff-view-unified"
     >
       {hunk.lines.map((line, i) => {
@@ -360,7 +360,7 @@ function SplitHunk({
 
   return (
     <div
-      className="overflow-x-hidden font-mono text-[12px] leading-relaxed"
+      className="overflow-x-hidden font-mono text-sm leading-relaxed"
       data-testid="diff-view-split"
     >
       {rows.map((row, i) => {
@@ -460,7 +460,7 @@ function DiffViewToggle({
         <button
           type="button"
           className={cn(
-            "inline-flex cursor-pointer items-center gap-1.5 px-3 py-1.5 text-[13px] transition-colors",
+            "inline-flex cursor-pointer items-center gap-1.5 px-3 py-1.5 text-base transition-colors",
             mode === "unified"
               ? "bg-gr-subtle text-gr-text"
               : "bg-transparent text-gr-muted hover:bg-gr-subtle hover:text-gr-text",
@@ -475,7 +475,7 @@ function DiffViewToggle({
         <button
           type="button"
           className={cn(
-            "inline-flex cursor-pointer items-center gap-1.5 border-l border-gr-border px-3 py-1.5 text-[13px] transition-colors",
+            "inline-flex cursor-pointer items-center gap-1.5 border-l border-gr-border px-3 py-1.5 text-base transition-colors",
             mode === "split"
               ? "bg-gr-subtle text-gr-text"
               : "bg-transparent text-gr-muted hover:bg-gr-subtle hover:text-gr-text",
@@ -495,7 +495,7 @@ function DiffViewToggle({
 function CommentModeChip() {
   return (
     <span
-      className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-gr-accent/40 bg-gr-accent-subtle px-2.5 py-1 text-[12px] text-gr-accent"
+      className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-gr-accent/40 bg-gr-accent-subtle px-2.5 py-1 text-sm text-gr-accent"
       data-testid="comment-mode-chip"
     >
       Comment mode
@@ -517,7 +517,7 @@ function AddCommentButton({
     <button
       type="button"
       className={cn(
-        "inline-flex shrink-0 items-center gap-1.5 rounded-md border border-gr-border px-3 py-1.5 text-[13px] transition-colors",
+        "inline-flex shrink-0 items-center gap-1.5 rounded-md border border-gr-border px-3 py-1.5 text-base transition-colors",
         disabled
           ? "cursor-not-allowed bg-gr-bg text-gr-faint opacity-60"
           : "cursor-pointer bg-gr-bg text-gr-text hover:bg-gr-subtle",
@@ -573,7 +573,7 @@ function BinaryElidedEmptyState({ filePath }: { filePath: string }) {
       className="flex min-h-[8rem] flex-col items-center justify-center gap-3 px-4 py-12 text-center"
       data-testid="binary-elided-empty"
     >
-      <span className="font-mono text-[13px] leading-relaxed text-gr-muted">
+      <span className="font-mono text-base leading-relaxed text-gr-muted">
         (binary or elided — no textual diff available)
       </span>
       {githubUrl && (
@@ -581,7 +581,7 @@ function BinaryElidedEmptyState({ filePath }: { filePath: string }) {
           href={githubUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-[13px] font-medium text-gr-accent underline-offset-2 hover:underline"
+          className="text-base font-medium text-gr-accent underline-offset-2 hover:underline"
           data-testid="binary-elided-github-link"
         >
           View file diff on GitHub
@@ -705,7 +705,7 @@ export function DiffPane({ files, unitTitle, unitId }: DiffPaneProps) {
     <div ref={rootRef}>
       <div className="mb-4 flex items-center justify-between gap-4">
         <h2
-          className="min-w-0 truncate text-[15px] font-semibold text-gr-text"
+          className="min-w-0 truncate text-lg font-semibold text-gr-text"
           data-testid="diff-unit-title"
           title={unitTitle}
         >
@@ -733,7 +733,7 @@ export function DiffPane({ files, unitTitle, unitId }: DiffPaneProps) {
             className="mb-7 overflow-hidden rounded-lg border border-gr-border bg-gr-canvas"
             key={file.path}
           >
-            <div className="flex items-baseline gap-2.5 border-b border-gr-border bg-gr-chrome px-3 py-2 font-mono text-[12.5px]">
+            <div className="flex items-baseline gap-2.5 border-b border-gr-border bg-gr-chrome px-3 py-2 font-mono text-sm">
               {file.previousPath
                 ? `${file.previousPath} → ${file.path}`
                 : file.path}

--- a/src/content/overlay/components/DraftCommentCard.test.tsx
+++ b/src/content/overlay/components/DraftCommentCard.test.tsx
@@ -14,7 +14,7 @@ const draft: DraftComment = {
 };
 
 describe("DraftCommentCard", () => {
-  it("renders the body in sans 14px and shows Edit / Remove", () => {
+  it("renders the body in sans text-base and shows Edit / Remove", () => {
     render(
       <DraftCommentCard comment={draft} onRemove={vi.fn()} onUpdate={vi.fn()} />,
     );
@@ -22,7 +22,7 @@ describe("DraftCommentCard", () => {
     const body = screen.getByTestId("draft-comment-body");
     expect(body).toHaveTextContent("Looks good");
     expect(body.className).toMatch(/font-sans/);
-    expect(body.className).toMatch(/text-\[14px\]/);
+    expect(body.className).toMatch(/\btext-base\b/);
     expect(screen.getByTestId("draft-comment-edit")).toBeInTheDocument();
     expect(screen.getByTestId("draft-comment-remove")).toBeInTheDocument();
   });
@@ -37,7 +37,7 @@ describe("DraftCommentCard", () => {
     expect(input).toHaveValue("Looks good");
     expect(input).toHaveFocus();
     expect(input.className).toMatch(/font-sans/);
-    expect(input.className).toMatch(/text-\[14px\]/);
+    expect(input.className).toMatch(/\btext-base\b/);
     expect(screen.queryByTestId("draft-comment-edit")).not.toBeInTheDocument();
     expect(screen.queryByTestId("draft-comment-body")).not.toBeInTheDocument();
   });

--- a/src/content/overlay/components/DraftCommentCard.tsx
+++ b/src/content/overlay/components/DraftCommentCard.tsx
@@ -65,14 +65,14 @@ export function DraftCommentCard({
       data-draft-id={comment.id}
     >
       <div className="mb-1.5 flex items-center justify-between gap-2">
-        <span className="font-mono text-[11px] text-gr-muted">
+        <span className="font-mono text-xs text-gr-muted">
           Draft · {formatLineRangeLabel(comment.filePath, comment.startLine, comment.endLine)}
         </span>
         <div className="flex items-center gap-1">
           {!editing && (
             <button
               type="button"
-              className="cursor-pointer rounded px-1.5 py-0.5 text-[12px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+              className="cursor-pointer rounded px-1.5 py-0.5 text-sm text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
               onClick={() => setEditing(true)}
               aria-label="Edit draft comment"
               data-testid="draft-comment-edit"
@@ -82,7 +82,7 @@ export function DraftCommentCard({
           )}
           <button
             type="button"
-            className="cursor-pointer rounded px-1.5 py-0.5 text-[12px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+            className="cursor-pointer rounded px-1.5 py-0.5 text-sm text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
             onClick={() => onRemove(comment.id)}
             aria-label="Remove draft comment"
             data-testid="draft-comment-remove"
@@ -95,7 +95,7 @@ export function DraftCommentCard({
         <>
           <textarea
             ref={textareaRef}
-            className="min-h-[88px] w-full resize-y rounded-md border border-gr-border bg-gr-chrome px-3 py-2 font-sans text-[14px] leading-relaxed text-gr-text outline-none placeholder:text-gr-faint focus:border-gr-accent"
+            className="min-h-[88px] w-full resize-y rounded-md border border-gr-border bg-gr-chrome px-3 py-2 font-sans text-base leading-relaxed text-gr-text outline-none placeholder:text-gr-faint focus:border-gr-accent"
             value={body}
             onChange={(e) => setBody(e.target.value)}
             onKeyDown={handleKeyDown}
@@ -105,7 +105,7 @@ export function DraftCommentCard({
           <div className="mt-2 flex flex-wrap items-center justify-end gap-2">
             <button
               type="button"
-              className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-chrome px-3 py-1.5 text-[13px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+              className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-chrome px-3 py-1.5 text-base text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
               onClick={exitEdit}
               data-testid="draft-comment-edit-cancel"
             >
@@ -114,7 +114,7 @@ export function DraftCommentCard({
             </button>
             <button
               type="button"
-              className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-[13px] font-medium text-gr-accent-on enabled:hover:border-gr-accent-hover enabled:hover:bg-gr-accent-hover disabled:cursor-not-allowed disabled:opacity-40 [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
+              className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-base font-medium text-gr-accent-on enabled:hover:border-gr-accent-hover enabled:hover:bg-gr-accent-hover disabled:cursor-not-allowed disabled:opacity-40 [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
               disabled={!canSave}
               onClick={saveEdit}
               data-testid="draft-comment-edit-save"
@@ -126,7 +126,7 @@ export function DraftCommentCard({
         </>
       ) : (
         <div
-          className="whitespace-pre-wrap font-sans text-[14px] leading-relaxed text-gr-text"
+          className="whitespace-pre-wrap font-sans text-base leading-relaxed text-gr-text"
           data-testid="draft-comment-body"
         >
           {comment.body}

--- a/src/content/overlay/components/DraftCommentCard.tsx
+++ b/src/content/overlay/components/DraftCommentCard.tsx
@@ -72,7 +72,7 @@ export function DraftCommentCard({
           {!editing && (
             <button
               type="button"
-              className="min-h-9 min-w-9 cursor-pointer rounded px-2 py-1.5 text-sm text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+              className="cursor-pointer rounded px-1.5 py-0.5 text-sm text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
               onClick={() => setEditing(true)}
               aria-label="Edit draft comment"
               data-testid="draft-comment-edit"
@@ -82,7 +82,7 @@ export function DraftCommentCard({
           )}
           <button
             type="button"
-            className="min-h-9 min-w-9 cursor-pointer rounded px-2 py-1.5 text-sm text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+            className="cursor-pointer rounded px-1.5 py-0.5 text-sm text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
             onClick={() => onRemove(comment.id)}
             aria-label="Remove draft comment"
             data-testid="draft-comment-remove"
@@ -105,7 +105,7 @@ export function DraftCommentCard({
           <div className="mt-2 flex flex-wrap items-center justify-end gap-2">
             <button
               type="button"
-              className="inline-flex min-h-11 cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-chrome px-3 py-2 text-base text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+              className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-chrome px-3 py-1.5 text-base text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
               onClick={exitEdit}
               data-testid="draft-comment-edit-cancel"
             >
@@ -114,7 +114,7 @@ export function DraftCommentCard({
             </button>
             <button
               type="button"
-              className="inline-flex min-h-11 cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-3 py-2 text-base font-medium text-gr-accent-on enabled:hover:border-gr-accent-hover enabled:hover:bg-gr-accent-hover disabled:cursor-not-allowed disabled:opacity-40 [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
+              className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-base font-medium text-gr-accent-on enabled:hover:border-gr-accent-hover enabled:hover:bg-gr-accent-hover disabled:cursor-not-allowed disabled:opacity-40 [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
               disabled={!canSave}
               onClick={saveEdit}
               data-testid="draft-comment-edit-save"

--- a/src/content/overlay/components/FooterNav.tsx
+++ b/src/content/overlay/components/FooterNav.tsx
@@ -9,7 +9,7 @@ interface FooterNavProps {
 }
 
 const navBtnBase =
-  "inline-flex min-h-11 cursor-pointer items-center gap-2 rounded-md border px-4 py-2 text-base font-medium disabled:cursor-default disabled:opacity-40";
+  "inline-flex cursor-pointer items-center gap-2 rounded-md border px-4 py-[7px] text-base font-medium disabled:cursor-default disabled:opacity-40";
 
 export function FooterNav({
   currentIndex,

--- a/src/content/overlay/components/FooterNav.tsx
+++ b/src/content/overlay/components/FooterNav.tsx
@@ -9,7 +9,7 @@ interface FooterNavProps {
 }
 
 const navBtnBase =
-  "inline-flex cursor-pointer items-center gap-2 rounded-md border px-4 py-[7px] text-[13px] font-medium disabled:cursor-default disabled:opacity-40";
+  "inline-flex cursor-pointer items-center gap-2 rounded-md border px-4 py-[7px] text-base font-medium disabled:cursor-default disabled:opacity-40";
 
 export function FooterNav({ currentIndex, total, onPrev, onNext }: FooterNavProps) {
   return (

--- a/src/content/overlay/components/Kbd.tsx
+++ b/src/content/overlay/components/Kbd.tsx
@@ -6,7 +6,7 @@ interface KbdProps {
 
 export function Kbd({ children }: KbdProps) {
   return (
-    <kbd className="inline-flex h-[18px] min-w-[18px] items-center justify-center rounded border border-gr-border border-b-2 bg-gr-subtle px-[5px] font-mono text-[11px] leading-none text-gr-muted">
+    <kbd className="inline-flex h-[18px] min-w-[18px] items-center justify-center rounded border border-gr-border border-b-2 bg-gr-subtle px-[5px] font-mono text-xs leading-none text-gr-muted">
       {children}
     </kbd>
   );

--- a/src/content/overlay/components/KeyboardShortcuts.tsx
+++ b/src/content/overlay/components/KeyboardShortcuts.tsx
@@ -45,7 +45,7 @@ function ShortcutRowKeys({ row }: { row: ShortcutRow }) {
     return (
       <span className="inline-flex items-center gap-1">
         <ShortcutKeys keys={[modifier]} join="none" />
-        <span className="text-[11px] opacity-70" aria-hidden="true">
+        <span className="text-xs opacity-70" aria-hidden="true">
           +
         </span>
         <ShortcutKeys keys={alternatives} join="none" />
@@ -63,7 +63,7 @@ export function KeyboardShortcuts() {
       </div>
       <ul className="m-0 flex list-none flex-col gap-2 p-0">
         {SHORTCUTS.map((row) => (
-          <li key={row.description} className="flex items-center gap-3 text-[13px] text-gr-muted">
+          <li key={row.description} className="flex items-center gap-3 text-base text-gr-muted">
             <span className="inline-flex min-w-[72px] shrink-0 items-center gap-1">
               <ShortcutRowKeys row={row} />
             </span>

--- a/src/content/overlay/components/ProgressHeader.tsx
+++ b/src/content/overlay/components/ProgressHeader.tsx
@@ -16,7 +16,7 @@ interface ProgressHeaderProps {
 }
 
 const headerBtn =
-  "inline-flex min-h-11 cursor-pointer items-center gap-1.5 rounded-md border px-3 py-2 text-base font-medium";
+  "inline-flex cursor-pointer items-center gap-1.5 rounded-md border px-3 py-1.5 text-base font-medium";
 
 export function ProgressHeader({
   prContext,

--- a/src/content/overlay/components/ProgressHeader.tsx
+++ b/src/content/overlay/components/ProgressHeader.tsx
@@ -34,18 +34,18 @@ export function ProgressHeader({
           />
           <div className="flex min-w-0 flex-col gap-1">
             <div className="flex min-w-0 items-baseline gap-2">
-              <span className="truncate text-[15px] font-semibold">
+              <span className="truncate text-lg font-semibold">
                 {prContext?.title || "Guided Review"}
               </span>
               {prContext && (
-                <span className="shrink-0 text-[13px] text-gr-muted">#{prContext.number}</span>
+                <span className="shrink-0 text-base text-gr-muted">#{prContext.number}</span>
               )}
             </div>
             {prContext && (prContext.author || prContext.baseRef || prContext.headRef || stats) && (
-              <div className="flex items-center gap-2.5 text-[12.5px] text-gr-muted">
+              <div className="flex items-center gap-2.5 text-sm text-gr-muted">
                 {prContext.author && <span>@{prContext.author}</span>}
                 {(prContext.baseRef || prContext.headRef) && (
-                  <span className="inline-block rounded-full border border-gr-border bg-gr-bg px-2.5 py-px font-mono text-xs text-gr-text">
+                  <span className="inline-block rounded-full border border-gr-border bg-gr-bg px-2.5 py-px font-mono text-sm text-gr-text">
                     {prContext.baseRef || "?"} ← {prContext.headRef || "?"}
                   </span>
                 )}
@@ -63,7 +63,7 @@ export function ProgressHeader({
         <div className="flex shrink-0 items-center gap-3">
           <button
             type="button"
-            className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-[13px] font-medium text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
+            className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-base font-medium text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
             onClick={onSubmitReview}
             data-testid="submit-review-button"
           >
@@ -72,7 +72,7 @@ export function ProgressHeader({
           </button>
           <button
             type="button"
-            className="inline-flex cursor-pointer items-center gap-2 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-[13px] text-gr-text hover:bg-gr-subtle"
+            className="inline-flex cursor-pointer items-center gap-2 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-base text-gr-text hover:bg-gr-subtle"
             onClick={onExit}
           >
             Exit

--- a/src/content/overlay/components/ReviewSubmittedModal.tsx
+++ b/src/content/overlay/components/ReviewSubmittedModal.tsx
@@ -82,13 +82,13 @@ export function ReviewSubmittedModal({
 
         <h2
           id={titleId}
-          className="m-0 text-center text-[16px] font-semibold text-gr-text"
+          className="m-0 text-center text-lg font-semibold text-gr-text"
         >
           Review submitted successfully
         </h2>
 
         <p
-          className="mt-2 mb-0 text-center text-[13.5px] leading-relaxed text-gr-muted"
+          className="mt-2 mb-0 text-center text-base leading-relaxed text-gr-muted"
           data-testid="review-submitted-summary"
         >
           {eventSummary(event, commentCount)}
@@ -97,7 +97,7 @@ export function ReviewSubmittedModal({
         <button
           ref={exitButtonRef}
           type="button"
-          className="mt-7 inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-4 py-2 text-[13px] font-medium text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
+          className="mt-7 inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-4 py-2 text-base font-medium text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
           onClick={onExit}
           data-testid="review-submitted-exit"
         >

--- a/src/content/overlay/components/ShortcutKeys.tsx
+++ b/src/content/overlay/components/ShortcutKeys.tsx
@@ -45,7 +45,7 @@ export function ShortcutKeys({
       {keys.map((key, i) => (
         <Fragment key={`${key}-${i}`}>
           {showPlus && i > 0 ? (
-            <span className="text-[11px] opacity-70" aria-hidden="true">
+            <span className="text-xs opacity-70" aria-hidden="true">
               +
             </span>
           ) : null}

--- a/src/content/overlay/components/Sidebar.tsx
+++ b/src/content/overlay/components/Sidebar.tsx
@@ -50,7 +50,7 @@ export function Sidebar({
             ref={isActive ? activeItemRef : undefined}
             aria-current={isActive ? "true" : undefined}
             className={cn(
-              "mb-0.5 block min-h-11 w-full cursor-pointer rounded-md border-none bg-transparent px-2 py-2.5 text-left text-base leading-snug text-gr-text",
+              "mb-0.5 block w-full cursor-pointer rounded-md border-none bg-transparent p-2 text-left text-base leading-snug text-gr-text",
               isActive &&
                 "bg-gr-accent-subtle text-gr-accent! hover:bg-gr-accent-subtle",
             )}

--- a/src/content/overlay/components/Sidebar.tsx
+++ b/src/content/overlay/components/Sidebar.tsx
@@ -37,7 +37,7 @@ export function Sidebar({
       className="mt-6 min-h-0 flex-[1_1_50%] overflow-y-auto border-t border-gr-border-muted pt-4"
       aria-label="Review units"
     >
-      <div className="px-2 pb-1 pt-2.5 text-[11px] tracking-[0.04em] text-gr-muted uppercase">
+      <div className="px-2 pb-1 pt-2.5 text-xs tracking-[0.04em] text-gr-muted uppercase">
         Review units
       </div>
 
@@ -50,7 +50,7 @@ export function Sidebar({
             ref={isActive ? activeItemRef : undefined}
             aria-current={isActive ? "true" : undefined}
             className={cn(
-              "mb-0.5 block w-full cursor-pointer rounded-md border-none bg-transparent p-2 text-left text-[13px] leading-snug text-gr-text",
+              "mb-0.5 block w-full cursor-pointer rounded-md border-none bg-transparent p-2 text-left text-base leading-snug text-gr-text",
               isActive &&
                 "bg-gr-accent-subtle text-gr-accent! hover:bg-gr-accent-subtle",
             )}

--- a/src/content/overlay/components/SubmitReviewModal.tsx
+++ b/src/content/overlay/components/SubmitReviewModal.tsx
@@ -35,7 +35,7 @@ interface SubmitReviewModalProps {
 }
 
 const modalBtn =
-  "inline-flex min-h-11 cursor-pointer items-center gap-1.5 rounded-md border px-3 py-2 text-base disabled:cursor-not-allowed disabled:opacity-50";
+  "inline-flex cursor-pointer items-center gap-1.5 rounded-md border px-3 py-1.5 text-base disabled:cursor-not-allowed disabled:opacity-50";
 
 
 const REVIEW_EVENTS: {
@@ -253,7 +253,7 @@ export function SubmitReviewModal({
           </h2>
           <button
             type="button"
-            className="inline-flex min-h-11 min-w-11 cursor-pointer items-center justify-center rounded-md border border-gr-border bg-gr-bg p-2 text-gr-muted hover:bg-gr-subtle hover:text-gr-text disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex cursor-pointer items-center justify-center rounded-md border border-gr-border bg-gr-bg p-1.5 text-gr-muted hover:bg-gr-subtle hover:text-gr-text disabled:cursor-not-allowed disabled:opacity-50"
             onClick={onClose}
             disabled={submitting}
             aria-label="Close"

--- a/src/content/overlay/components/SubmitReviewModal.tsx
+++ b/src/content/overlay/components/SubmitReviewModal.tsx
@@ -239,7 +239,7 @@ export function SubmitReviewModal({
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between gap-3 border-b border-gr-border px-4 py-3">
-          <h2 id={titleId} className="m-0 text-[15px] font-semibold text-gr-text">
+          <h2 id={titleId} className="m-0 text-lg font-semibold text-gr-text">
             Submit Review
           </h2>
           <button
@@ -269,7 +269,7 @@ export function SubmitReviewModal({
         {step === "choose" ? (
           <>
             <div className="flex flex-col gap-3 px-4 py-4">
-              <p className="m-0 text-[13px] text-gr-muted">
+              <p className="m-0 text-base text-gr-muted">
                 What would you like to do?
               </p>
               <div
@@ -301,17 +301,17 @@ export function SubmitReviewModal({
                       onClick={() => confirmMode(index)}
                       onMouseEnter={() => setHighlight(index)}
                     >
-                      <div className="text-[13px] font-semibold text-gr-text">
+                      <div className="text-base font-semibold text-gr-text">
                         {opt.label}
                       </div>
-                      <div className="mt-0.5 text-[12.5px] leading-snug text-gr-muted">
+                      <div className="mt-0.5 text-sm leading-snug text-gr-muted">
                         {opt.description}
                       </div>
                     </div>
                   );
                 })}
               </div>
-              <div className="flex items-center gap-2 text-[12px] text-gr-faint">
+              <div className="flex items-center gap-2 text-sm text-gr-faint">
                 <Kbd>↑</Kbd>
                 <Kbd>↓</Kbd>
                 <span>to choose</span>
@@ -324,7 +324,7 @@ export function SubmitReviewModal({
             <div className="flex items-center justify-end gap-2 border-t border-gr-border px-4 py-3">
               <button
                 type="button"
-                className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-[13px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+                className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-base text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
                 onClick={onClose}
                 data-testid="submit-review-cancel"
               >
@@ -338,7 +338,7 @@ export function SubmitReviewModal({
             <div className="flex flex-col gap-4 px-4 py-4">
               <textarea
                 ref={textareaRef}
-                className="min-h-[100px] w-full resize-y rounded-md border border-gr-border bg-gr-bg px-3 py-2 font-sans text-[14px] leading-relaxed text-gr-text outline-none placeholder:text-gr-faint focus:border-gr-accent disabled:opacity-60"
+                className="min-h-[100px] w-full resize-y rounded-md border border-gr-border bg-gr-bg px-3 py-2 font-sans text-base leading-relaxed text-gr-text outline-none placeholder:text-gr-faint focus:border-gr-accent disabled:opacity-60"
                 placeholder="Leave a comment"
                 value={body}
                 onChange={(e) => setBody(e.target.value)}
@@ -353,17 +353,17 @@ export function SubmitReviewModal({
                 data-testid="submit-review-selected-event"
                 data-event={selectedOpt.value}
               >
-                <div className="text-[13px] font-semibold text-gr-text">
+                <div className="text-base font-semibold text-gr-text">
                   {selectedOpt.label}
                 </div>
-                <div className="mt-0.5 text-[12.5px] leading-snug text-gr-muted">
+                <div className="mt-0.5 text-sm leading-snug text-gr-muted">
                   {selectedOpt.description}
                 </div>
               </div>
 
               {error ? (
                 <p
-                  className="m-0 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-[13px] leading-snug text-red-200"
+                  className="m-0 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-base leading-snug text-red-200"
                   role="alert"
                   data-testid="submit-review-error"
                 >
@@ -375,7 +375,7 @@ export function SubmitReviewModal({
             <div className="flex items-center justify-between gap-2 border-t border-gr-border px-4 py-3">
               <button
                 type="button"
-                className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-[13px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text disabled:cursor-not-allowed disabled:opacity-50"
+                className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-base text-gr-muted hover:bg-gr-subtle hover:text-gr-text disabled:cursor-not-allowed disabled:opacity-50"
                 onClick={goBack}
                 disabled={submitting}
                 data-testid="submit-review-back"
@@ -385,7 +385,7 @@ export function SubmitReviewModal({
               <div className="flex items-center gap-2">
                 <button
                   type="button"
-                  className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-[13px] text-gr-muted hover:bg-gr-subtle hover:text-gr-text disabled:cursor-not-allowed disabled:opacity-50"
+                  className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-base text-gr-muted hover:bg-gr-subtle hover:text-gr-text disabled:cursor-not-allowed disabled:opacity-50"
                   onClick={onClose}
                   disabled={submitting}
                   data-testid="submit-review-cancel"
@@ -395,7 +395,7 @@ export function SubmitReviewModal({
                 </button>
                 <button
                   type="button"
-                  className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-[13px] font-medium text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover disabled:cursor-not-allowed disabled:opacity-60 [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
+                  className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-base font-medium text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover disabled:cursor-not-allowed disabled:opacity-60 [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit"
                   onClick={handleSubmit}
                   disabled={submitting}
                   data-testid="submit-review-confirm"

--- a/src/content/overlay/styles/overlay.css
+++ b/src/content/overlay/styles/overlay.css
@@ -51,10 +51,36 @@
 /*
  * Visible focus for keyboard users (2.4.7). Prefer :focus-visible so mouse
  * clicks do not show a ring. Accent meets ≥ 3:1 against dark surfaces.
+ *
+ * Scoped to interactive controls only — containers (dialog shell, main column,
+ * cards) may be programmatically focused for traps/scroll restore but must not
+ * draw a chrome ring. Lives in @layer base so Tailwind `outline-none` can
+ * still suppress the ring on widgets that use a custom focus style (e.g.
+ * listbox + option highlight, textareas with focus:border).
  */
-:focus-visible {
-  outline: 2px solid var(--color-gr-accent, #caff57);
-  outline-offset: 2px;
+@layer base {
+  :is(
+    a,
+    button,
+    input,
+    select,
+    textarea,
+    summary,
+    [role="button"],
+    [role="link"],
+    [role="menuitem"],
+    [role="option"],
+    [role="tab"],
+    [role="checkbox"],
+    [role="radio"],
+    [role="switch"],
+    [role="combobox"],
+    [contenteditable="true"],
+    [tabindex]:not([tabindex="-1"])
+  ):focus-visible {
+    outline: 2px solid var(--color-gr-accent, #caff57);
+    outline-offset: 2px;
+  }
 }
 
 /* Screen-reader-only utility (Tailwind sr-only may not always ship into the host) */

--- a/src/content/overlay/styles/overlay.css
+++ b/src/content/overlay/styles/overlay.css
@@ -58,6 +58,10 @@
  * still suppress the ring on widgets that use a custom focus style (e.g.
  * listbox + option highlight, textareas with focus:border).
  */
+:focus-visible {
+  outline: none;
+}
+
 @layer base {
   :is(
     a,

--- a/src/options/About.tsx
+++ b/src/options/About.tsx
@@ -1,7 +1,7 @@
 import { BrandHeader } from "./BrandHeader";
 
-const sectionTitle = "mb-2 mt-0 text-[13px] font-semibold text-opt-text";
-const bodyText = "m-0 text-[13px] leading-relaxed text-opt-muted";
+const sectionTitle = "mb-2 mt-0 text-base font-semibold text-opt-text";
+const bodyText = "m-0 text-base leading-relaxed text-opt-muted";
 
 /**
  * Explains what Guided Review does, how a walkthrough works, and where data goes.
@@ -13,7 +13,7 @@ export function About() {
   return (
     <div className="mx-auto max-w-[480px] px-6 py-8">
       <BrandHeader />
-      <p className="mb-6 text-[13px] text-opt-muted">
+      <p className="mb-6 text-base text-opt-muted">
         AI-structured walkthroughs for GitHub pull requests
         {version ? (
           <>
@@ -35,7 +35,7 @@ export function About() {
 
       <section className="mb-6">
         <h2 className={sectionTitle}>How a review works</h2>
-        <ol className="m-0 list-decimal space-y-2 pl-5 text-[13px] leading-relaxed text-opt-muted">
+        <ol className="m-0 list-decimal space-y-2 pl-5 text-base leading-relaxed text-opt-muted">
           <li>Open a pull request on GitHub.</li>
           <li>
             Click <strong className="font-semibold text-opt-text">Start Guided Review</strong> on
@@ -57,7 +57,7 @@ export function About() {
         <h2 className={sectionTitle}>Privacy</h2>
         <p className={bodyText}>
           Your AI API key and optional GitHub OAuth token are stored only in this browser via{" "}
-          <code className="rounded bg-opt-subtle px-1 py-0.5 text-[12px] text-opt-text">
+          <code className="rounded bg-opt-subtle px-1 py-0.5 text-sm text-opt-text">
             chrome.storage.local
           </code>
           . Diffs and prompts go only to the AI provider you choose (Anthropic, OpenAI, or xAI).
@@ -70,7 +70,7 @@ export function About() {
       <nav className="mt-8 border-t border-opt-border pt-6">
         <a
           href="#settings"
-          className="text-[13px] font-semibold text-opt-muted no-underline hover:text-opt-text hover:underline"
+          className="text-base font-semibold text-opt-muted no-underline hover:text-opt-text hover:underline"
         >
           ← Settings
         </a>

--- a/src/options/GitHubAuthSection.tsx
+++ b/src/options/GitHubAuthSection.tsx
@@ -18,10 +18,10 @@ type SessionState =
   | { kind: "connected"; auth: GitHubAuthState };
 
 const primaryBtn =
-  "inline-flex cursor-pointer items-center gap-2 rounded-md border border-opt-accent bg-opt-accent px-4 py-2 text-[13px] font-semibold text-opt-accent-on enabled:hover:border-opt-accent-hover enabled:hover:bg-opt-accent-hover disabled:cursor-default disabled:opacity-60";
+  "inline-flex cursor-pointer items-center gap-2 rounded-md border border-opt-accent bg-opt-accent px-4 py-2 text-base font-semibold text-opt-accent-on enabled:hover:border-opt-accent-hover enabled:hover:bg-opt-accent-hover disabled:cursor-default disabled:opacity-60";
 
 const secondaryBtn =
-  "inline-flex cursor-pointer items-center gap-2 rounded-md border border-opt-border bg-opt-subtle px-4 py-2 text-[13px] font-semibold text-opt-text disabled:cursor-default disabled:opacity-60";
+  "inline-flex cursor-pointer items-center gap-2 rounded-md border border-opt-border bg-opt-subtle px-4 py-2 text-base font-semibold text-opt-text disabled:cursor-default disabled:opacity-60";
 
 /**
  * Options section: GitHub device OAuth connect / disconnect.
@@ -102,16 +102,16 @@ export function GitHubAuthSection() {
 
   return (
     <section className="mb-8 border-b border-opt-border pb-8" data-testid="github-auth-section">
-      <h2 className="mb-1.5 text-[13px] font-semibold text-opt-text">GitHub account</h2>
-      <p className="mb-4 text-[13px] text-opt-muted">
+      <h2 className="mb-1.5 text-base font-semibold text-opt-text">GitHub account</h2>
+      <p className="mb-4 text-base text-opt-muted">
         Connect GitHub so Guided Review can act on your behalf (for example, submitting reviews).
         Uses device sign-in — no password is stored here. Token stays in this browser only.
       </p>
 
       {!configured && (
-        <p className="text-[13px] text-opt-muted" role="status">
+        <p className="text-base text-opt-muted" role="status">
           GitHub connection isn’t configured in this build. Set{" "}
-          <code className="rounded bg-opt-subtle px-1 py-0.5 text-[12px] text-opt-text">
+          <code className="rounded bg-opt-subtle px-1 py-0.5 text-sm text-opt-text">
             VITE_GITHUB_CLIENT_ID
           </code>{" "}
           and rebuild.
@@ -119,7 +119,7 @@ export function GitHubAuthSection() {
       )}
 
       {configured && session.kind === "loading" && flow.kind === "idle" && !showError && (
-        <p className="flex items-center gap-2 text-[13px] text-opt-muted" role="status">
+        <p className="flex items-center gap-2 text-base text-opt-muted" role="status">
           <ActionSpinner label="Loading GitHub connection" />
           Loading…
         </p>
@@ -142,7 +142,7 @@ export function GitHubAuthSection() {
               {busy && <ActionSpinner label="Connecting to GitHub" />}
               {busy ? "Connecting…" : "Connect GitHub"}
             </button>
-            <span className="text-xs text-opt-muted">Requests repo and read:user access.</span>
+            <span className="text-sm text-opt-muted">Requests repo and read:user access.</span>
           </div>
         )}
 
@@ -165,13 +165,13 @@ export function GitHubAuthSection() {
             </button>
           </div>
           <p
-            className="m-0 text-[13px] text-opt-muted"
+            className="m-0 text-base text-opt-muted"
             data-testid="github-copy-hint"
           >
             Copy this code, then paste it on the GitHub tab.
           </p>
           <div className="flex flex-wrap items-center gap-2.5">
-            <span className="flex items-center gap-2 text-[13px] text-opt-muted" role="status">
+            <span className="flex items-center gap-2 text-base text-opt-muted" role="status">
               <ActionSpinner label="Waiting for GitHub authorization" />
               Waiting for authorization…
             </span>
@@ -213,13 +213,13 @@ export function GitHubAuthSection() {
               </div>
             )}
             <div className="min-w-0">
-              <p className="m-0 truncate text-[13px] font-semibold text-opt-text">
+              <p className="m-0 truncate text-base font-semibold text-opt-text">
                 @{session.auth.login}
               </p>
               {session.auth.name ? (
-                <p className="m-0 truncate text-xs text-opt-muted">{session.auth.name}</p>
+                <p className="m-0 truncate text-sm text-opt-muted">{session.auth.name}</p>
               ) : (
-                <p className="m-0 text-xs text-opt-ok">Connected</p>
+                <p className="m-0 text-sm text-opt-ok">Connected</p>
               )}
             </div>
           </div>
@@ -237,7 +237,7 @@ export function GitHubAuthSection() {
 
       {configured && showError && (
         <div className="space-y-3" role="alert">
-          <p className={cn("m-0 text-[13px] text-opt-error")}>{showError}</p>
+          <p className={cn("m-0 text-base text-opt-error")}>{showError}</p>
           <button
             type="button"
             className={primaryBtn}

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -22,7 +22,7 @@ type ActionStatus =
   | { kind: "error"; message: string };
 
 const fieldControl =
-  "w-full rounded-md border border-opt-border bg-opt-subtle px-2.5 py-2 text-[13px] text-opt-text";
+  "w-full rounded-md border border-opt-border bg-opt-subtle px-2.5 py-2 text-base text-opt-text";
 
 function OptionRow({ icon, label }: { icon: ProviderId; label: string }) {
   return (
@@ -128,16 +128,16 @@ export function Options() {
   return (
     <div className="mx-auto max-w-[480px] px-6 py-8">
       <BrandHeader />
-      <p className="mb-6 text-[13px] text-opt-muted">
+      <p className="mb-6 text-base text-opt-muted">
         Connect GitHub and choose an AI provider. Keys and tokens stay in this browser only.
       </p>
 
       <GitHubAuthSection />
 
-      <h2 className="mb-4 text-[13px] font-semibold text-opt-text">AI provider</h2>
+      <h2 className="mb-4 text-base font-semibold text-opt-text">AI provider</h2>
 
       <div className="mb-4">
-        <label className="mb-1.5 block text-[13px] font-semibold" id="provider-label" htmlFor="provider">
+        <label className="mb-1.5 block text-base font-semibold" id="provider-label" htmlFor="provider">
           Provider
         </label>
         <Select
@@ -151,7 +151,7 @@ export function Options() {
       </div>
 
       <div className="mb-4">
-        <label className="mb-1.5 block text-[13px] font-semibold" id="model-label" htmlFor="model">
+        <label className="mb-1.5 block text-base font-semibold" id="model-label" htmlFor="model">
           Model
         </label>
         <Select
@@ -165,7 +165,7 @@ export function Options() {
       </div>
 
       <div className="mb-4">
-        <label className="mb-1.5 block text-[13px] font-semibold" htmlFor="apiKey">
+        <label className="mb-1.5 block text-base font-semibold" htmlFor="apiKey">
           API key
         </label>
         <input
@@ -178,7 +178,7 @@ export function Options() {
           onChange={(e) => onApiKeyChange(e.target.value)}
           disabled={busy}
         />
-        <p className="mt-1 text-xs text-opt-muted">
+        <p className="mt-1 text-sm text-opt-muted">
           Stored locally on this device via chrome.storage.local — never synced.
         </p>
       </div>
@@ -187,7 +187,7 @@ export function Options() {
         <button
           type="button"
           className={cn(
-            "inline-flex cursor-pointer items-center gap-2 rounded-md border border-opt-accent bg-opt-accent px-4 py-2 text-[13px] font-semibold text-opt-accent-on",
+            "inline-flex cursor-pointer items-center gap-2 rounded-md border border-opt-accent bg-opt-accent px-4 py-2 text-base font-semibold text-opt-accent-on",
             "enabled:hover:border-opt-accent-hover enabled:hover:bg-opt-accent-hover",
             "disabled:cursor-default disabled:opacity-60",
           )}
@@ -200,7 +200,7 @@ export function Options() {
         <button
           type="button"
           className={cn(
-            "inline-flex cursor-pointer items-center gap-2 rounded-md border border-opt-border bg-opt-subtle px-4 py-2 text-[13px] font-semibold text-opt-text",
+            "inline-flex cursor-pointer items-center gap-2 rounded-md border border-opt-border bg-opt-subtle px-4 py-2 text-base font-semibold text-opt-text",
             "disabled:cursor-default disabled:opacity-60",
           )}
           onClick={onTestConnection}
@@ -214,7 +214,7 @@ export function Options() {
             role="status"
             aria-live="polite"
             className={cn(
-              "text-[13px]",
+              "text-base",
               statusMessage.kind === "ok" && "text-opt-ok",
               statusMessage.kind === "error" && "text-opt-error",
             )}
@@ -227,7 +227,7 @@ export function Options() {
       <nav className="mt-8 border-t border-opt-border pt-6">
         <a
           href="#about"
-          className="text-[13px] font-semibold text-opt-muted no-underline hover:text-opt-text hover:underline"
+          className="text-base font-semibold text-opt-muted no-underline hover:text-opt-text hover:underline"
         >
           About Guided Review
         </a>

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -24,7 +24,7 @@ const fieldControl =
   "w-full rounded-md border border-opt-border bg-opt-subtle px-2.5 py-2 text-base text-opt-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-opt-accent";
 
 const actionBtn =
-  "inline-flex min-h-11 cursor-pointer items-center gap-2 rounded-md border px-4 py-2 text-base font-semibold disabled:cursor-default disabled:opacity-60";
+  "inline-flex cursor-pointer items-center gap-2 rounded-md border px-4 py-2 text-base font-semibold disabled:cursor-default disabled:opacity-60";
 
 function OptionRow({ icon, label }: { icon: ProviderId; label: string }) {
   return (

--- a/src/options/components/Select.tsx
+++ b/src/options/components/Select.tsx
@@ -231,7 +231,7 @@ export function Select<T extends string = string>({
         aria-label={ariaLabel}
         disabled={disabled}
         className={cn(
-          "flex min-h-11 w-full items-center gap-2 rounded-md border border-opt-border bg-opt-subtle px-2.5 py-2 text-left text-base text-opt-text",
+          "flex w-full items-center gap-2 rounded-md border border-opt-border bg-opt-subtle px-2.5 py-2 text-left text-base text-opt-text",
           "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-opt-accent",
           "disabled:cursor-not-allowed disabled:opacity-60",
         )}

--- a/src/options/components/Select.tsx
+++ b/src/options/components/Select.tsx
@@ -231,7 +231,7 @@ export function Select<T extends string = string>({
         aria-label={ariaLabel}
         disabled={disabled}
         className={cn(
-          "flex w-full items-center gap-2 rounded-md border border-opt-border bg-opt-subtle px-2.5 py-2 text-left text-[13px] text-opt-text",
+          "flex w-full items-center gap-2 rounded-md border border-opt-border bg-opt-subtle px-2.5 py-2 text-left text-base text-opt-text",
           "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-opt-accent",
           "disabled:cursor-not-allowed disabled:opacity-60",
         )}
@@ -285,7 +285,7 @@ export function Select<T extends string = string>({
                 aria-selected={isSelected}
                 aria-disabled={opt.disabled || undefined}
                 className={cn(
-                  "flex cursor-pointer items-center gap-2 px-2.5 py-1.5 text-[13px] text-opt-text",
+                  "flex cursor-pointer items-center gap-2 px-2.5 py-1.5 text-base text-opt-text",
                   isHighlighted && "bg-opt-subtle",
                   isSelected && "font-semibold",
                   opt.disabled && "cursor-not-allowed opacity-50",

--- a/src/options/options.scss
+++ b/src/options/options.scss
@@ -5,6 +5,7 @@
 
 body {
   margin: 0;
+  font-size: 0.875rem;
   font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -47,7 +47,7 @@ body {
 
 .popup__message {
   margin: 0;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 500;
   line-height: 1.45;
   color: #fefefe;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -58,6 +58,12 @@
   --font-mono:
     ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
 
+  /* Product type scale: 10 / 12 / 14 (body) / 16 */
+  --text-xs: 0.625rem; /* 10px — micro (kbd, section labels) */
+  --text-sm: 0.75rem; /* 12px — secondary (diff mono, badges, captions) */
+  --text-base: 0.875rem; /* 14px — body */
+  --text-lg: 1rem; /* 16px — titles / emphasis */
+
   --animate-gr-spin: gr-spin 0.8s linear infinite;
   --animate-gr-skeleton: gr-skeleton-pulse 1.2s ease-in-out infinite;
 }


### PR DESCRIPTION
## Summary

- Define a product type scale in `@theme` (`text-xs` / `sm` / `base` / `lg` → 10 / 12 / 14 / 16px) so Tailwind utilities map to the extension’s intended sizes.
- Replace hardcoded `text-[Npx]` classes across the overlay, options, and popup with those tokens for consistent typography.
- Keeps accessibility touch targets and disabled styles from main; only the font sizing path changes.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test`
- [ ] Load `dist/` in Chrome and smoke the guided review overlay (header, footer, comment composer, submit modal)
- [ ] Open options + About and confirm type sizes look consistent with the overlay
- [ ] Spot-check kbd chips and secondary captions still read as micro/secondary, not body size