### PR TITLE
fix: confirmation dialogs, header button polish, SPA content-script match

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,12 +40,15 @@ the latest changes — no need to remove/re-add the unpacked extension.
 The extension has three isolated runtime contexts that only talk to each other through
 `chrome.runtime.sendMessage` — keep this boundary in mind when adding functionality:
 
-- **Content script** (`src/content/`) — injected on `https://github.com/*/*/pull/*`. `index.tsx` is the
-  entry point: it watches the DOM (GitHub is an SPA) to inject the button, scrapes PR metadata directly
-  from the page (`src/lib/github/prContext.ts`), and mounts the review overlay into a Shadow DOM host
-  (`ensureOverlayMounted`) so its styles never leak into/from GitHub's page. Overlay UI is styled with
-  Tailwind utilities; residual overrides (highlight.js, markdown-body, host reset) live in SCSS under
-  `src/content/overlay/styles/` and are injected via `overlay.css?inline` into the shadow root.
+- **Content script** (`src/content/`) — injected on `https://github.com/*` so it is already running when
+  the user SPA-navigates from e.g. the PR list into a PR (Chrome does not re-inject content scripts on
+  History API navigations). `index.tsx` is the entry point: a MutationObserver watches the DOM and only
+  injects the "Start Guided Review" button when the URL is a PR path (`parsePRUrl`); it removes the
+  button when the SPA leaves a PR. Scrapes PR metadata from the page (`src/lib/github/prContext.ts`),
+  and mounts the review overlay into a Shadow DOM host (`ensureOverlayMounted`) so its styles never
+  leak into/from GitHub's page. Overlay UI is styled with Tailwind utilities; residual overrides
+  (highlight.js, markdown-body, host reset) live in SCSS under `src/content/overlay/styles/` and are
+  injected via `overlay.css?inline` into the shadow root.
 - **Background service worker** (`src/background/index.ts`) — the only context allowed to make
   cross-origin requests and hold the API key. Handles three message types: `FETCH_DIFF`,
   `ANNOTATE_REVIEW`, `TEST_CONNECTION`. Diff fetching happens here (not in the content script) because

