### PR TITLE
Tighten user-facing copy across overlay, options, and errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 # Guided Review
 
-**AI-structured walkthroughs for GitHub pull requests**
+**AI-structured review plans for GitHub pull requests**

--- a/e2e/options.spec.ts
+++ b/e2e/options.spec.ts
@@ -19,17 +19,17 @@ test.describe("Options page", () => {
       "Claude (Anthropic)",
     );
 
-    await page.getByLabel("API key").fill("sk-e2e-test-key");
+    await page.getByLabel("API Key").fill("sk-e2e-test-key");
     await page.getByRole("button", { name: "Save" }).click();
     await expect(page.getByText("Saved")).toBeVisible();
 
-    await page.getByRole("button", { name: "Test connection" }).click();
-    await expect(page.getByText("Connection works")).toBeVisible();
+    await page.getByRole("button", { name: "Test Connection" }).click();
+    await expect(page.getByText("Connection OK")).toBeVisible();
 
     // Reload to prove the settings round-tripped through the real chrome.storage.local,
     // not just in-memory component state.
     await page.reload();
-    await expect(page.getByLabel("API key")).toHaveValue("sk-e2e-test-key");
+    await expect(page.getByLabel("API Key")).toHaveValue("sk-e2e-test-key");
     await expect(page.getByRole("combobox", { name: "Provider" })).toContainText(
       "Claude (Anthropic)",
     );
@@ -54,7 +54,7 @@ test.describe("Options page", () => {
     await page.goto(`chrome-extension://${extensionId}/src/options/index.html`);
 
     await page.getByRole("link", { name: /about guided review/i }).click();
-    await expect(page.getByRole("heading", { name: "What it does" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "What It Does" })).toBeVisible();
     await expect(page).toHaveURL(/#about$/);
     await expect(page).toHaveTitle(/About/);
 

--- a/e2e/overlay.spec.ts
+++ b/e2e/overlay.spec.ts
@@ -61,7 +61,7 @@ test.describe("Guided review overlay", () => {
     // way a user would configure the extension before it can call an AI provider.
     const optionsPage = await context.newPage();
     await optionsPage.goto(`chrome-extension://${extensionId}/src/options/index.html`);
-    await optionsPage.getByLabel("API key").fill("sk-e2e-test-key");
+    await optionsPage.getByLabel("API Key").fill("sk-e2e-test-key");
     await optionsPage.getByRole("button", { name: "Save" }).click();
     await expect(optionsPage.getByText("Saved")).toBeVisible();
     await optionsPage.close();
@@ -90,7 +90,7 @@ test.describe("Guided review overlay", () => {
     // Playwright locators pierce open shadow roots by default, so these resolve inside the
     // overlay's shadow DOM without any special selector syntax.
     // First unit is always the synthetic PR description.
-    await expect(page.getByText("PR description").first()).toBeVisible();
+    await expect(page.getByText("PR Description").first()).toBeVisible();
 
     // After the plan streams in, the AI unit is listed and reachable via Next.
     await expect(page.getByText(CANNED_PLAN.units[0].title)).toBeVisible();

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -402,7 +402,7 @@ function describeError(error: unknown): ReviewErrorInfo {
     return { message: "Review annotation was cancelled." };
   }
   if (error instanceof Error) return { message: error.message };
-  return { message: "Something went wrong talking to the AI provider." };
+  return { message: "Could not reach the AI provider." };
 }
 
 /** Flatten structured errors for one-shot message responses that still use a string. */

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -240,7 +240,7 @@ async function onStartReview(): Promise<void> {
     const latestContext = useReviewStore.getState().prContext ?? prContext;
     startAnnotationStream(diff, latestContext, streamGeneration);
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Failed to build the guided review.";
+    const message = error instanceof Error ? error.message : "Failed to build the review.";
     useReviewStore.getState().setError(message, streamGeneration);
   }
 }

--- a/src/content/overlay/Overlay.test.tsx
+++ b/src/content/overlay/Overlay.test.tsx
@@ -695,7 +695,7 @@ describe("Overlay", () => {
 
       fireEvent.keyDown(window, { key: "Escape" });
       expect(await screen.findByTestId("confirmation-dialog")).toBeInTheDocument();
-      expect(screen.getByText(/Exit Guided Review/i)).toBeInTheDocument();
+      expect(screen.getByText("Exit review?")).toBeInTheDocument();
       expect(useReviewStore.getState().isOpen).toBe(true);
 
       fireEvent.click(screen.getByTestId("confirmation-ok"));
@@ -766,7 +766,7 @@ describe("Overlay", () => {
       expect(useReviewStore.getState().isOpen).toBe(true);
     });
 
-    it("exits guided review from the success modal and navigates to conversation", async () => {
+    it("exits the review from the success modal and navigates to conversation", async () => {
       const assign = vi.fn();
       const originalLocation = window.location;
       Object.defineProperty(window, "location", {
@@ -802,7 +802,7 @@ describe("Overlay", () => {
       });
     });
 
-    it("exits guided review with Enter while the success modal is open", async () => {
+    it("exits the review with Enter while the success modal is open", async () => {
       const assign = vi.fn();
       const originalLocation = window.location;
       Object.defineProperty(window, "location", {

--- a/src/content/overlay/Overlay.test.tsx
+++ b/src/content/overlay/Overlay.test.tsx
@@ -156,8 +156,8 @@ describe("Overlay", () => {
     // Title in left pane + entry in the unit list.
     expect(screen.getAllByText(PR_DESCRIPTION_UNIT_TITLE).length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("This PR adds a feature.")).toBeInTheDocument();
-    expect(screen.getByText(/building the rest of the walkthrough/i)).toBeInTheDocument();
-    expect(screen.getByRole("status", { name: /building the rest of the walkthrough/i })).toBeInTheDocument();
+    expect(screen.getByText(/building remaining units/i)).toBeInTheDocument();
+    expect(screen.getByRole("status", { name: /building remaining units/i })).toBeInTheDocument();
     // Skeleton placeholders are present (non-interactive bars in the unit list).
     expect(screen.getAllByTestId("unit-skeleton").length).toBeGreaterThan(0);
     // Shortcuts are reserved for the ready state; spinner occupies that slot while loading.
@@ -181,7 +181,7 @@ describe("Overlay", () => {
     expect(screen.getByLabelText(/diff summary/i)).toBeInTheDocument();
     expect(screen.getByText("src/foo.ts")).toBeInTheDocument();
     // Plan still loading — skeleton + status copy remain.
-    expect(screen.getByText(/building the rest of the walkthrough/i)).toBeInTheDocument();
+    expect(screen.getByText(/building remaining units/i)).toBeInTheDocument();
     expect(screen.getAllByTestId("unit-skeleton").length).toBeGreaterThan(0);
   });
 
@@ -198,7 +198,7 @@ describe("Overlay", () => {
 
     expect(screen.getByText("Update foo")).toBeInTheDocument();
     expect(screen.getAllByTestId("unit-skeleton").length).toBeGreaterThan(0);
-    expect(screen.getByText(/building the rest of the walkthrough/i)).toBeInTheDocument();
+    expect(screen.getByText(/building remaining units/i)).toBeInTheDocument();
   });
 
   it("shows unit context without the building spinner when viewing a streamed unit", () => {
@@ -213,10 +213,10 @@ describe("Overlay", () => {
     render(<Overlay />);
 
     expect(screen.getByText("because it needed updating")).toBeInTheDocument();
-    expect(screen.queryByText(/building the rest of the walkthrough/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/building remaining units/i)).not.toBeInTheDocument();
   });
 
-  it("shows keyboard shortcuts on the description unit once the walkthrough is ready", () => {
+  it("shows keyboard shortcuts on the description unit once the review plan is ready", () => {
     useReviewStore.setState({
       isOpen: true,
       status: "ready",
@@ -234,7 +234,7 @@ describe("Overlay", () => {
     expect(screen.getByText(/^split view$/i)).toBeInTheDocument();
     expect(screen.getByText(/^enter comment mode$/i)).toBeInTheDocument();
     expect(screen.getByText(/exit comment mode \/ exit review/i)).toBeInTheDocument();
-    expect(screen.queryByText(/building the rest of the walkthrough/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/building remaining units/i)).not.toBeInTheDocument();
   });
 
   it("shows the error in the context panel without collapsing the layout", () => {
@@ -251,7 +251,7 @@ describe("Overlay", () => {
     });
     const onRetry = vi.fn();
     render(<Overlay onRetry={onRetry} />);
-    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+    expect(screen.getByText(/^error$/i)).toBeInTheDocument();
     expect(screen.getByTestId("error-message")).toHaveTextContent("Invalid API key");
     expect(screen.getByTestId("error-status-code")).toHaveTextContent("401");
     expect(screen.getByTestId("error-code")).toHaveTextContent("authentication_error");
@@ -317,11 +317,11 @@ describe("Overlay", () => {
     });
     render(<Overlay />);
     expect(
-      screen.getByText(/read the author's intent before walking the code/i)
+      screen.getByText(/author's summary of intent/i)
     ).toBeInTheDocument();
   });
 
-  it("explains missing description and that the AI will infer intent", () => {
+  it("explains missing description and that intent will be inferred", () => {
     useReviewStore.setState({
       isOpen: true,
       status: "ready",
@@ -334,13 +334,13 @@ describe("Overlay", () => {
 
     // Left pane empty state + right pane context both mention the gap.
     expect(screen.getByTestId("description-pane-empty").textContent).toMatch(
-      /author hasn't added a PR description/i
+      /No PR description/i
     );
     expect(screen.getByTestId("context-panel-body").textContent).toMatch(
-      /rely on the AI to tell us what this PR is about/i
+      /Intent will be inferred from the title and diff/i
     );
     expect(
-      screen.queryByText(/read the author's intent before walking the code/i)
+      screen.queryByText(/author's summary of intent/i)
     ).not.toBeInTheDocument();
   });
 
@@ -354,13 +354,13 @@ describe("Overlay", () => {
     render(<Overlay />);
 
     expect(screen.getByTestId("description-pane-empty").textContent).toMatch(
-      /author hasn't added a PR title or description/i
+      /No PR title or description/i
     );
     expect(screen.getByTestId("context-panel-body").textContent).toMatch(
-      /author hasn't added a PR title or description/i
+      /No PR title or description/i
     );
     expect(screen.getByTestId("context-panel-body").textContent).toMatch(
-      /rely on the AI to tell us what this PR is about from the diff/i
+      /Intent will be inferred from the diff/i
     );
   });
 
@@ -579,7 +579,7 @@ describe("Overlay", () => {
       expect(await screen.findByTestId("connect-github-modal")).toBeInTheDocument();
       expect(screen.queryByTestId("submit-review-modal")).not.toBeInTheDocument();
       expect(screen.getByTestId("connect-github-prompt")).toHaveTextContent(
-        /authenticate via GitHub/i,
+        /Connect GitHub to submit this review/i,
       );
     });
 
@@ -695,7 +695,7 @@ describe("Overlay", () => {
 
       fireEvent.keyDown(window, { key: "Escape" });
       expect(await screen.findByTestId("confirmation-dialog")).toBeInTheDocument();
-      expect(screen.getByText(/Exit guided review/i)).toBeInTheDocument();
+      expect(screen.getByText(/Exit Guided Review/i)).toBeInTheDocument();
       expect(useReviewStore.getState().isOpen).toBe(true);
 
       fireEvent.click(screen.getByTestId("confirmation-ok"));

--- a/src/content/overlay/Overlay.tsx
+++ b/src/content/overlay/Overlay.tsx
@@ -122,10 +122,10 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
     close();
   }, [onRequestClose, close]);
 
-  /** Esc (and Exit button) — confirm before leaving guided review. */
+  /** Esc (and Exit button) — confirm before leaving the review. */
   const requestExit = useCallback(() => {
     confirm({
-      title: "Exit Guided Review?",
+      title: "Exit review?",
       body: "You can reopen on this PR later. Draft comments stay for this browser session.",
       variant: "destructive",
       okButtonText: "Exit",
@@ -383,7 +383,7 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
         return;
       }
 
-      // Success modal: Enter / Esc exit guided review (single CTA dialog).
+      // Success modal: Enter / Esc exit the review (single CTA dialog).
       if (submitSuccess) {
         viewChordRef.current = null;
         if (

--- a/src/content/overlay/Overlay.tsx
+++ b/src/content/overlay/Overlay.tsx
@@ -125,8 +125,8 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
   /** Esc (and Exit button) — confirm before leaving guided review. */
   const requestExit = useCallback(() => {
     confirm({
-      title: "Exit guided review?",
-      body: "You can reopen this walkthrough on the same PR later. Unsubmitted draft comments are kept for this browser session.",
+      title: "Exit Guided Review?",
+      body: "You can reopen on this PR later. Draft comments stay for this browser session.",
       variant: "destructive",
       okButtonText: "Exit",
       cancelButtonText: "Stay",
@@ -263,7 +263,7 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
         const message =
           error instanceof Error
             ? error.message
-            : "Something went wrong while submitting the review.";
+            : "Could not submit the review.";
         setSubmitReviewError(message);
       } finally {
         if (generation === submitGenerationRef.current) {
@@ -614,11 +614,11 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
     if (status === "streaming") {
       const n = plan?.units.length ?? 0;
       return n > 0
-        ? `Building walkthrough. ${n} review unit${n === 1 ? "" : "s"} ready.`
-        : "Building walkthrough…";
+        ? `Building review plan. ${n} review unit${n === 1 ? "" : "s"} ready.`
+        : "Building review plan…";
     }
     if (status === "ready" && plan) {
-      return `Walkthrough ready. ${displayUnitCount(plan)} steps.`;
+      return `Review plan ready. ${displayUnitCount(plan)} steps.`;
     }
     return "";
   }, [status, error, plan]);

--- a/src/content/overlay/components/CommentComposer.tsx
+++ b/src/content/overlay/components/CommentComposer.tsx
@@ -58,7 +58,7 @@ export function CommentComposer({
       <textarea
         ref={textareaRef}
         className="min-h-[88px] w-full resize-y rounded-md border border-gr-border bg-gr-bg px-3 py-2 font-sans text-base leading-relaxed text-gr-text placeholder:text-gr-faint focus:border-gr-accent"
-        placeholder="Leave a review comment (markdown supported)…"
+        placeholder="Line comment (markdown supported)…"
         value={body}
         onChange={(e) => setBody(e.target.value)}
         onKeyDown={handleKeyDown}

--- a/src/content/overlay/components/ConnectGitHubModal.test.tsx
+++ b/src/content/overlay/components/ConnectGitHubModal.test.tsx
@@ -72,7 +72,7 @@ describe("ConnectGitHubModal", () => {
     expect(screen.getByRole("dialog", { name: "Connect GitHub" })).toBeInTheDocument();
     expect(screen.getByTestId("connect-github-logo")).toBeInTheDocument();
     expect(screen.getByTestId("connect-github-prompt")).toHaveTextContent(
-      /authenticate via GitHub to submit your reviews/i,
+      /Connect GitHub to submit this review/i,
     );
     const connect = screen.getByTestId("connect-github-connect");
     expect(connect).toBeInTheDocument();
@@ -101,7 +101,7 @@ describe("ConnectGitHubModal", () => {
       /Copy this code, then paste it on the GitHub tab/i,
     );
     expect(screen.getByTestId("connect-github-enter-code")).toHaveTextContent(
-      /Enter Code On Github/,
+      /Enter Code On GitHub/,
     );
     expect(
       screen.getByTestId("connect-github-enter-code").querySelector("kbd"),
@@ -109,7 +109,7 @@ describe("ConnectGitHubModal", () => {
     expect(openVerificationUriSpy).not.toHaveBeenCalled();
   });
 
-  it("opens GitHub when Enter Code On Github is clicked", async () => {
+  it("opens GitHub when Enter Code On GitHub is clicked", async () => {
     const user = userEvent.setup();
     await startAwaitingFlow(user);
 

--- a/src/content/overlay/components/ConnectGitHubModal.tsx
+++ b/src/content/overlay/components/ConnectGitHubModal.tsx
@@ -235,7 +235,7 @@ export function ConnectGitHubModal({
                   onClick={() => void onCopyCode(flow.userCode)}
                   data-testid="connect-github-copy-code"
                 >
-                  {copied ? "Copied" : "Copy code"}
+                  {copied ? "Copied" : "Copy Code"}
                 </button>
               </div>
               <p
@@ -257,7 +257,8 @@ export function ConnectGitHubModal({
               className="m-0 w-full text-center text-base leading-relaxed text-gr-muted"
               data-testid="connect-github-prompt"
             >
-              You need to authenticate via GitHub to submit your reviews.
+              Connect GitHub to submit this review. Uses device sign-in; the token
+              stays in this browser only.
             </p>
           )}
         </div>
@@ -287,7 +288,7 @@ export function ConnectGitHubModal({
                 </>
               ) : (
                 <>
-                  Try again
+                  Try Again
                   <Kbd>Enter</Kbd>
                 </>
               )}
@@ -299,7 +300,7 @@ export function ConnectGitHubModal({
               onClick={() => void openVerificationUri(flow.verificationUri)}
               data-testid="connect-github-enter-code"
             >
-              Enter Code On Github
+              Enter Code On GitHub
               <Kbd>Enter</Kbd>
             </button>
           ) : configured ? (

--- a/src/content/overlay/components/ContextPanel.test.tsx
+++ b/src/content/overlay/components/ContextPanel.test.tsx
@@ -1,26 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { ContextPanel, missingMetadataHint } from "./ContextPanel";
-
-describe("missingMetadataHint", () => {
-  it("mentions both title and description when neither is present", () => {
-    expect(missingMetadataHint(false, false)).toMatch(/title or description/i);
-    expect(missingMetadataHint(false, false)).toMatch(/AI/i);
-  });
-
-  it("mentions only description when the title is present", () => {
-    const hint = missingMetadataHint(true, false);
-    expect(hint).toMatch(/description/i);
-    expect(hint).not.toMatch(/title/i);
-    expect(hint).toMatch(/AI/i);
-  });
-
-  it("mentions only title when the description is present", () => {
-    const hint = missingMetadataHint(false, true);
-    expect(hint).toMatch(/title/i);
-    expect(hint).toMatch(/AI/i);
-  });
-});
+import { ContextPanel } from "./ContextPanel";
 
 describe("ContextPanel error state", () => {
   it("renders status code, error code, message, and retry", () => {
@@ -37,7 +17,7 @@ describe("ContextPanel error state", () => {
       />,
     );
 
-    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+    expect(screen.getByText(/^error$/i)).toBeInTheDocument();
     expect(screen.getByTestId("error-status-code")).toHaveTextContent("429");
     expect(screen.getByTestId("error-code")).toHaveTextContent("rate_limit_error");
     expect(screen.getByTestId("error-message")).toHaveTextContent("Rate limit exceeded");

--- a/src/content/overlay/components/ContextPanel.tsx
+++ b/src/content/overlay/components/ContextPanel.tsx
@@ -34,14 +34,14 @@ export function ContextPanel({
         data-testid="context-panel-error"
       >
         <div className="mb-2 text-xs font-semibold tracking-[0.04em] text-gr-muted uppercase">
-          Something went wrong
+          Error
         </div>
 
         {(error.statusCode !== undefined || error.code) && (
           <dl className="mb-2 m-0 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-sm leading-normal">
             {error.statusCode !== undefined && (
               <>
-                <dt className="m-0 font-medium text-gr-muted">HTTP status</dt>
+                <dt className="m-0 font-medium text-gr-muted">HTTP Status</dt>
                 <dd
                   className="m-0 font-mono text-gr-danger"
                   data-testid="error-status-code"
@@ -52,7 +52,7 @@ export function ContextPanel({
             )}
             {error.code && (
               <>
-                <dt className="m-0 font-medium text-gr-muted">Error code</dt>
+                <dt className="m-0 font-medium text-gr-muted">Error Code</dt>
                 <dd
                   className="m-0 font-mono break-all text-gr-danger"
                   data-testid="error-code"
@@ -99,9 +99,9 @@ export function ContextPanel({
         </div>
         {loading ? (
           <div className="mt-4 flex items-center gap-2.5 border-t border-gr-border-muted pt-3">
-            <Spinner label="Building the rest of the walkthrough" />
+            <Spinner label="Building remaining units" />
             <p className="m-0 text-base text-gr-muted">
-              Building the rest of the walkthrough…
+              Building remaining units…
             </p>
           </div>
         ) : (

--- a/src/content/overlay/components/DescriptionPane.test.tsx
+++ b/src/content/overlay/components/DescriptionPane.test.tsx
@@ -96,7 +96,7 @@ function diffFixture(): ParsedDiff {
 describe("DescriptionPane", () => {
   it("renders the PR description without a diff summary when diff is null", () => {
     render(<DescriptionPane prContext={prContext()} diff={null} />);
-    expect(screen.getByText("PR description")).toBeInTheDocument();
+    expect(screen.getByText("PR Description")).toBeInTheDocument();
     expect(screen.getByText("This PR adds a feature.")).toBeInTheDocument();
     expect(screen.queryByLabelText(/diff summary/i)).not.toBeInTheDocument();
   });

--- a/src/content/overlay/components/DescriptionPane.tsx
+++ b/src/content/overlay/components/DescriptionPane.tsx
@@ -50,7 +50,7 @@ export function DescriptionPane({ prContext, diff }: DescriptionPaneProps) {
     >
       <div className="min-w-0 max-w-[720px] flex-1">
         <h2 className="mb-5 text-[1.375rem] font-semibold leading-snug tracking-[-0.01em] text-gr-text">
-          PR description
+          PR Description
         </h2>
         {descriptionHtml ? (
           <div

--- a/src/content/overlay/components/DiffPane.test.tsx
+++ b/src/content/overlay/components/DiffPane.test.tsx
@@ -253,7 +253,7 @@ describe("DiffPane", () => {
     );
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
-    expect(link).toHaveTextContent("View file diff on GitHub");
+    expect(link).toHaveTextContent("View File Diff on GitHub");
   });
 
   it("persists the view mode to chrome.storage.local", async () => {

--- a/src/content/overlay/components/DiffPane.tsx
+++ b/src/content/overlay/components/DiffPane.tsx
@@ -85,8 +85,7 @@ function CodeContent({
 }
 
 /** Soft-wrap long lines (e.g. SVG paths) like GitHub — no horizontal scroll bleed. */
-const DIFF_LINE_WRAP =
-  "flex min-w-0 whitespace-pre-wrap break-all pr-3";
+const DIFF_LINE_WRAP = "flex min-w-0 whitespace-pre-wrap break-all pr-3";
 
 function selectionClasses(
   lineId: string | undefined,
@@ -129,7 +128,11 @@ interface LineExtrasProps {
   lineId: string;
   draftsByEndLineId: Map<string, DraftComment[]>;
   composerPlacementId: string | null;
-  composerRange: { filePath: string; startLine: number; endLine: number } | null;
+  composerRange: {
+    filePath: string;
+    startLine: number;
+    endLine: number;
+  } | null;
   unitId?: string;
 }
 
@@ -151,8 +154,8 @@ function LineExtras({
 
   function requestRemoveDraft(id: string): void {
     confirm({
-      title: "Remove draft comment?",
-      body: "This draft will be discarded. You can write a new comment on these lines later.",
+      title: "Remove Comment?",
+      body: "This comment will be removed. You can comment on these lines again later.",
       variant: "destructive",
       okButtonText: "Remove",
       cancelButtonText: "Cancel",
@@ -201,7 +204,11 @@ function UnifiedHunk({
   focusId: string | null;
   draftsByEndLineId: Map<string, DraftComment[]>;
   composerPlacementId: string | null;
-  composerRange: { filePath: string; startLine: number; endLine: number } | null;
+  composerRange: {
+    filePath: string;
+    startLine: number;
+    endLine: number;
+  } | null;
   unitId?: string;
 }) {
   const highlighted = useMemo(
@@ -327,9 +334,7 @@ function SplitCellView({
     >
       <span
         className={lineNumberClasses(highlightNumber)}
-        data-testid={
-          highlightNumber ? "diff-line-number-highlight" : undefined
-        }
+        data-testid={highlightNumber ? "diff-line-number-highlight" : undefined}
       >
         {cell.lineNumber ?? ""}
       </span>
@@ -365,7 +370,11 @@ function SplitHunk({
   focusId: string | null;
   draftsByEndLineId: Map<string, DraftComment[]>;
   composerPlacementId: string | null;
-  composerRange: { filePath: string; startLine: number; endLine: number } | null;
+  composerRange: {
+    filePath: string;
+    startLine: number;
+    endLine: number;
+  } | null;
   unitId?: string;
 }) {
   const highlighted = useMemo(
@@ -428,7 +437,10 @@ function SplitHunk({
             {(showLeftExtras || showRightExtras) && (
               <div className="flex min-w-0" data-testid="split-line-extras">
                 <div className="min-w-0 flex-1" aria-hidden="true" />
-                <div className="w-px shrink-0 bg-gr-border" aria-hidden="true" />
+                <div
+                  className="w-px shrink-0 bg-gr-border"
+                  aria-hidden="true"
+                />
                 <div className="min-w-0 flex-1">
                   {showLeftExtras && leftId && (
                     <LineExtras
@@ -516,9 +528,9 @@ function CommentModeChip() {
       className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-gr-accent/40 bg-gr-accent-subtle px-2.5 py-1 text-sm text-gr-accent"
       data-testid="comment-mode-chip"
     >
-      Comment mode
+      Comment Mode
       <span className="inline-flex items-center gap-1 text-gr-muted">
-        · <Kbd>Esc</Kbd> to exit
+        · <Kbd>Esc</Kbd> exits
       </span>
     </span>
   );
@@ -603,7 +615,7 @@ function BinaryElidedEmptyState({ filePath }: { filePath: string }) {
           className="text-base font-medium text-gr-accent underline-offset-2 hover:underline"
           data-testid="binary-elided-github-link"
         >
-          View file diff on GitHub
+          View File Diff on GitHub
         </a>
       )}
     </div>
@@ -737,12 +749,7 @@ export function DiffPane({ files, unitTitle, unitId }: DiffPaneProps) {
       return `Comment mode. ${focused.filePath}, lines ${start ?? "?"} to ${end ?? "?"} selected.`;
     }
     return `Comment mode. ${focused.filePath}, line ${focusNum ?? "?"}.`;
-  }, [
-    uiMode,
-    lineSelection,
-    selectableLines,
-    unitSelectableLines,
-  ]);
+  }, [uiMode, lineSelection, selectableLines, unitSelectableLines]);
 
   return (
     <div ref={rootRef}>

--- a/src/content/overlay/components/KeyboardShortcuts.tsx
+++ b/src/content/overlay/components/KeyboardShortcuts.tsx
@@ -65,7 +65,7 @@ export function KeyboardShortcuts() {
         id="keyboard-shortcuts-heading"
         className="mb-2 text-xs font-semibold tracking-[0.04em] text-gr-muted uppercase"
       >
-        Keyboard shortcuts
+        Keyboard Shortcuts
       </h2>
       <ul className="m-0 flex list-none flex-col gap-2 p-0">
         {SHORTCUTS.map((row) => (

--- a/src/content/overlay/components/ReviewSubmittedModal.test.tsx
+++ b/src/content/overlay/components/ReviewSubmittedModal.test.tsx
@@ -26,7 +26,7 @@ describe("ReviewSubmittedModal", () => {
     );
 
     expect(
-      screen.getByRole("dialog", { name: "Review submitted successfully" }),
+      screen.getByRole("dialog", { name: "Review Submitted" }),
     ).toBeInTheDocument();
     expect(screen.getByTestId("review-submitted-icon")).toBeInTheDocument();
     expect(screen.getByTestId("review-submitted-modal")).toHaveAttribute(

--- a/src/content/overlay/components/ReviewSubmittedModal.tsx
+++ b/src/content/overlay/components/ReviewSubmittedModal.tsx
@@ -84,7 +84,7 @@ export function ReviewSubmittedModal({
           id={titleId}
           className="m-0 text-center text-lg font-semibold text-gr-text"
         >
-          Review submitted successfully
+          Review Submitted
         </h2>
 
         <p

--- a/src/content/overlay/components/ReviewSubmittedModal.tsx
+++ b/src/content/overlay/components/ReviewSubmittedModal.tsx
@@ -101,7 +101,7 @@ export function ReviewSubmittedModal({
           onClick={onExit}
           data-testid="review-submitted-exit"
         >
-          Exit Guided Review
+          Exit review
           <Kbd>Enter</Kbd>
         </button>
       </div>

--- a/src/content/overlay/components/Sidebar.tsx
+++ b/src/content/overlay/components/Sidebar.tsx
@@ -35,10 +35,10 @@ export function Sidebar({
   return (
     <nav
       className="mt-6 min-h-0 flex-[1_1_50%] overflow-y-auto border-t border-gr-border-muted pt-4"
-      aria-label="Review units"
+      aria-label="Review Units"
     >
       <div className="px-2 pb-1 pt-2.5 text-xs tracking-[0.04em] text-gr-muted uppercase">
-        Review units
+        Review Units
       </div>
 
       {displayUnits.map((unit, displayIndex) => {

--- a/src/content/overlay/components/SubmitReviewModal.test.tsx
+++ b/src/content/overlay/components/SubmitReviewModal.test.tsx
@@ -25,18 +25,18 @@ describe("SubmitReviewModal", () => {
     );
     expect(screen.getByRole("dialog", { name: "Submit Review" })).toBeInTheDocument();
     expect(screen.queryByTestId("submit-review-body")).not.toBeInTheDocument();
-    expect(screen.getByText("What would you like to do?")).toBeInTheDocument();
+    expect(screen.getByText("Choose a review type.")).toBeInTheDocument();
     expect(screen.getByText("Comment")).toBeInTheDocument();
     expect(
-      screen.getByText("Submit general feedback without explicit approval."),
+      screen.getByText("General feedback without approving or requesting changes."),
     ).toBeInTheDocument();
     expect(screen.getByText("Approve")).toBeInTheDocument();
     expect(
-      screen.getByText("Submit feedback and approve merging these changes."),
+      screen.getByText("Approve these changes for merge. Optional summary."),
     ).toBeInTheDocument();
     expect(screen.getByText("Request Changes")).toBeInTheDocument();
     expect(
-      screen.getByText("Submit feedback that must be addressed before merging."),
+      screen.getByText("Require changes before merge. Summary required."),
     ).toBeInTheDocument();
     expect(screen.queryByTestId("submit-review-confirm")).not.toBeInTheDocument();
   });

--- a/src/content/overlay/components/SubmitReviewModal.tsx
+++ b/src/content/overlay/components/SubmitReviewModal.tsx
@@ -46,17 +46,17 @@ const REVIEW_EVENTS: {
   {
     value: "COMMENT",
     label: "Comment",
-    description: "Submit general feedback without explicit approval.",
+    description: "General feedback without approving or requesting changes.",
   },
   {
     value: "APPROVE",
     label: "Approve",
-    description: "Submit feedback and approve merging these changes.",
+    description: "Approve these changes for merge. Optional summary.",
   },
   {
     value: "REQUEST_CHANGES",
     label: "Request Changes",
-    description: "Submit feedback that must be addressed before merging.",
+    description: "Require changes before merge. Summary required.",
   },
 ];
 
@@ -279,7 +279,7 @@ export function SubmitReviewModal({
           <>
             <div className="flex flex-col gap-3 px-4 py-4">
               <p className="m-0 text-base text-gr-muted">
-                What would you like to do?
+                Choose a review type.
               </p>
               <div
                 ref={listboxRef}
@@ -348,7 +348,7 @@ export function SubmitReviewModal({
               <textarea
                 ref={textareaRef}
                 className="min-h-[100px] w-full resize-y rounded-md border border-gr-border bg-gr-bg px-3 py-2 font-sans text-base leading-relaxed text-gr-text outline-none placeholder:text-gr-faint focus:border-gr-accent disabled:opacity-60"
-                placeholder="Leave a comment"
+                placeholder="Review summary (markdown supported)…"
                 value={body}
                 onChange={(e) => setBody(e.target.value)}
                 onKeyDown={handleTextareaKeyDown}

--- a/src/content/overlay/displayUnits.ts
+++ b/src/content/overlay/displayUnits.ts
@@ -1,7 +1,7 @@
 import type { ReviewPlan, ReviewUnit } from "../../lib/types";
 
 export const PR_DESCRIPTION_UNIT_ID = "__pr_description";
-export const PR_DESCRIPTION_UNIT_TITLE = "PR description";
+export const PR_DESCRIPTION_UNIT_TITLE = "PR Description";
 
 export type DisplayUnit =
   | { kind: "pr_description"; id: typeof PR_DESCRIPTION_UNIT_ID; title: typeof PR_DESCRIPTION_UNIT_TITLE }

--- a/src/content/overlay/missingMetadata.test.ts
+++ b/src/content/overlay/missingMetadata.test.ts
@@ -3,21 +3,21 @@ import { emptyDescriptionCopy, missingMetadataHint, PR_DESCRIPTION_HINT } from "
 
 describe("missingMetadataHint", () => {
   it("mentions both title and description when neither is present", () => {
-    expect(missingMetadataHint(false, false)).toMatch(/title or description/i);
-    expect(missingMetadataHint(false, false)).toMatch(/AI/i);
+    const hint = missingMetadataHint(false, false);
+    expect(hint).toMatch(/title or description/i);
+    expect(hint).toMatch(/inferred from the diff/i);
   });
 
-  it("mentions only description when the title is present", () => {
+  it("mentions missing description when the title is present", () => {
     const hint = missingMetadataHint(true, false);
-    expect(hint).toMatch(/description/i);
-    expect(hint).not.toMatch(/title/i);
-    expect(hint).toMatch(/AI/i);
+    expect(hint).toMatch(/^No PR description\./);
+    expect(hint).toMatch(/inferred from the title and diff/i);
   });
 
-  it("mentions only title when the description is present", () => {
+  it("mentions missing title when the description is present", () => {
     const hint = missingMetadataHint(false, true);
-    expect(hint).toMatch(/title/i);
-    expect(hint).toMatch(/AI/i);
+    expect(hint).toMatch(/^No PR title\./);
+    expect(hint).toMatch(/inferred from the description and diff/i);
   });
 
   it("returns the default PR description hint when both are present", () => {
@@ -28,11 +28,12 @@ describe("missingMetadataHint", () => {
 describe("emptyDescriptionCopy", () => {
   it("mentions title and description when the title is missing", () => {
     expect(emptyDescriptionCopy(false)).toMatch(/title or description/i);
+    expect(emptyDescriptionCopy(false)).toMatch(/inferred from the diff/i);
   });
 
   it("mentions only description when the title is present", () => {
     const copy = emptyDescriptionCopy(true);
-    expect(copy).toMatch(/description/i);
-    expect(copy).not.toMatch(/title/i);
+    expect(copy).toMatch(/^No PR description\./);
+    expect(copy).toMatch(/inferred from the title and diff/i);
   });
 });

--- a/src/content/overlay/missingMetadata.ts
+++ b/src/content/overlay/missingMetadata.ts
@@ -1,6 +1,6 @@
 /** Default right-pane copy when the PR has both a title and a description. */
 export const PR_DESCRIPTION_HINT =
-  "Read the author's intent before walking the code. This is always the first step of a guided review.";
+  "Author's summary of intent. Start here, then step through the planned units.";
 
 /**
  * User-facing copy when the PR is missing a title and/or description.
@@ -9,13 +9,13 @@ export const PR_DESCRIPTION_HINT =
  */
 export function missingMetadataHint(hasTitle: boolean, hasDescription: boolean): string {
   if (!hasTitle && !hasDescription) {
-    return "The author hasn't added a PR title or description. We'll rely on the AI to tell us what this PR is about from the diff.";
+    return "No PR title or description. Intent will be inferred from the diff.";
   }
   if (!hasDescription) {
-    return "The author hasn't added a PR description. We'll rely on the AI to tell us what this PR is about from the diff.";
+    return "No PR description. Intent will be inferred from the title and diff.";
   }
   if (!hasTitle) {
-    return "The author hasn't added a PR title. We'll rely on the AI to fill in the intent from the description and the diff.";
+    return "No PR title. Intent will be inferred from the description and diff.";
   }
   return PR_DESCRIPTION_HINT;
 }
@@ -23,7 +23,7 @@ export function missingMetadataHint(hasTitle: boolean, hasDescription: boolean):
 /** Left-pane empty-state copy when there is no description body to render. */
 export function emptyDescriptionCopy(hasTitle: boolean): string {
   if (!hasTitle) {
-    return "The author hasn't added a PR title or description. The AI will infer what this PR is about from the diff.";
+    return "No PR title or description. Intent will be inferred from the diff.";
   }
-  return "The author hasn't added a PR description. The AI will infer what this PR is about from the diff.";
+  return "No PR description. Intent will be inferred from the title and diff.";
 }

--- a/src/options/About.test.tsx
+++ b/src/options/About.test.tsx
@@ -8,11 +8,11 @@ describe("About", () => {
 
     expect(screen.getByRole("heading", { name: "Guided Review" })).toBeInTheDocument();
     expect(screen.getByText(/v0\.1\.0/)).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "What it does" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "What It Does" })).toBeInTheDocument();
     expect(
-      screen.getByText(/turns a GitHub pull request diff into an ordered, AI-guided review/i),
+      screen.getByText(/turns a PR diff into an ordered review plan/i),
     ).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "How a review works" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "How a Review Works" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Privacy" })).toBeInTheDocument();
     expect(screen.getByText(/no Guided Review backend/i)).toBeInTheDocument();
   });

--- a/src/options/About.tsx
+++ b/src/options/About.tsx
@@ -4,7 +4,7 @@ const sectionTitle = "mb-2 mt-0 text-base font-semibold text-opt-text";
 const bodyText = "m-0 text-base leading-relaxed text-opt-muted";
 
 /**
- * Explains what Guided Review does, how a walkthrough works, and where data goes.
+ * Explains what Guided Review does, how a review works, and where data goes.
  * Linked from the Settings (options) page via `#about`.
  */
 export function About() {
@@ -14,7 +14,7 @@ export function About() {
     <main id="main-content" className="mx-auto max-w-[480px] px-6 py-8">
       <BrandHeader />
       <p className="mb-6 text-base text-opt-muted">
-        AI-structured walkthroughs for GitHub pull requests
+        AI-structured review plans for GitHub pull requests
         {version ? (
           <>
             {" "}
@@ -24,17 +24,16 @@ export function About() {
       </p>
 
       <section className="mb-6">
-        <h2 className={sectionTitle}>What it does</h2>
+        <h2 className={sectionTitle}>What It Does</h2>
         <p className={bodyText}>
-          Guided Review turns a GitHub pull request diff into an ordered, AI-guided review.
-          Instead of scrolling a flat file list, you walk through logical units — schema and
-          data-model changes first, then the core logic that depends on them, then call-sites,
-          then tests — with short context and risk flags for each step.
+          Guided Review turns a PR diff into an ordered review plan. You step through
+          logical units — schema and data model first, then core logic, call-sites, then
+          tests — with short context and risk notes per step.
         </p>
       </section>
 
       <section className="mb-6">
-        <h2 className={sectionTitle}>How a review works</h2>
+        <h2 className={sectionTitle}>How a Review Works</h2>
         <ol className="m-0 list-decimal space-y-2 pl-5 text-base leading-relaxed text-opt-muted">
           <li>Open a pull request on GitHub.</li>
           <li>

--- a/src/options/App.test.tsx
+++ b/src/options/App.test.tsx
@@ -24,7 +24,7 @@ describe("App", () => {
     window.location.hash = "#about";
     render(<App />);
 
-    expect(await screen.findByRole("heading", { name: "What it does" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "What It Does" })).toBeInTheDocument();
     expect(screen.queryByRole("combobox", { name: /provider/i })).not.toBeInTheDocument();
     expect(document.title).toBe("Guided Review — About");
   });
@@ -36,7 +36,7 @@ describe("App", () => {
     await screen.findByRole("combobox", { name: /provider/i });
     await user.click(screen.getByRole("link", { name: /about guided review/i }));
 
-    expect(await screen.findByRole("heading", { name: "What it does" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "What It Does" })).toBeInTheDocument();
     await waitFor(() => expect(window.location.hash).toBe("#about"));
 
     await user.click(screen.getByRole("link", { name: /settings/i }));

--- a/src/options/GitHubAuthSection.test.tsx
+++ b/src/options/GitHubAuthSection.test.tsx
@@ -92,12 +92,12 @@ describe("GitHubAuthSection", () => {
       /Copy this code, then paste it on the GitHub tab/i,
     );
     expect(screen.getByTestId("github-enter-code")).toHaveTextContent(
-      /Enter Code On Github/,
+      /Enter Code On GitHub/,
     );
     expect(openVerificationUriSpy).not.toHaveBeenCalled();
   });
 
-  it("opens GitHub when Enter Code On Github is clicked", async () => {
+  it("opens GitHub when Enter Code On GitHub is clicked", async () => {
     const user = userEvent.setup();
     vi.mocked(messaging.startGitHubDeviceAuth).mockResolvedValue({
       ok: true,

--- a/src/options/GitHubAuthSection.tsx
+++ b/src/options/GitHubAuthSection.tsx
@@ -96,7 +96,7 @@ export function GitHubAuthSection() {
     if (disconnectBusy || connectBusy) return;
     confirm({
       title: "Disconnect GitHub?",
-      body: "Guided Review will no longer be able to submit reviews on your behalf until you connect again. Your AI provider settings are unchanged.",
+      body: "Guided Review will not submit reviews on your behalf until you connect again. AI provider settings are unchanged.",
       variant: "destructive",
       okButtonText: "Disconnect",
       cancelButtonText: "Cancel",
@@ -119,10 +119,10 @@ export function GitHubAuthSection() {
 
   return (
     <section className="mb-8 border-b border-opt-border pb-8" data-testid="github-auth-section">
-      <h2 className="mb-1.5 text-base font-semibold text-opt-text">GitHub account</h2>
+      <h2 className="mb-1.5 text-base font-semibold text-opt-text">GitHub Account</h2>
       <p className="mb-4 text-base text-opt-muted">
-        Connect GitHub so Guided Review can act on your behalf (for example, submitting reviews).
-        Uses device sign-in — no password is stored here. Token stays in this browser only.
+        Connect GitHub so Guided Review can submit reviews on your behalf. Uses
+        device sign-in — no password is stored. Token stays in this browser only.
       </p>
 
       {!configured && (
@@ -178,7 +178,7 @@ export function GitHubAuthSection() {
               onClick={() => void onCopyCode(flow.userCode)}
               data-testid="github-copy-code"
             >
-              {copied ? "Copied" : "Copy code"}
+              {copied ? "Copied" : "Copy Code"}
             </button>
           </div>
           <p
@@ -201,7 +201,7 @@ export function GitHubAuthSection() {
               onClick={() => void openVerificationUri(flow.verificationUri)}
               data-testid="github-enter-code"
             >
-              Enter Code On Github
+              Enter Code On GitHub
             </button>
           </div>
         </div>
@@ -264,7 +264,7 @@ export function GitHubAuthSection() {
             }}
             disabled={busy}
           >
-            Try again
+            Try Again
           </button>
         </div>
       )}

--- a/src/options/Options.test.tsx
+++ b/src/options/Options.test.tsx
@@ -109,7 +109,7 @@ describe("Options", () => {
     await user.type(screen.getByLabelText(/api key/i), "sk-test");
     await user.click(screen.getByRole("button", { name: /test connection/i }));
 
-    await waitFor(() => expect(screen.getByText("Connection works")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText("Connection OK")).toBeInTheDocument());
   });
 
   it("shows the error message when the connection test fails", async () => {

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -107,7 +107,7 @@ export function Options() {
       await setProviderSettings(settings);
       const result = await testConnection(settings);
       if (result.ok) {
-        setConnection({ kind: "ok", message: "Connection works" });
+        setConnection({ kind: "ok", message: "Connection OK" });
       } else {
         setConnection({
           kind: "error",
@@ -137,7 +137,7 @@ export function Options() {
 
       <GitHubAuthSection />
 
-      <h2 className="mb-4 text-base font-semibold text-opt-text">AI provider</h2>
+      <h2 className="mb-4 text-base font-semibold text-opt-text">AI Provider</h2>
 
       <div className="mb-4">
         <label className="mb-1.5 block text-base font-semibold" id="provider-label" htmlFor="provider">
@@ -169,7 +169,7 @@ export function Options() {
 
       <div className="mb-4">
         <label className="mb-1.5 block text-base font-semibold" htmlFor="apiKey">
-          API key
+          API Key
         </label>
         <input
           id="apiKey"
@@ -213,7 +213,7 @@ export function Options() {
           disabled={!settings.apiKey || busy}
         >
           {connection.kind === "working" && <ActionSpinner label="Testing connection" />}
-          {connection.kind === "working" ? "Testing…" : "Test connection"}
+          {connection.kind === "working" ? "Testing…" : "Test Connection"}
         </button>
         {statusMessage && (
           <span

--- a/src/popup/main.ts
+++ b/src/popup/main.ts
@@ -3,7 +3,7 @@ import type { StartGuidedReviewMessage } from "../lib/types";
 import "./popup.css";
 
 const NOT_ON_PR =
-  "Open a GitHub pull request page to start Guided Review.";
+  "Open a GitHub pull request page to start a review.";
 const RELOAD_PR =
   "Reload this pull request page, then try again.";
 

--- a/src/popup/main.ts
+++ b/src/popup/main.ts
@@ -3,9 +3,9 @@ import type { StartGuidedReviewMessage } from "../lib/types";
 import "./popup.css";
 
 const NOT_ON_PR =
-  "Guided Review only works on GitHub pull request pages right now.";
+  "Open a GitHub pull request page to start Guided Review.";
 const RELOAD_PR =
-  "Open a GitHub pull request and reload the page, then try again.";
+  "Reload this pull request page, then try again.";
 
 /** Path registered as `options_page` in the manifest (stable across builds). */
 const OPTIONS_PAGE = "src/options/index.html";


### PR DESCRIPTION
## Summary
- Standardize user-facing copy: title case on labels/buttons, shorter empty states, and clearer error messaging.
- Rename “walkthrough” → “review plan” in status text, README tagline, and related UI so product language stays consistent.
- Update unit and e2e tests to match the new strings.

## Test plan
- [ ] `npm test` — unit tests pass with updated copy assertions
- [ ] `npm run typecheck` / `npm run build`
- [ ] Smoke options page: API Key label, Test Connection / Connection OK, About headings
- [ ] Smoke overlay: streaming status (“Building review plan…”), PR Description unit, missing metadata empty states, Connect GitHub modal, submit review labels