--- a/e2e/fixtures/pulls-list.html
+++ b/e2e/fixtures/pulls-list.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Pull requests · acme/widgets</title>
+  </head>
+  <body>
+    <!--
+      Minimal stand-in for the repo PR list page. Used to assert the content
+      script is active outside /*/*/pull/* and can inject the button after a
+      client-side navigation into a PR (no full page reload).
+    -->
+    <main>
+      <h1>Pull requests</h1>
+      <a href="/acme/widgets/pull/1">#1 Add feature</a>
+    </main>
+  </body>
+</html>

--- a/e2e/overlay.spec.ts
+++ b/e2e/overlay.spec.ts
@@ -5,8 +5,10 @@ import { expect, test } from "./fixtures";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PR_URL = "https://github.com/acme/widgets/pull/1";
+const PULLS_LIST_URL = "https://github.com/acme/widgets/pulls";
 const PR_FIXTURE_PATH = path.resolve(__dirname, "fixtures/pr-page.html");
 const PR_MODERN_FIXTURE_PATH = path.resolve(__dirname, "fixtures/pr-page-modern.html");
+const PULLS_LIST_FIXTURE_PATH = path.resolve(__dirname, "fixtures/pulls-list.html");
 
 const CANNED_DIFF = [
   "diff --git a/src/foo.ts b/src/foo.ts",
@@ -131,5 +133,47 @@ test.describe("Guided review overlay", () => {
       await page.goto(url);
       await expect(page.getByRole("button", { name: "Start Guided Review" })).toBeVisible();
     }
+  });
+
+  test("injects Start Guided Review after SPA navigation from the PR list", async ({ context }) => {
+    // Content script matches all of github.com so it is already running on the
+    // list page; MutationObserver + URL check should inject after a client-side
+    // route change without a full reload.
+    await context.route(PULLS_LIST_URL, (route) =>
+      route.fulfill({ path: PULLS_LIST_FIXTURE_PATH, contentType: "text/html" }),
+    );
+    await context.route(PR_URL, (route) =>
+      route.fulfill({ path: PR_MODERN_FIXTURE_PATH, contentType: "text/html" }),
+    );
+
+    const page = await context.newPage();
+    await page.goto(PULLS_LIST_URL);
+
+    await expect(page.getByRole("button", { name: "Start Guided Review" })).toHaveCount(0);
+
+    // Simulate GitHub SPA navigation: history update + swap in PR header DOM
+    // (the MutationObserver reacts to the DOM mutation).
+    await page.evaluate((prUrl) => {
+      history.pushState({}, "", prUrl);
+      document.body.innerHTML = `
+        <header data-component="PageHeader">
+          <div data-component="TitleArea">
+            <h1 data-component="PH_Title">
+              <span data-component="Text">Add feature</span>
+            </h1>
+            <div data-component="PH_Actions" class="d-none"></div>
+          </div>
+          <div data-component="PH_Navigation">
+            <div class="right-actions"></div>
+            <nav aria-label="Pull request navigation tabs">
+              <a role="tab" href="/acme/widgets/pull/1" aria-selected="true">Conversation</a>
+            </nav>
+          </div>
+        </header>
+      `;
+    }, PR_URL);
+
+    await expect(page.getByRole("button", { name: "Start Guided Review" })).toBeVisible();
+    await expect(page.locator('[data-component="PH_Actions"] #guided-review-start-btn')).toBeVisible();
   });
 });

--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -27,7 +27,10 @@ export default defineManifest({
   },
   content_scripts: [
     {
-      matches: ["https://github.com/*/*/pull/*"],
+      // Match all of github.com so the content script (and its MutationObserver)
+      // is already running when the user SPA-navigates from e.g. the PR list into
+      // a PR. UI is only injected when parsePRUrl matches a PR path.
+      matches: ["https://github.com/*"],
       js: ["src/content/index.tsx"],
       run_at: "document_idle",
     },

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -51,9 +51,19 @@ function init(): void {
   observer.observe(document.body, { childList: true, subtree: true });
 }
 
+function removeStartButton(): void {
+  document.getElementById(BUTTON_ID)?.remove();
+  document.getElementById(FALLBACK_HOST_ID)?.remove();
+  currentPR = null;
+}
+
 function tryInjectButton(): void {
   const pr = parsePRUrl(window.location.href);
-  if (!pr) return;
+  // Content script matches all github.com; tear down UI when the SPA leaves a PR.
+  if (!pr) {
+    removeStartButton();
+    return;
+  }
 
   currentPR = pr;
 
@@ -76,22 +86,26 @@ function tryInjectButton(): void {
   const button = document.createElement("button");
   button.id = BUTTON_ID;
   button.type = "button";
+  // Size matches GitHub Primer medium action buttons (32px) in the PR header.
   button.setAttribute(
     "style",
     [
       "display: inline-flex",
       "align-items: center",
+      "justify-content: center",
+      "box-sizing: border-box",
+      "height: 32px",
       "gap: 8px",
       "margin-left: 8px",
-      "padding: 5px 12px",
+      "padding: 0 12px",
       "border-radius: 6px",
       "border: 1px solid #CAFF57",
       "background: #CAFF57",
       "color: #0D0806",
-      "font-size: 12px",
+      "font-size: 14px",
       "font-weight: 600",
       "cursor: pointer",
-      "line-height: 1.2",
+      "line-height: 20px",
       "transition: background 0.12s ease, border-color 0.12s ease",
     ].join(";"),
   );

--- a/src/content/overlay/Overlay.test.tsx
+++ b/src/content/overlay/Overlay.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Overlay } from "./Overlay";
+import { resetConfirmationQueueForTests } from "./components/confirmation";
 import { DEFAULT_DIFF_VIEW_MODE } from "./diffViewMode";
 import { useReviewStore } from "./store";
 import { PR_DESCRIPTION_UNIT_TITLE } from "./displayUnits";
@@ -115,6 +116,7 @@ function seedReadyReview(unitIndex = 1): void {
 describe("Overlay", () => {
   beforeEach(() => {
     resetStore();
+    resetConfirmationQueueForTests();
     Element.prototype.scrollIntoView = vi.fn();
     Element.prototype.scrollTo = vi.fn();
     // jsdom does not implement scrollBy; ArrowDown scrolls the code column.
@@ -131,6 +133,10 @@ describe("Overlay", () => {
       ok: true,
       auth: sampleAuth,
     });
+  });
+
+  afterEach(() => {
+    resetConfirmationQueueForTests();
   });
 
   it("renders nothing when the review isn't open", () => {
@@ -679,7 +685,7 @@ describe("Overlay", () => {
       expect(useReviewStore.getState().isOpen).toBe(true);
     });
 
-    it("exits the overlay on Esc after the modal is closed", async () => {
+    it("prompts to exit on Esc after the modal is closed, then exits on confirm", async () => {
       seedReadyReview(0);
       render(<Overlay />);
 
@@ -688,7 +694,28 @@ describe("Overlay", () => {
       expect(screen.queryByTestId("submit-review-modal")).not.toBeInTheDocument();
 
       fireEvent.keyDown(window, { key: "Escape" });
-      expect(useReviewStore.getState().isOpen).toBe(false);
+      expect(await screen.findByTestId("confirmation-dialog")).toBeInTheDocument();
+      expect(screen.getByText(/Exit guided review/i)).toBeInTheDocument();
+      expect(useReviewStore.getState().isOpen).toBe(true);
+
+      fireEvent.click(screen.getByTestId("confirmation-ok"));
+      await waitFor(() => {
+        expect(useReviewStore.getState().isOpen).toBe(false);
+      });
+    });
+
+    it("stays open when exit confirmation is cancelled", async () => {
+      seedReadyReview(0);
+      render(<Overlay />);
+
+      fireEvent.keyDown(window, { key: "Escape" });
+      expect(await screen.findByTestId("confirmation-dialog")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId("confirmation-cancel"));
+      await waitFor(() => {
+        expect(screen.queryByTestId("confirmation-dialog")).not.toBeInTheDocument();
+      });
+      expect(useReviewStore.getState().isOpen).toBe(true);
     });
 
     it("submits a review to GitHub and shows the success modal", async () => {

--- a/src/content/overlay/Overlay.tsx
+++ b/src/content/overlay/Overlay.tsx
@@ -23,6 +23,13 @@ import { DescriptionPane } from "./components/DescriptionPane";
 import { ContextPanel } from "./components/ContextPanel";
 import { FooterNav } from "./components/FooterNav";
 import { ConnectGitHubModal } from "./components/ConnectGitHubModal";
+import {
+  confirm,
+  ConfirmationHost,
+  confirmationHandlesKey,
+  getConfirmationDialogElement,
+  useConfirmationOpen,
+} from "./components/confirmation";
 import { SubmitReviewModal } from "./components/SubmitReviewModal";
 import { ReviewSubmittedModal } from "./components/ReviewSubmittedModal";
 
@@ -115,16 +122,32 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
     close();
   }, [onRequestClose, close]);
 
+  /** Esc (and Exit button) — confirm before leaving guided review. */
+  const requestExit = useCallback(() => {
+    confirm({
+      title: "Exit guided review?",
+      body: "You can reopen this walkthrough on the same PR later. Unsubmitted draft comments are kept for this browser session.",
+      variant: "destructive",
+      okButtonText: "Exit",
+      cancelButtonText: "Stay",
+      okButtonHandler: () => {
+        handleExit();
+      },
+    });
+  }, [handleExit]);
+
   const exitAfterSubmit = useCallback(() => {
     setSubmitSuccess(null);
     if (prContext) {
       navigateToPrConversation(prContext);
     }
+    // Post-submit exit is intentional (single CTA) — skip the confirm prompt.
     handleExit();
   }, [prContext, handleExit]);
 
   const draftComments = useReviewStore((s) => s.draftComments);
   const clearDraftComments = useReviewStore((s) => s.clearDraftComments);
+  const confirmationOpen = useConfirmationOpen();
 
   const closeSubmitReviewModal = useCallback(() => {
     if (submittingReview) return;
@@ -340,13 +363,23 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
     function onKeyDown(event: KeyboardEvent): void {
       event.stopPropagation();
 
-      // Tab trap: keep focus inside the submit modal when open, else the overlay.
+      // Tab trap: confirmation → submit modal → overlay.
       // Must run here — window capture stopPropagation means element traps never see Tab.
       if (event.key === "Tab") {
-        const trapRoot = submitReviewOpen
-          ? submitModalDialogRef.current
-          : overlayRef.current;
+        const confirmDialog = getConfirmationDialogElement();
+        const trapRoot = confirmDialog
+          ? confirmDialog
+          : submitReviewOpen
+            ? submitModalDialogRef.current
+            : overlayRef.current;
         if (trapRoot) trapTabKey(event, trapRoot);
+        return;
+      }
+
+      // Confirmation dialog: Enter = OK, Esc = cancel (highest priority modal).
+      if (confirmationHandlesKey(event)) {
+        event.preventDefault();
+        viewChordRef.current = null;
         return;
       }
 
@@ -511,8 +544,7 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
         case "Escape":
           event.preventDefault();
           viewChordRef.current = null;
-          onRequestClose?.();
-          store.close();
+          requestExit();
           return;
         case "ArrowRight":
           event.preventDefault();
@@ -568,6 +600,8 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
     exitAfterSubmit,
     requestOpenSubmitReview,
     closeSubmitReviewModal,
+    confirmationOpen,
+    requestExit,
   ]);
 
   const statusAnnouncement = useMemo(() => {
@@ -618,7 +652,7 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
         diff={diff}
         titleId={titleId}
         title={dialogTitle}
-        onExit={handleExit}
+        onExit={requestExit}
         onSubmitReview={() => {
           void requestOpenSubmitReview();
         }}
@@ -706,6 +740,8 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
         commentCount={submitSuccess?.commentCount ?? 0}
         onExit={exitAfterSubmit}
       />
+
+      <ConfirmationHost />
     </div>
   );
 }

--- a/src/content/overlay/components/DescriptionPane.tsx
+++ b/src/content/overlay/components/DescriptionPane.tsx
@@ -42,11 +42,13 @@ export function DescriptionPane({ prContext, diff }: DescriptionPaneProps) {
     <div
       className={cn(
         "w-full max-w-full",
-        summary && "flex flex-wrap items-start justify-start gap-x-8 gap-y-7"
+        // Keep Changes to the right of the description; shrink the description
+        // before wrapping so the side-by-side layout holds in typical pane widths.
+        summary && "flex flex-nowrap items-start justify-start gap-x-8"
       )}
       data-testid="description-pane"
     >
-      <div className="min-w-0 max-w-[720px] flex-[0_1_720px]">
+      <div className="min-w-0 max-w-[720px] flex-1">
         <h2 className="mb-5 text-[1.375rem] font-semibold leading-snug tracking-[-0.01em] text-gr-text">
           PR description
         </h2>
@@ -71,7 +73,7 @@ export function DescriptionPane({ prContext, diff }: DescriptionPaneProps) {
 
       {summary && (
         <section
-          className="ml-0 w-full min-w-[min(100%,260px)] max-w-[400px] flex-[0_1_360px] rounded-none border-0 border-l border-gr-border bg-transparent py-0 pr-0 pl-6"
+          className="w-[min(100%,360px)] shrink-0 max-w-[400px] border-l border-gr-border pl-6"
           aria-label="Diff summary"
         >
           <h3 className="mb-2.5 text-lg font-semibold text-gr-text">Changes</h3>
@@ -82,7 +84,7 @@ export function DescriptionPane({ prContext, diff }: DescriptionPaneProps) {
               · {summary.files} file{summary.files === 1 ? "" : "s"}
             </span>
           </p>
-          <ul className="m-0 flex list-none flex-col gap-0.5 p-0">
+          <ul className="m-0 flex max-h-[min(60vh,520px)] list-none flex-col gap-0.5 overflow-y-auto p-0">
             {summary.fileSummaries.map((file) => (
               <DiffSummaryFileRow key={fileKey(file)} file={file} />
             ))}
@@ -101,7 +103,7 @@ function DiffSummaryFileRow({ file }: { file: FileDiffSummary }) {
       : file.path;
 
   return (
-    <li className="grid grid-cols-[1.25rem_minmax(0,1fr)_auto] items-center gap-2 rounded-md px-2 py-1.5 font-mono text-[0.8125rem] hover:bg-gr-subtle">
+    <li className="grid grid-cols-[1.25rem_minmax(0,1fr)_auto] items-center gap-2 rounded-md px-2 py-1.5 font-mono text-[0.8125rem]">
       <span
         className={cn(
           "inline-flex h-5 w-5 shrink-0 items-center justify-center rounded text-xs font-bold leading-none",

--- a/src/content/overlay/components/DiffPane.tsx
+++ b/src/content/overlay/components/DiffPane.tsx
@@ -17,6 +17,7 @@ import type { DiffViewMode } from "../diffViewMode";
 import { hydrateDiffViewMode, useReviewStore } from "../store";
 import type { ResolvedUnitFile } from "../selectors";
 import { CommentComposer } from "./CommentComposer";
+import { confirm } from "./confirmation";
 import { DraftCommentCard } from "./DraftCommentCard";
 import { Kbd } from "./Kbd";
 import { ShortcutKeys } from "./ShortcutKeys";
@@ -148,13 +149,26 @@ function LineExtras({
 
   if (!showComposer && drafts.length === 0) return null;
 
+  function requestRemoveDraft(id: string): void {
+    confirm({
+      title: "Remove draft comment?",
+      body: "This draft will be discarded. You can write a new comment on these lines later.",
+      variant: "destructive",
+      okButtonText: "Remove",
+      cancelButtonText: "Cancel",
+      okButtonHandler: () => {
+        removeDraftComment(id);
+      },
+    });
+  }
+
   return (
     <div className="font-sans" data-testid={`line-extras-${lineId}`}>
       {drafts.map((d) => (
         <DraftCommentCard
           key={d.id}
           comment={d}
-          onRemove={removeDraftComment}
+          onRemove={requestRemoveDraft}
           onUpdate={updateDraftComment}
         />
       ))}

--- a/src/content/overlay/components/confirmation.test.tsx
+++ b/src/content/overlay/components/confirmation.test.tsx
@@ -1,0 +1,383 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ConfirmationHost,
+  confirm,
+  confirmationHandlesKey,
+  getConfirmationDialogElement,
+  isConfirmationOpen,
+  resetConfirmationQueueForTests,
+  useConfirmationOpen,
+} from "./confirmation";
+
+function OpenProbe() {
+  const open = useConfirmationOpen();
+  return <span data-testid="open-probe">{open ? "open" : "closed"}</span>;
+}
+
+describe("confirmation", () => {
+  beforeEach(() => {
+    resetConfirmationQueueForTests();
+  });
+
+  afterEach(() => {
+    resetConfirmationQueueForTests();
+  });
+
+  it("does not throw when confirm is called without a host", () => {
+    expect(() => {
+      confirm({
+        title: "Orphan",
+        body: "No host",
+        okButtonHandler: () => {},
+      });
+    }).not.toThrow();
+    expect(isConfirmationOpen()).toBe(true);
+  });
+
+  it("renders title and body when confirm is called with host mounted", async () => {
+    render(<ConfirmationHost />);
+
+    act(() => {
+      confirm({
+        title: "Delete item",
+        body: "This cannot be undone.",
+        okButtonHandler: () => {},
+      });
+    });
+
+    expect(await screen.findByTestId("confirmation-dialog")).toBeInTheDocument();
+    expect(screen.getByText("Delete item")).toBeInTheDocument();
+    expect(screen.getByText("This cannot be undone.")).toBeInTheDocument();
+    expect(screen.getByTestId("confirmation-ok")).toHaveTextContent("Confirm");
+    expect(screen.getByTestId("confirmation-cancel")).toHaveTextContent("Cancel");
+  });
+
+  it("renders ReactNode body and custom button labels", async () => {
+    render(<ConfirmationHost />);
+
+    act(() => {
+      confirm({
+        title: "Custom",
+        body: (
+          <span data-testid="custom-body">
+            Rich <strong>content</strong>
+          </span>
+        ),
+        okButtonText: "Remove",
+        cancelButtonText: "Keep",
+        okButtonHandler: () => {},
+      });
+    });
+
+    expect(await screen.findByTestId("custom-body")).toBeInTheDocument();
+    expect(screen.getByTestId("confirmation-ok")).toHaveTextContent("Remove");
+    expect(screen.getByTestId("confirmation-cancel")).toHaveTextContent("Keep");
+  });
+
+  it("sets destructive variant data attribute", async () => {
+    render(<ConfirmationHost />);
+
+    act(() => {
+      confirm({
+        title: "Danger",
+        body: "Really?",
+        variant: "destructive",
+        okButtonHandler: () => {},
+      });
+    });
+
+    expect(await screen.findByTestId("confirmation-dialog")).toHaveAttribute(
+      "data-variant",
+      "destructive",
+    );
+  });
+
+  it("focuses the cancel button on open", async () => {
+    render(<ConfirmationHost />);
+
+    act(() => {
+      confirm({
+        title: "Focus",
+        body: "Cancel first",
+        okButtonHandler: () => {},
+      });
+    });
+
+    await screen.findByTestId("confirmation-dialog");
+    expect(screen.getByTestId("confirmation-cancel")).toHaveFocus();
+  });
+
+  it("calls okButtonHandler and closes on OK click", async () => {
+    const user = userEvent.setup();
+    const okButtonHandler = vi.fn();
+    render(<ConfirmationHost />);
+
+    act(() => {
+      confirm({
+        title: "OK test",
+        body: "Proceed?",
+        okButtonHandler,
+      });
+    });
+
+    await screen.findByTestId("confirmation-dialog");
+    await user.click(screen.getByTestId("confirmation-ok"));
+
+    await waitFor(() => {
+      expect(okButtonHandler).toHaveBeenCalledTimes(1);
+      expect(screen.queryByTestId("confirmation-dialog")).not.toBeInTheDocument();
+    });
+    expect(isConfirmationOpen()).toBe(false);
+  });
+
+  it("calls cancelButtonHandler and closes on Cancel click", async () => {
+    const user = userEvent.setup();
+    const cancelButtonHandler = vi.fn();
+    const okButtonHandler = vi.fn();
+    render(<ConfirmationHost />);
+
+    act(() => {
+      confirm({
+        title: "Cancel test",
+        body: "Leave?",
+        okButtonHandler,
+        cancelButtonHandler,
+      });
+    });
+
+    await screen.findByTestId("confirmation-dialog");
+    await user.click(screen.getByTestId("confirmation-cancel"));
+
+    await waitFor(() => {
+      expect(cancelButtonHandler).toHaveBeenCalledTimes(1);
+      expect(okButtonHandler).not.toHaveBeenCalled();
+      expect(screen.queryByTestId("confirmation-dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  it("cancels when the scrim is clicked", async () => {
+    const user = userEvent.setup();
+    const cancelButtonHandler = vi.fn();
+    render(<ConfirmationHost />);
+
+    act(() => {
+      confirm({
+        title: "Scrim",
+        body: "Click outside",
+        okButtonHandler: () => {},
+        cancelButtonHandler,
+      });
+    });
+
+    await screen.findByTestId("confirmation-dialog");
+    await user.click(screen.getByTestId("confirmation-scrim"));
+
+    await waitFor(() => {
+      expect(cancelButtonHandler).toHaveBeenCalledTimes(1);
+      expect(screen.queryByTestId("confirmation-dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows Processing… while okButtonHandler is pending", async () => {
+    const user = userEvent.setup();
+    let resolveOk!: () => void;
+    const okButtonHandler = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveOk = resolve;
+        }),
+    );
+    render(<ConfirmationHost />);
+
+    act(() => {
+      confirm({
+        title: "Slow",
+        body: "Wait",
+        okButtonHandler,
+      });
+    });
+
+    await screen.findByTestId("confirmation-dialog");
+    await user.click(screen.getByTestId("confirmation-ok"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("confirmation-ok")).toHaveTextContent("Processing…");
+      expect(screen.getByTestId("confirmation-ok")).toBeDisabled();
+      expect(screen.getByTestId("confirmation-cancel")).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveOk();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("confirmation-dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  it("keeps the dialog open when okButtonHandler rejects", async () => {
+    const user = userEvent.setup();
+    const okButtonHandler = vi.fn().mockRejectedValue(new Error("Boom"));
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(<ConfirmationHost />);
+
+    act(() => {
+      confirm({
+        title: "Fail",
+        body: "Will throw",
+        okButtonHandler,
+      });
+    });
+
+    await screen.findByTestId("confirmation-dialog");
+    await user.click(screen.getByTestId("confirmation-ok"));
+
+    await waitFor(() => {
+      expect(okButtonHandler).toHaveBeenCalled();
+    });
+    expect(screen.getByTestId("confirmation-dialog")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId("confirmation-ok")).not.toBeDisabled();
+    });
+
+    consoleError.mockRestore();
+  });
+
+  it("handles Enter as OK and Escape as cancel via confirmationHandlesKey", async () => {
+    const okButtonHandler = vi.fn();
+    const cancelButtonHandler = vi.fn();
+    render(<ConfirmationHost />);
+
+    act(() => {
+      confirm({
+        title: "Keys",
+        body: "Keyboard",
+        okButtonHandler,
+        cancelButtonHandler,
+      });
+    });
+
+    await screen.findByTestId("confirmation-dialog");
+    expect(getConfirmationDialogElement()).toBeInstanceOf(HTMLElement);
+
+    act(() => {
+      const handled = confirmationHandlesKey(
+        new KeyboardEvent("keydown", { key: "Escape" }),
+      );
+      expect(handled).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(cancelButtonHandler).toHaveBeenCalledTimes(1);
+      expect(screen.queryByTestId("confirmation-dialog")).not.toBeInTheDocument();
+    });
+
+    act(() => {
+      confirm({
+        title: "Keys OK",
+        body: "Enter",
+        okButtonHandler,
+      });
+    });
+
+    await screen.findByTestId("confirmation-dialog");
+
+    act(() => {
+      const handled = confirmationHandlesKey(
+        new KeyboardEvent("keydown", { key: "Enter" }),
+      );
+      expect(handled).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(okButtonHandler).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("does not treat modifier+Enter as OK", async () => {
+    const okButtonHandler = vi.fn();
+    render(<ConfirmationHost />);
+
+    act(() => {
+      confirm({
+        title: "Mod",
+        body: "No",
+        okButtonHandler,
+      });
+    });
+
+    await screen.findByTestId("confirmation-dialog");
+
+    act(() => {
+      expect(
+        confirmationHandlesKey(
+          new KeyboardEvent("keydown", { key: "Enter", metaKey: true }),
+        ),
+      ).toBe(false);
+      expect(
+        confirmationHandlesKey(
+          new KeyboardEvent("keydown", { key: "Enter", ctrlKey: true }),
+        ),
+      ).toBe(false);
+    });
+
+    expect(okButtonHandler).not.toHaveBeenCalled();
+    expect(screen.getByTestId("confirmation-dialog")).toBeInTheDocument();
+  });
+
+  it("useConfirmationOpen tracks queue state", async () => {
+    render(
+      <>
+        <OpenProbe />
+        <ConfirmationHost />
+      </>,
+    );
+
+    expect(screen.getByTestId("open-probe")).toHaveTextContent("closed");
+
+    act(() => {
+      confirm({
+        title: "Probe",
+        body: "Open",
+        okButtonHandler: () => {},
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("open-probe")).toHaveTextContent("open");
+    });
+
+    await userEvent.setup().click(screen.getByTestId("confirmation-cancel"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("open-probe")).toHaveTextContent("closed");
+    });
+  });
+
+  it("shows the next queued confirmation after the first closes", async () => {
+    const user = userEvent.setup();
+    render(<ConfirmationHost />);
+
+    act(() => {
+      confirm({
+        title: "First",
+        body: "One",
+        okButtonHandler: () => {},
+      });
+      confirm({
+        title: "Second",
+        body: "Two",
+        okButtonHandler: () => {},
+      });
+    });
+
+    expect(await screen.findByText("First")).toBeInTheDocument();
+    expect(screen.queryByText("Second")).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId("confirmation-cancel"));
+
+    expect(await screen.findByText("Second")).toBeInTheDocument();
+  });
+});

--- a/src/content/overlay/components/confirmation.tsx
+++ b/src/content/overlay/components/confirmation.tsx
@@ -1,0 +1,368 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react";
+import { cn } from "../../../lib/cn";
+import { Kbd } from "./Kbd";
+
+export type ConfirmVariant = "primary" | "destructive";
+
+export interface ConfirmOptions {
+  title: string;
+  /** Description; string or rich content. */
+  body: ReactNode;
+  okButtonText?: string;
+  cancelButtonText?: string;
+  variant?: ConfirmVariant;
+  okButtonHandler: () => void | Promise<void>;
+  cancelButtonHandler?: () => void | Promise<void>;
+}
+
+interface QueuedConfirmation {
+  id: string;
+  options: Required<
+    Pick<ConfirmOptions, "okButtonText" | "cancelButtonText" | "variant">
+  > &
+    ConfirmOptions;
+}
+
+// ── Module queue + subscribers (abstractions-style imperative API) ─────────
+
+let confirmationQueue: QueuedConfirmation[] = [];
+const queueListeners = new Set<() => void>();
+const openListeners = new Set<() => void>();
+
+let dialogElement: HTMLElement | null = null;
+let okAction: (() => void) | null = null;
+let cancelAction: (() => void) | null = null;
+
+function notifyQueue(): void {
+  for (const l of queueListeners) l();
+}
+
+function notifyOpen(): void {
+  for (const l of openListeners) l();
+}
+
+function getSnapshot(): QueuedConfirmation[] {
+  return confirmationQueue;
+}
+
+function subscribe(listener: () => void): () => void {
+  queueListeners.add(listener);
+  return () => {
+    queueListeners.delete(listener);
+  };
+}
+
+function getOpenSnapshot(): boolean {
+  return confirmationQueue.length > 0;
+}
+
+function subscribeOpen(listener: () => void): () => void {
+  openListeners.add(listener);
+  return () => {
+    openListeners.delete(listener);
+  };
+}
+
+function enqueue(options: ConfirmOptions): void {
+  const id = `confirm-${Math.random().toString(36).slice(2, 11)}`;
+  confirmationQueue = [
+    ...confirmationQueue,
+    {
+      id,
+      options: {
+        variant: "primary",
+        okButtonText: "Confirm",
+        cancelButtonText: "Cancel",
+        ...options,
+      },
+    },
+  ];
+  notifyQueue();
+  notifyOpen();
+}
+
+function dequeueHead(): void {
+  if (confirmationQueue.length === 0) return;
+  confirmationQueue = confirmationQueue.slice(1);
+  notifyQueue();
+  notifyOpen();
+}
+
+/**
+ * Open a confirmation dialog. The host must be mounted (e.g. under Overlay).
+ * Handlers run when the user chooses OK or Cancel.
+ */
+export function confirm(options: ConfirmOptions): void {
+  enqueue(options);
+}
+
+/** Whether a confirmation dialog is currently queued/visible. */
+export function isConfirmationOpen(): boolean {
+  return confirmationQueue.length > 0;
+}
+
+/**
+ * Subscribe to open/closed state so Overlay can rebind keyboard / Tab trap.
+ * Uses useSyncExternalStore against the module queue.
+ */
+export function useConfirmationOpen(): boolean {
+  return useSyncExternalStore(subscribeOpen, getOpenSnapshot, getOpenSnapshot);
+}
+
+/** Dialog panel element for Tab focus trapping (null when closed). */
+export function getConfirmationDialogElement(): HTMLElement | null {
+  return dialogElement;
+}
+
+/**
+ * Handle overlay-level keyboard when a confirmation is open.
+ * Returns true if the event was consumed (caller should preventDefault / return).
+ */
+export function confirmationHandlesKey(event: KeyboardEvent): boolean {
+  if (confirmationQueue.length === 0) return false;
+
+  if (event.key === "Escape") {
+    cancelAction?.();
+    return true;
+  }
+
+  if (
+    event.key === "Enter" &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.altKey
+  ) {
+    okAction?.();
+    return true;
+  }
+
+  return false;
+}
+
+/** Test helper: drain the queue without running handlers. */
+export function resetConfirmationQueueForTests(): void {
+  const hadItems = confirmationQueue.length > 0;
+  confirmationQueue = [];
+  dialogElement = null;
+  okAction = null;
+  cancelAction = null;
+  // Only notify when something was cleared — avoids noisy re-renders in parallel tests.
+  if (hadItems) {
+    notifyQueue();
+    notifyOpen();
+  }
+}
+
+// ── Dialog UI ──────────────────────────────────────────────────────────────
+
+const secondaryBtn =
+  "inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-border bg-gr-bg px-3 py-1.5 text-base text-gr-muted hover:bg-gr-subtle hover:text-gr-text disabled:cursor-not-allowed disabled:opacity-50";
+
+const primaryOkBtn =
+  "inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-accent bg-gr-accent px-3 py-1.5 text-base font-medium text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover disabled:cursor-not-allowed disabled:opacity-50 [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit";
+
+const destructiveOkBtn =
+  "inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-gr-danger bg-gr-danger-subtle px-3 py-1.5 text-base font-medium text-gr-danger hover:bg-[rgba(255,123,114,0.2)] disabled:cursor-not-allowed disabled:opacity-50";
+
+interface ConfirmationDialogProps {
+  title: string;
+  body: ReactNode;
+  okButtonText: string;
+  cancelButtonText: string;
+  variant: ConfirmVariant;
+  okButtonHandler: () => void | Promise<void>;
+  cancelButtonHandler?: () => void | Promise<void>;
+  onClose: () => void;
+}
+
+function ConfirmationDialog({
+  title,
+  body,
+  okButtonText,
+  cancelButtonText,
+  variant,
+  okButtonHandler,
+  cancelButtonHandler,
+  onClose,
+}: ConfirmationDialogProps) {
+  const titleId = useId();
+  const bodyId = useId();
+  const cancelRef = useRef<HTMLButtonElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const isLoadingRef = useRef(false);
+  // Keep latest handlers without re-registering keyboard actions every render.
+  const okHandlerRef = useRef(okButtonHandler);
+  const cancelHandlerRef = useRef(cancelButtonHandler);
+  const onCloseRef = useRef(onClose);
+  okHandlerRef.current = okButtonHandler;
+  cancelHandlerRef.current = cancelButtonHandler;
+  onCloseRef.current = onClose;
+
+  const settledRef = useRef(false);
+
+  const handleOk = useCallback(async () => {
+    if (isLoadingRef.current || settledRef.current) return;
+    isLoadingRef.current = true;
+    setIsLoading(true);
+    try {
+      await okHandlerRef.current();
+      settledRef.current = true;
+      onCloseRef.current();
+    } catch (error) {
+      console.error("Confirmation okButtonHandler error:", error);
+    } finally {
+      isLoadingRef.current = false;
+      setIsLoading(false);
+    }
+  }, []);
+
+  const handleCancel = useCallback(async () => {
+    if (isLoadingRef.current || settledRef.current) return;
+    settledRef.current = true;
+    try {
+      await cancelHandlerRef.current?.();
+    } catch (error) {
+      console.error("Confirmation cancelButtonHandler error:", error);
+    }
+    onCloseRef.current();
+  }, []);
+
+  // Register dialog + actions for overlay keyboard / Tab trap.
+  useEffect(() => {
+    dialogElement = dialogRef.current;
+    okAction = () => {
+      void handleOk();
+    };
+    cancelAction = () => {
+      void handleCancel();
+    };
+    return () => {
+      if (dialogElement === dialogRef.current) dialogElement = null;
+      okAction = null;
+      cancelAction = null;
+    };
+  }, [handleOk, handleCancel]);
+
+  // Own capture listener so Enter/Esc work outside the overlay (e.g. options page).
+  // Overlay also routes keys via confirmationHandlesKey; settledRef prevents double-fire.
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent): void {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        void handleCancel();
+        return;
+      }
+      if (
+        event.key === "Enter" &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.altKey
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        void handleOk();
+      }
+    }
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [handleOk, handleCancel]);
+
+  // Focus Cancel on open (safer for destructive confirms).
+  useEffect(() => {
+    cancelRef.current?.focus();
+  }, []);
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 p-4"
+      data-testid="confirmation-scrim"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !isLoading) {
+          void handleCancel();
+        }
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={bodyId}
+        data-testid="confirmation-dialog"
+        data-variant={variant}
+        className="flex w-full max-w-[420px] flex-col rounded-lg border border-gr-border bg-gr-chrome shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex flex-col gap-2 px-4 py-4">
+          <h2 id={titleId} className="m-0 text-lg font-semibold text-gr-text">
+            {title}
+          </h2>
+          <div id={bodyId} className="m-0 text-base leading-relaxed text-gr-muted">
+            {typeof body === "string" ? <p className="m-0">{body}</p> : body}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-end gap-2 border-t border-gr-border px-4 py-3">
+          <button
+            ref={cancelRef}
+            type="button"
+            className={secondaryBtn}
+            onClick={() => void handleCancel()}
+            disabled={isLoading}
+            data-testid="confirmation-cancel"
+          >
+            {cancelButtonText}
+            <Kbd>Esc</Kbd>
+          </button>
+          <button
+            type="button"
+            className={cn(variant === "destructive" ? destructiveOkBtn : primaryOkBtn)}
+            onClick={() => void handleOk()}
+            disabled={isLoading}
+            data-testid="confirmation-ok"
+          >
+            {isLoading ? "Processing…" : okButtonText}
+            {!isLoading && <Kbd>Enter</Kbd>}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Mount once under the guided review overlay (or any React root that needs confirms).
+ * Renders the head of the confirmation queue.
+ */
+export function ConfirmationHost() {
+  const queue = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  const head = queue[0] ?? null;
+
+  if (!head) return null;
+
+  const { options, id } = head;
+
+  return (
+    <ConfirmationDialog
+      key={id}
+      title={options.title}
+      body={options.body}
+      okButtonText={options.okButtonText}
+      cancelButtonText={options.cancelButtonText}
+      variant={options.variant}
+      okButtonHandler={options.okButtonHandler}
+      cancelButtonHandler={options.cancelButtonHandler}
+      onClose={dequeueHead}
+    />
+  );
+}

--- a/src/options/GitHubAuthSection.test.tsx
+++ b/src/options/GitHubAuthSection.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetConfirmationQueueForTests } from "../content/overlay/components/confirmation";
 import { GitHubAuthSection } from "./GitHubAuthSection";
 import * as messaging from "../lib/messaging";
 import * as oauthConfig from "../lib/github/oauthConfig";
@@ -34,6 +35,7 @@ describe("GitHubAuthSection", () => {
 
   afterEach(() => {
     openVerificationUriSpy.mockRestore();
+    resetConfirmationQueueForTests();
   });
 
   it("shows a setup message when OAuth is not configured", async () => {
@@ -153,7 +155,7 @@ describe("GitHubAuthSection", () => {
     expect(messaging.pollGitHubDeviceAuth).toHaveBeenCalledWith("device-2");
   });
 
-  it("disconnects and returns to Connect", async () => {
+  it("disconnects and returns to Connect after confirmation", async () => {
     const user = userEvent.setup();
     vi.mocked(messaging.getGitHubAuthStatus).mockResolvedValue({
       ok: true,
@@ -170,7 +172,38 @@ describe("GitHubAuthSection", () => {
     await screen.findByText("@octocat");
     await user.click(screen.getByRole("button", { name: /disconnect/i }));
 
-    expect(messaging.clearGitHubAuthSession).toHaveBeenCalled();
+    expect(messaging.clearGitHubAuthSession).not.toHaveBeenCalled();
+    expect(await screen.findByTestId("confirmation-dialog")).toBeInTheDocument();
+    expect(screen.getByText(/Disconnect GitHub/i)).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("confirmation-ok"));
+
+    await waitFor(() => {
+      expect(messaging.clearGitHubAuthSession).toHaveBeenCalled();
+    });
     expect(await screen.findByRole("button", { name: /connect github/i })).toBeInTheDocument();
+  });
+
+  it("does not disconnect when confirmation is cancelled", async () => {
+    const user = userEvent.setup();
+    vi.mocked(messaging.getGitHubAuthStatus).mockResolvedValue({
+      ok: true,
+      auth: {
+        accessToken: "gho_x",
+        tokenType: "bearer",
+        scope: "repo",
+        login: "octocat",
+      },
+    });
+
+    render(<GitHubAuthSection />);
+    await screen.findByText("@octocat");
+    await user.click(screen.getByRole("button", { name: /disconnect/i }));
+    await screen.findByTestId("confirmation-dialog");
+    await user.click(screen.getByTestId("confirmation-cancel"));
+
+    expect(messaging.clearGitHubAuthSession).not.toHaveBeenCalled();
+    expect(screen.getByText("@octocat")).toBeInTheDocument();
+    expect(screen.queryByTestId("confirmation-dialog")).not.toBeInTheDocument();
   });
 });

--- a/src/options/GitHubAuthSection.tsx
+++ b/src/options/GitHubAuthSection.tsx
@@ -9,6 +9,10 @@ import {
   clearGitHubAuthSession,
   getGitHubAuthStatus,
 } from "../lib/messaging";
+import {
+  confirm,
+  ConfirmationHost,
+} from "../content/overlay/components/confirmation";
 import { ActionSpinner } from "./components/ActionSpinner";
 import { cn } from "../lib/cn";
 
@@ -71,7 +75,7 @@ export function GitHubAuthSection() {
     setCopied(false);
   };
 
-  const onDisconnect = async () => {
+  const performDisconnect = async () => {
     if (disconnectBusy || connectBusy) return;
     setDisconnectBusy(true);
     setDisconnectError(null);
@@ -82,9 +86,22 @@ export function GitHubAuthSection() {
       const message =
         error instanceof Error ? error.message : "Could not disconnect GitHub.";
       setDisconnectError(message);
+      throw error instanceof Error ? error : new Error(message);
     } finally {
       setDisconnectBusy(false);
     }
+  };
+
+  const requestDisconnect = () => {
+    if (disconnectBusy || connectBusy) return;
+    confirm({
+      title: "Disconnect GitHub?",
+      body: "Guided Review will no longer be able to submit reviews on your behalf until you connect again. Your AI provider settings are unchanged.",
+      variant: "destructive",
+      okButtonText: "Disconnect",
+      cancelButtonText: "Cancel",
+      okButtonHandler: () => performDisconnect(),
+    });
   };
 
   const onCopyCode = async (code: string) => {
@@ -226,7 +243,7 @@ export function GitHubAuthSection() {
           <button
             type="button"
             className={secondaryBtn}
-            onClick={() => void onDisconnect()}
+            onClick={requestDisconnect}
             disabled={busy}
           >
             {disconnectBusy && <ActionSpinner label="Disconnecting" />}
@@ -251,6 +268,8 @@ export function GitHubAuthSection() {
           </button>
         </div>
       )}
+
+      <ConfirmationHost />
     </section>
   );
 }

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -12,6 +12,7 @@ import { Select, type SelectOption } from "./components/Select";
 import { ProviderIcon } from "./components/ProviderIcon";
 import { ActionSpinner } from "./components/ActionSpinner";
 import { BrandHeader } from "./BrandHeader";
+import { GitHubAuthSection } from "./GitHubAuthSection";
 import { cn } from "../lib/cn";
 
 type ActionStatus =
@@ -131,9 +132,12 @@ export function Options() {
     <main id="main-content" className="mx-auto max-w-[480px] px-6 py-8">
       <BrandHeader />
       <p className="mb-6 text-base text-opt-muted">
-        Choose an AI provider and paste your own API key. The key is stored only in this
-        browser and is used solely to annotate PR diffs you open.
+        Connect GitHub and choose an AI provider. Keys and tokens stay in this browser only.
       </p>
+
+      <GitHubAuthSection />
+
+      <h2 className="mb-4 text-base font-semibold text-opt-text">AI provider</h2>
 
       <div className="mb-4">
         <label className="mb-1.5 block text-base font-semibold" id="provider-label" htmlFor="provider">


### PR DESCRIPTION
## Summary
- Add a shared confirmation dialog (`confirm` + `ConfirmationHost`) for destructive actions — used for ending a review and disconnecting GitHub, with keyboard (Enter/Esc), focus, and queue support.
- Align the “Start Guided Review” button with GitHub Primer medium action buttons (32px height, sizing) in the PR header.
- Broaden the content-script match to `https://github.com/*` so injection still works after SPA navigation from the PR list; tear down the button when leaving a PR path.
- Surface GitHub auth on the options page and require confirmation before disconnect.

## Test plan
- [x] Unit tests for confirmation dialog (queue, keyboard, loading, variants)
- [x] Overlay / GitHub auth tests updated for confirm-before-action flows
- [x] E2E: inject Start Guided Review after SPA navigation from PR list
- [ ] Manual: load `dist/` on a real GitHub PR — button size matches header actions
- [ ] Manual: End review and Disconnect GitHub show confirm; Esc/Cancel abort; Enter/OK proceeds
- [ ] Manual: navigate repo PR list → open a PR without full reload; button appears