### PR TITLE
Add legal pages (privacy, terms, cookies)

### DIFF
--- a/apps/web/app/cookies/page.tsx
+++ b/apps/web/app/cookies/page.tsx
@@ -1,0 +1,149 @@
+import type { Metadata } from "next";
+import { LegalDocument } from "../../components/LegalDocument";
+
+export const metadata: Metadata = {
+  title: "Cookies Policy",
+  description: "How Guided Review uses cookies and similar technologies on the marketing website.",
+  alternates: { canonical: "/cookies" },
+};
+
+export default function CookiesPage() {
+  return (
+    <LegalDocument
+      title="Cookies Policy"
+      meta={
+        <>
+          Effective date: July 2026 &nbsp;·&nbsp; Artery Ventures, LLP &nbsp;·&nbsp;{" "}
+          <a href="mailto:support@guidedreview.com">support@guidedreview.com</a>
+        </>
+      }
+    >
+      <section>
+        <h2>Introduction</h2>
+        <p>
+          We, Artery Ventures, LLP (&quot;Company&quot;, &quot;we&quot;, &quot;us&quot;,
+          &quot;our&quot;) may use cookies or similar technologies to understand how visitors use
+          our website <a href="https://guidedreview.com">https://guidedreview.com</a>{" "}
+          (&quot;Website&quot;). We are committed to protecting the privacy and security of your
+          personal information. We advise you to carefully read this cookie policy
+          (&quot;Policy&quot;), together with the Company&apos;s Privacy Policy at{" "}
+          <a href="https://guidedreview.com/privacy">guidedreview.com/privacy</a>, so that you are
+          aware of the cookies and technologies used as well as how we treat your personal
+          information.
+        </p>
+        <p>
+          This Policy applies to the Website. The Guided Review Chrome extension primarily uses
+          browser extension storage (for example Chrome storage) for settings and review sessions
+          rather than Website cookies. The Extension is not designed to set analytics cookies or
+          send usage telemetry to us.
+        </p>
+      </section>
+
+      <section>
+        <h2>What are cookies?</h2>
+        <p>
+          Cookies are small text files which are placed on your device when you visit a website.
+          They can allow a site to recognize your device, store preferences, analyze trends, operate
+          and improve services, and provide a better experience.
+        </p>
+      </section>
+
+      <section>
+        <h2>Types of cookies</h2>
+        <h3>By duration</h3>
+        <p>
+          <strong>Permanent (persistent) cookies</strong> — Remain on your device for a pre-defined
+          period or until you delete them. They can help recognize returning visitors.
+        </p>
+        <p>
+          <strong>Session cookies</strong> — Last only for the browsing session and are typically
+          erased when you close the browser.
+        </p>
+        <h3>By domain</h3>
+        <p>
+          <strong>First-party cookies</strong> — Set by the Website you are visiting.
+        </p>
+        <p>
+          <strong>Third-party cookies</strong> — Set by a domain other than the Website you are
+          visiting (for example an analytics provider).
+        </p>
+      </section>
+
+      <section>
+        <h2>How we use cookies on the Website</h2>
+        <p>
+          We aim to keep Website tracking minimal. Depending on deployment and hosting
+          configuration, the Website may use:
+        </p>
+        <h3>Essential / functional</h3>
+        <p>
+          Cookies or similar storage that are necessary for the Website to function securely and
+          correctly (for example load balancing, security, or basic preferences). These are
+          typically first-party and do not require advertising use.
+        </p>
+        <h3>Anonymous analytics</h3>
+        <p>
+          We may use an anonymous analytics script on the Website to understand aggregate traffic
+          patterns—such as page views, approximate geography at a coarse level, and referring
+          sources—so we can improve the marketing site. We configure analytics with the intent that
+          it is anonymous or aggregated where the tool allows, and we do not use Website analytics
+          to build a profile of Extension usage inside GitHub.
+        </p>
+        <p>
+          The specific analytics provider may change over time. We do not currently rely on
+          advertising pixels as a core part of the product. If we introduce additional tracking
+          tools, we will update this Policy.
+        </p>
+        <h3>What we do not do with the Extension</h3>
+        <p>
+          The Extension does not send product analytics or telemetry to Artery Ventures as part of
+          ordinary operation. It communicates with GitHub and with the LLM Provider you configure in
+          order to provide review plans. See the Privacy Policy for details on that processing.
+        </p>
+      </section>
+
+      <section>
+        <h2>Use of information from cookies</h2>
+        <p>Information from cookies and similar technologies may be used to:</p>
+        <ul>
+          <li>operate and secure the Website;</li>
+          <li>understand how visitors navigate the Website;</li>
+          <li>improve content, performance, and layout; and</li>
+          <li>measure whether marketing pages are useful.</li>
+        </ul>
+        <p>
+          We do not sell personal information collected via Website cookies. We do not use cookies
+          on the Website to personalize third-party advertising as part of the current Guided Review
+          product experience.
+        </p>
+      </section>
+
+      <section>
+        <h2>Disabling cookies</h2>
+        <p>
+          You can decide whether to accept cookies. Most browsers let you refuse or delete cookies
+          via settings (see your browser&apos;s help documentation). Disabling cookies may affect
+          Website functionality. You may also use browser privacy features, extensions, or
+          provider-specific opt-outs where available for analytics tools.
+        </p>
+      </section>
+
+      <section>
+        <h2>Changes to this Policy</h2>
+        <p>
+          Please revisit this page periodically to stay aware of any changes to this Policy, which
+          we may update from time to time. If we modify this Policy, we will make it available
+          through the Website and indicate the date of the latest revision.
+        </p>
+      </section>
+
+      <section>
+        <h2>Contact us</h2>
+        <p>
+          If you have any questions or concerns regarding this Policy, you can contact us at{" "}
+          <a href="mailto:support@guidedreview.com">support@guidedreview.com</a>.
+        </p>
+      </section>
+    </LegalDocument>
+  );
+}

--- a/apps/web/app/privacy/page.tsx
+++ b/apps/web/app/privacy/page.tsx
@@ -1,59 +1,392 @@
 import type { Metadata } from "next";
+import { LegalContactBlock, LegalDocument } from "../../components/LegalDocument";
 
 export const metadata: Metadata = {
   title: "Privacy Policy",
-  description: "How Guided Review handles data, API keys, and pull request content.",
+  description:
+    "How Guided Review collects, uses, and protects personal data across the website and Chrome extension.",
+  alternates: { canonical: "/privacy" },
 };
 
 export default function PrivacyPage() {
   return (
-    <article className="mx-auto max-w-3xl px-6 py-16">
-      <h1 className="m-0 text-3xl font-bold tracking-tight">Privacy Policy</h1>
-      <p className="mt-2 text-sm text-opt-muted">Last updated: July 21, 2026</p>
+    <LegalDocument
+      title="Privacy Policy"
+      meta={
+        <>
+          Last updated: July 2026 &nbsp;·&nbsp; Artery Ventures, LLP &nbsp;·&nbsp;{" "}
+          <a href="mailto:support@guidedreview.com">support@guidedreview.com</a>
+        </>
+      }
+    >
+      <section>
+        <p>
+          We, Artery Ventures, LLP (&quot;we&quot;, &quot;us&quot;, &quot;our&quot;,
+          &quot;Company&quot;) are the owners of the website{" "}
+          <a href="https://guidedreview.com">guidedreview.com</a> (&quot;Website&quot;) and the
+          Guided Review Chrome browser extension (&quot;Extension&quot;). The Website and the
+          Extension are collectively referred to as the &quot;Platform&quot;. The Website describes
+          the Extension and its features. The Extension helps users structure GitHub pull request
+          reviews with AI-assisted review plans (&quot;Services&quot;).
+        </p>
+        <p>
+          We respect data privacy rights and are committed to protecting personal information
+          collected on this Platform. This Privacy Policy (&quot;Privacy Policy&quot;) sets forth
+          how we collect, use, and protect personal information in connection with the Platform.
+        </p>
+        <p>
+          PLEASE READ THIS PRIVACY POLICY CAREFULLY. BY CONTINUING TO USE THE PLATFORM OR PROVIDING
+          US PERSONAL INFORMATION, YOU CONSENT TO OUR USE OF YOUR PERSONAL INFORMATION IN ACCORDANCE
+          WITH THE TERMS OF THIS PRIVACY POLICY. IF YOU DO NOT AGREE TO THIS PRIVACY POLICY, YOU MAY
+          WITHDRAW YOUR CONSENT OR ALTERNATIVELY CHOOSE NOT TO PROVIDE YOUR PERSONAL INFORMATION ON
+          THE PLATFORM. SUCH AN INTIMATION TO WITHDRAW YOUR CONSENT CAN BE PROVIDED BY EMAIL AT{" "}
+          <a href="mailto:support@guidedreview.com">support@guidedreview.com</a>.
+        </p>
+        <p>
+          IF YOU ARE ACCESSING THE PLATFORM ON BEHALF OF A THIRD PARTY, YOU REPRESENT THAT YOU HAVE
+          THE AUTHORITY TO BIND SUCH THIRD PARTY TO THE TERMS AND CONDITIONS OF THIS PRIVACY POLICY
+          AND, IN SUCH AN EVENT, YOUR USE OF THE PLATFORM SHALL REFER TO USE BY SUCH THIRD PARTY. IF
+          YOU DO NOT HAVE SUCH AUTHORITY OR DO NOT AGREE TO THE TERMS OF THIS PRIVACY POLICY, THEN
+          YOU SHOULD REFRAIN FROM USING THE PLATFORM.
+        </p>
+        <p>
+          This Privacy Policy is an electronic record in the form of an electronic contract
+          construed in accordance with applicable data protection laws.
+        </p>
+      </section>
 
-      <div className="mt-8 space-y-6 text-base leading-relaxed text-opt-text">
-        <section>
-          <h2 className="m-0 text-lg font-semibold">Overview</h2>
-          <p className="mt-2 text-opt-muted">
-            Guided Review is a Chrome extension that helps you review GitHub pull requests with an
-            AI-structured plan. This policy describes what data is processed and where it goes.
-          </p>
-        </section>
+      <section>
+        <h2>1. Definitions</h2>
+        <p>
+          &quot;User(s)&quot;, &quot;you&quot;, &quot;your&quot; shall mean and include individuals,
+          business organizations, commercial establishments, and their permitted users who use the
+          Platform or may opt to share Personal Information in connection with the Services.
+        </p>
+        <p>
+          &quot;UK Data Protection Law&quot; means the UK GDPR, the United Kingdom Data Protection
+          Act 2018, the Privacy and Electronic Communications Regulations, and any regulation
+          superseding any of the foregoing.
+        </p>
+        <p>
+          &quot;LLM Provider&quot; means a third-party large language model service that you
+          configure in the Extension (for example Anthropic, OpenAI, or xAI/Grok), including any
+          compatible API endpoint you supply.
+        </p>
+      </section>
 
-        <section>
-          <h2 className="m-0 text-lg font-semibold">API keys and settings</h2>
-          <p className="mt-2 text-opt-muted">
-            Provider API keys and preferences you enter in the extension options are stored locally
-            in your browser via Chrome storage. They are not sent to Guided Review servers (the
-            extension does not operate a backend for your keys).
-          </p>
-        </section>
+      <section>
+        <h2>2. Personal information collected</h2>
+        <p>
+          For purposes of this Privacy Policy, &quot;Personal Information&quot; means information
+          that can be used to personally identify the User, including but not limited to a
+          User&apos;s name, email address, or similar identifiers.
+        </p>
+        <p>
+          <strong>Personal Information collected on the Website</strong> — We may collect Personal
+          Information from you when you (a) visit our Website, (b) contact us by email or other
+          channels we publish, or (c) otherwise interact with materials on the Website. Information
+          collected may include your name, email address, and the content of your message.
+        </p>
+        <p>
+          <strong>Information processed by the Extension (on your device)</strong> — The Extension
+          is designed to process data primarily on your device. When you use the Extension, the
+          following may be stored locally in your browser via Chrome storage (including{" "}
+          <code>chrome.storage.local</code> and <code>chrome.storage.session</code> as applicable):
+        </p>
+        <ul>
+          <li>
+            LLM Provider API keys, model preferences, and other settings you enter in the Extension
+            options;
+          </li>
+          <li>
+            optional GitHub authentication tokens obtained via device-flow authentication, so the
+            Extension can call GitHub&apos;s API on your behalf (for example to submit review
+            comments);
+          </li>
+          <li>
+            review session data for pull requests you review (for example parsed diffs, review
+            plans, and progress), keyed by pull request identity, so you can resume a session.
+          </li>
+        </ul>
+        <p>
+          This locally stored data is not transmitted to Artery Ventures servers as part of ordinary
+          Extension operation. We do not operate a Guided Review backend that receives your API keys
+          or stores your pull request content for the core review workflow.
+        </p>
+        <p>
+          <strong>Pull request content and third-party processing</strong> — When you start a guided
+          review, the Extension fetches the pull request diff from GitHub and sends that content
+          (and related prompt context) to the LLM Provider you configured. That content is processed
+          under that provider&apos;s terms and privacy policy. We do not control how your chosen LLM
+          Provider stores or uses that data. You are responsible for ensuring you are authorized to
+          share repository and pull request content with that provider.
+        </p>
+        <p>
+          <strong>GitHub</strong> — Interactions with GitHub (fetching diffs, optional
+          authentication, submitting reviews) are subject to GitHub&apos;s terms and privacy policy.
+          Tokens and requests stay between your browser, GitHub, and (where you configured it) your
+          LLM Provider.
+        </p>
+        <p>
+          <strong>Social Media Platforms</strong> — If you contact us through social media platforms
+          such as LinkedIn, Twitter/X, or others, we may receive your publicly available profile
+          information such as your name, email, and handle.
+        </p>
+        <p>
+          <strong>Log Data and Website analytics</strong> — When you visit the Website, our hosting
+          infrastructure or browsers may automatically record technical information such as IP
+          address, browser type, referring page, pages visited, and similar log data. We may also
+          use anonymous analytics on the Website to understand aggregate traffic and improve the
+          site. The Extension is not designed to send analytics or usage telemetry to us; it
+          communicates with GitHub and your configured LLM Provider as described above. See our{" "}
+          <a href="https://guidedreview.com/cookies">Cookies Policy</a> for more detail.
+        </p>
+        <p>
+          <strong>Payment Information</strong> — The Platform is currently offered without a paid
+          subscription. If we later introduce paid features, payment card details would be handled
+          by a third-party payment processor and not stored by us; we would update this Privacy
+          Policy before collecting such information.
+        </p>
+      </section>
 
-        <section>
-          <h2 className="m-0 text-lg font-semibold">Pull request content</h2>
-          <p className="mt-2 text-opt-muted">
-            When you start a guided review, the extension fetches the PR diff from GitHub and sends
-            it to the LLM provider you configured (for example Anthropic, OpenAI, or xAI). That
-            content is processed under that provider&apos;s terms and privacy policy.
-          </p>
-        </section>
+      <section>
+        <h2>3. Cookies</h2>
+        <p>
+          The Website may use cookies and similar technologies, including for anonymous analytics
+          and essential site operation. You may choose to disable cookies through your browser
+          settings. For more information, please refer to our Cookies Policy at{" "}
+          <a href="https://guidedreview.com/cookies">guidedreview.com/cookies</a>. The Extension
+          primarily uses browser extension storage rather than website cookies for its settings and
+          session data.
+        </p>
+      </section>
 
-        <section>
-          <h2 className="m-0 text-lg font-semibold">GitHub authentication</h2>
-          <p className="mt-2 text-opt-muted">
-            Optional GitHub device-flow authentication stores tokens in Chrome storage so the
-            extension can submit reviews on your behalf. Tokens stay on your device except when used
-            to call GitHub&apos;s API.
-          </p>
-        </section>
+      <section>
+        <h2>4. Accuracy of information</h2>
+        <p>
+          You shall be solely responsible for the accuracy, correctness, and truthfulness of the
+          Personal Information you share with us, whether your own or that of a third party. If you
+          share Personal Information on behalf of a third party, you represent that you have the
+          necessary authority and have obtained appropriate consent from that third party. We shall
+          not be responsible for verifying such authority or consent.
+        </p>
+      </section>
 
-        <section>
-          <h2 className="m-0 text-lg font-semibold">Contact</h2>
-          <p className="mt-2 text-opt-muted">
-            For privacy questions about this product, open an issue on the project repository.
-          </p>
-        </section>
-      </div>
-    </article>
+      <section>
+        <h2>5. Use of personal information</h2>
+        <p>We use Personal Information we collect for the following purposes:</p>
+        <ul>
+          <li>to respond to your requests and support inquiries;</li>
+          <li>to operate, maintain, and improve the Website and Services;</li>
+          <li>
+            for creation or development of business intelligence or data analytics in relation to
+            Website traffic (in aggregate or anonymous form where applicable);
+          </li>
+          <li>to manage our relationship with you;</li>
+          <li>for internal record keeping; and</li>
+          <li>to comply with our legal or statutory obligations.</li>
+        </ul>
+        <p>
+          Local Extension settings, API keys, tokens, and review session data are used on your
+          device to provide the Services you request. Transmission of pull request content to your
+          LLM Provider is initiated by you when you run a guided review.
+        </p>
+      </section>
+
+      <section>
+        <h2>6. Disclosures</h2>
+        <p>
+          We do not sell, rent, share, distribute, lease, or otherwise provide your Personal
+          Information to third parties without your prior consent, except in the following cases:
+        </p>
+        <p>
+          <strong>Affiliates</strong> — We may provide your Personal Information to our affiliates
+          to enable them to improve the Services and respond to queries.
+        </p>
+        <p>
+          <strong>Service Providers</strong> — We may share Personal Information with service
+          providers who work with us in connection with operating the Website (for example hosting
+          or anonymous analytics providers). All such service providers are subject to
+          confidentiality restrictions consistent with this Privacy Policy.
+        </p>
+        <p>
+          <strong>LLM Providers and GitHub (your choices)</strong> — When you use the Extension,
+          pull request content and API requests are sent to the LLM Provider you configure and to
+          GitHub as needed to provide the Services. Those parties process data under their own
+          policies. We are not responsible for their independent processing.
+        </p>
+        <p>
+          <strong>Merger or Acquisition</strong> — We may transfer your Personal Information if we
+          are acquired by another entity, merge with another company, or transfer part of our
+          business to a third party. Any such third party that receives your Personal Information
+          shall have the right to continue to use it in line with the purposes set out herein. We
+          may notify you of such a transfer.
+        </p>
+        <p>
+          <strong>Legal and Regulatory Authorities</strong> — We may disclose your Personal
+          Information in order to comply with legal obligations, court orders, or requests by
+          government authorities.
+        </p>
+      </section>
+
+      <section>
+        <h2>7. Data retention</h2>
+        <p>
+          Personal Information we hold (for example email correspondence or Website logs) is
+          retained for as long as needed to provide the Services, respond to inquiries, comply with
+          legal obligations, resolve disputes, and enforce our agreements.
+        </p>
+        <p>
+          Data stored by the Extension in Chrome storage remains on your device until you clear it,
+          uninstall the Extension, or otherwise remove it via Extension or browser controls. We do
+          not control retention of data held by your LLM Provider or GitHub.
+        </p>
+      </section>
+
+      <section>
+        <h2>8. Security</h2>
+        <p>
+          We take reasonable measures to protect Personal Information we process in connection with
+          the Website. The Extension relies on browser security and Chrome storage mechanisms; API
+          keys and tokens stored locally can still be exposed if your device or browser profile is
+          compromised. Although we and our providers use industry-standard protections where
+          applicable, no method of transmission or storage is completely secure. You are responsible
+          for safeguarding your device, browser profile, API keys, and GitHub credentials.
+        </p>
+      </section>
+
+      <section>
+        <h2>9. Your rights</h2>
+        <p>
+          You have the right to access Personal Information in our possession, the right to have us
+          rectify or modify such Personal Information, the right to have us erase or delete your
+          Personal Information, the right to restrict our processing of such Personal Information,
+          the right to object to our use of Personal Information, and the right to withdraw consent
+          at any time where we rely on consent to process your Personal Information. If you would
+          like to exercise any of these rights regarding data we hold, please contact{" "}
+          <a href="mailto:support@guidedreview.com">support@guidedreview.com</a>.
+        </p>
+        <p>
+          For data stored only in your browser by the Extension, you can delete or modify it
+          directly by clearing Extension storage, changing options, or uninstalling the Extension.
+          For data held by an LLM Provider or GitHub, please use those providers&apos; account and
+          privacy tools.
+        </p>
+      </section>
+
+      <section>
+        <h2>10. Choice and opt-out</h2>
+        <p>
+          We may send you communications if you contact us or if we later offer optional product
+          updates or newsletters you opt into. You may opt out of promotional emails by following
+          unsubscribe instructions in those emails, or by emailing{" "}
+          <a href="mailto:support@guidedreview.com">support@guidedreview.com</a> with your request.
+        </p>
+      </section>
+
+      <section>
+        <h2>11. Information for EU and UK visitors</h2>
+        <p>
+          Residents of the European Union (&quot;EU&quot;) and United Kingdom (&quot;UK&quot;)
+          should note that this Privacy Policy has been prepared with reference to the requirements
+          of the EU General Data Protection Regulation (&quot;GDPR&quot;) and UK Privacy Laws. Where
+          we determine the purposes and means of processing Personal Information collected via the
+          Website, we act as a controller of that information.
+        </p>
+        <p>
+          <strong>Legal Basis</strong> — We will not process your Personal Information without a
+          lawful basis to do so. We will process your Personal Information only on the legal bases
+          of consent, contract, or on the basis of our legitimate interests, provided that such
+          interests are not overridden by your privacy rights and interests.
+        </p>
+        <p>
+          <strong>Cross-border transfers</strong> — Personal Information of EU and UK residents may
+          be processed outside the EU and UK (including by hosting or analytics providers, or by LLM
+          Providers you choose). We collect and transfer Personal Information we control in
+          accordance with applicable law. If you have questions, please contact{" "}
+          <a href="mailto:support@guidedreview.com">support@guidedreview.com</a>.
+        </p>
+        <p>
+          <strong>Your rights (EU and UK residents)</strong> — In addition to the rights described
+          in Section 9, you have the right to lodge a complaint with a data protection authority. UK
+          residents have the right to make a complaint to the Information Commissioner&apos;s Office
+          (&quot;ICO&quot;) at <a href="https://www.ico.org.uk">www.ico.org.uk</a>. We would
+          appreciate the chance to address your concerns before you approach the ICO, so please
+          contact us first at <a href="mailto:support@guidedreview.com">support@guidedreview.com</a>
+          .
+        </p>
+        <p>
+          <strong>Governing Laws</strong> — For EU and UK residents, this Privacy Policy shall be
+          governed respectively by the provisions of the GDPR and UK Privacy Laws to the extent they
+          apply.
+        </p>
+      </section>
+
+      <section>
+        <h2>12. Links to other websites</h2>
+        <p>
+          Our Platform may contain links to other websites or applications (including GitHub, LLM
+          Provider dashboards, and the Chrome Web Store). We do not control such third-party
+          websites and are not responsible for the protection or privacy of any information you
+          provide while visiting them. You should review the privacy policy applicable to any
+          third-party website you visit.
+        </p>
+      </section>
+
+      <section>
+        <h2>13. Limitation of liability</h2>
+        <p>
+          To the extent permissible under law, we shall not be liable for any direct, indirect,
+          incidental, special, consequential, or exemplary damages arising out of this Privacy
+          Policy, including but not limited to damages for loss of profits, goodwill, data, or other
+          intangible losses.
+        </p>
+      </section>
+
+      <section>
+        <h2>14. Children&apos;s privacy</h2>
+        <p>
+          This Platform is not intended for children under the age of 18. We do not knowingly
+          collect Personal Information from children under the age of 18 without prior, verifiable
+          consent of a legal representative. If you are under 18, please do not provide any Personal
+          Information on this Platform. If a legal representative discovers that a child has
+          provided us with Personal Information, please contact us at{" "}
+          <a href="mailto:support@guidedreview.com">support@guidedreview.com</a> to have the
+          information deleted.
+        </p>
+      </section>
+
+      <section>
+        <h2>15. Governing law and dispute resolution</h2>
+        <p>
+          Subject to applicable mandatory data-protection laws (including for EU and UK residents as
+          described in Section 11), this Privacy Policy shall in all respects be governed by and
+          construed in accordance with the laws of India. Any dispute arising under this Privacy
+          Policy shall be subject to the exclusive jurisdiction of the courts in Mumbai,
+          Maharashtra, India.
+        </p>
+      </section>
+
+      <section>
+        <h2>16. Changes to this policy</h2>
+        <p>
+          Please revisit this page periodically to stay aware of any changes to this Privacy Policy.
+          If we modify this Privacy Policy, we will make it available through the Website and
+          indicate the date of the latest revision. If such modifications materially alter your
+          rights or obligations, we will make reasonable efforts to notify you via email (where we
+          have your address) or through our Website.
+        </p>
+      </section>
+
+      <section>
+        <h2>17. Contact us</h2>
+        <p>
+          If you have any questions, concerns, or grievances about this Privacy Policy, or wish to
+          withdraw your consent in relation to the processing of your Personal Information, please
+          contact us at:
+        </p>
+        <LegalContactBlock />
+      </section>
+    </LegalDocument>
   );
 }

--- a/apps/web/app/terms/page.tsx
+++ b/apps/web/app/terms/page.tsx
@@ -1,60 +1,534 @@
 import type { Metadata } from "next";
+import { LegalContactBlock, LegalDocument } from "../../components/LegalDocument";
 
 export const metadata: Metadata = {
-  title: "Terms of Use",
-  description: "Terms governing use of the Guided Review extension and website.",
+  title: "Terms of Service",
+  description: "Terms governing use of the Guided Review Chrome extension and website.",
+  alternates: { canonical: "/terms" },
 };
 
 export default function TermsPage() {
   return (
-    <article className="mx-auto max-w-3xl px-6 py-16">
-      <h1 className="m-0 text-3xl font-bold tracking-tight">Terms of Use</h1>
-      <p className="mt-2 text-sm text-opt-muted">Last updated: July 21, 2026</p>
+    <LegalDocument
+      title="Terms of Service"
+      meta={
+        <>
+          Effective date: July 2026 &nbsp;·&nbsp; Artery Ventures, LLP &nbsp;·&nbsp;{" "}
+          <a href="mailto:support@guidedreview.com">support@guidedreview.com</a>
+        </>
+      }
+    >
+      <section>
+        <h2>1. Agreement to terms</h2>
+        <p>
+          These Terms of Use constitute a legally binding agreement made between you, whether
+          personally or on behalf of an entity (&quot;you&quot;), and Artery Ventures, LLP
+          (&quot;Company&quot;, &quot;we&quot;, &quot;us&quot;, or &quot;our&quot;), concerning your
+          access to and use of the <a href="https://guidedreview.com">https://guidedreview.com</a>{" "}
+          website and the Guided Review Chrome browser extension, as well as any other media form,
+          media channel, mobile website, or application related, linked, or otherwise connected
+          thereto (collectively, the &quot;Site&quot; or &quot;Service&quot;).
+        </p>
+        <p>
+          You agree that by accessing the Site or installing or using the Extension, you have read,
+          understood, and agree to be bound by all of these Terms of Use. IF YOU DO NOT AGREE WITH
+          ALL OF THESE TERMS OF USE, THEN YOU ARE EXPRESSLY PROHIBITED FROM USING THE SITE AND YOU
+          MUST DISCONTINUE USE IMMEDIATELY.
+        </p>
+        <p>
+          Supplemental terms and conditions or documents that may be posted on the Site from time to
+          time are hereby expressly incorporated herein by reference. We reserve the right, in our
+          sole discretion, to make changes or modifications to these Terms of Use at any time and
+          for any reason. We will alert you about any changes by updating the &quot;Last
+          updated&quot; or &quot;Effective date&quot; of these Terms of Use. Your continued use of
+          the Site after any revised Terms of Use are posted constitutes your acceptance of those
+          changes.
+        </p>
+        <p>
+          The Site is intended for users who are at least 18 years old. Persons under the age of 18
+          are not permitted to use or register for the Site.
+        </p>
+      </section>
 
-      <div className="mt-8 space-y-6 text-base leading-relaxed text-opt-text">
-        <section>
-          <h2 className="m-0 text-lg font-semibold">Acceptance</h2>
-          <p className="mt-2 text-opt-muted">
-            By installing or using Guided Review, you agree to these terms. If you do not agree, do
-            not use the extension or this website.
-          </p>
-        </section>
+      <section>
+        <h2>2. Description of service</h2>
+        <p>
+          Guided Review is a browser extension and related website that helps users structure
+          reviews of GitHub pull requests. The Service may include, without limitation: injecting UI
+          into GitHub pull request pages; fetching pull request diffs; sending diff content to a
+          large language model provider that you configure; generating ordered review units and
+          commentary; displaying an overlay walkthrough; optionally authenticating with GitHub so
+          you can submit review comments; and related documentation on the Website.
+        </p>
+        <p>
+          The Service is designed so that API keys, optional GitHub tokens, and review session data
+          are stored in your browser. We do not operate a Guided Review backend that receives your
+          API keys or stores your pull request content for the core review workflow. Processing of
+          pull request content by your chosen LLM Provider is between you and that provider.
+        </p>
+        <p>
+          We reserve the right to modify, suspend, or discontinue the Service (or any part thereof)
+          at any time with or without notice. We shall not be liable to you or any third party for
+          any modification, suspension, or discontinuation of the Service.
+        </p>
+      </section>
 
-        <section>
-          <h2 className="m-0 text-lg font-semibold">Service description</h2>
-          <p className="mt-2 text-opt-muted">
-            Guided Review helps structure GitHub pull request reviews using third-party language
-            models you configure. The product is provided as-is without warranties of accuracy of
-            AI-generated review plans.
-          </p>
-        </section>
+      <section>
+        <h2>3. Intellectual property rights</h2>
+        <p>
+          Unless otherwise indicated, the Site (including branding, marketing copy, and non-source
+          materials we publish) is our proprietary property, and the trademarks, service marks, and
+          logos contained therein (the &quot;Marks&quot;) are owned or controlled by us or licensed
+          to us, and are protected under applicable intellectual property laws of India and
+          international conventions.
+        </p>
+        <p>
+          Site content and the Marks are provided &quot;AS IS&quot; for your information and
+          personal use only. Except as expressly provided in these Terms of Use, no part of the Site
+          and no Marks may be copied, reproduced, aggregated, republished, uploaded, posted,
+          publicly displayed, encoded, translated, transmitted, distributed, sold, licensed, or
+          otherwise exploited for any commercial purpose whatsoever, without our express prior
+          written permission.
+        </p>
+        <p>
+          Provided that you are eligible to use the Site, you are granted a limited, non-exclusive,
+          non-transferable license to access and use the Site and to install and use the Extension
+          solely for your personal or internal business use, subject to these Terms. We reserve all
+          rights not expressly granted to you.
+        </p>
+        <p>
+          Separately from these Terms, source code for Guided Review may be made available on public
+          repositories (for example on GitHub). Rights to use, modify, and redistribute that source
+          code are governed by the applicable open-source license (if any) and notices in the
+          repository, not solely by the limited Site license in this section. Trademarks and hosted
+          branding for guidedreview.com are not licensed merely because source code is available.
+        </p>
+      </section>
 
-        <section>
-          <h2 className="m-0 text-lg font-semibold">Your responsibilities</h2>
-          <p className="mt-2 text-opt-muted">
-            You are responsible for API keys you supply, compliance with GitHub and LLM provider
-            terms, and for any review comments you submit. Do not use the product for unlawful
-            purposes or to process data you are not authorized to share with your chosen providers.
-          </p>
-        </section>
+      <section>
+        <h2>4. User representations</h2>
+        <p>By using the Site or Extension, you represent and warrant that:</p>
+        <ol>
+          <li>
+            Any information you submit to us (for example support requests) will be true, accurate,
+            current, and complete.
+          </li>
+          <li>You have the legal capacity and agree to comply with these Terms of Use.</li>
+          <li>You are not a minor in the jurisdiction in which you reside.</li>
+          <li>
+            You will not access the Site through automated or non-human means, whether through a
+            bot, script, or otherwise, except as expressly permitted by the Service or for
+            legitimate open-source development and testing of the Extension itself.
+          </li>
+          <li>You will not use the Site or Extension for any illegal or unauthorized purpose.</li>
+          <li>
+            Your use of the Site and Extension will not violate any applicable law or regulation,
+            including GitHub&apos;s terms and the terms of any LLM Provider you use.
+          </li>
+          <li>
+            You are authorized to access the GitHub repositories and pull requests you process with
+            the Extension, and to send related content to your configured LLM Provider.
+          </li>
+        </ol>
+      </section>
 
-        <section>
-          <h2 className="m-0 text-lg font-semibold">Limitation of liability</h2>
-          <p className="mt-2 text-opt-muted">
-            To the fullest extent permitted by law, Guided Review and its contributors are not
-            liable for indirect, incidental, or consequential damages arising from use of the
-            extension, including reliance on AI-generated guidance.
-          </p>
-        </section>
+      <section>
+        <h2>5. Extension configuration and credentials</h2>
+        <p>
+          Certain features require you to supply credentials or configuration in the Extension, such
+          as an LLM Provider API key and optional GitHub authentication. You agree to:
+        </p>
+        <ol>
+          <li>Keep API keys, tokens, and other credentials confidential and secure.</li>
+          <li>
+            Use only credentials that you are authorized to use, and revoke or rotate them if
+            compromised.
+          </li>
+          <li>
+            Accept full responsibility for all use of the Extension under your browser profile and
+            credentials, including charges incurred with your LLM Provider.
+          </li>
+          <li>
+            Understand that we do not store your API keys on our servers as part of ordinary
+            Extension operation, and that loss of local browser data may result in loss of settings
+            or session progress.
+          </li>
+        </ol>
+      </section>
 
-        <section>
-          <h2 className="m-0 text-lg font-semibold">Changes</h2>
-          <p className="mt-2 text-opt-muted">
-            These terms may be updated from time to time. Continued use after changes constitutes
-            acceptance of the updated terms.
-          </p>
-        </section>
-      </div>
-    </article>
+      <section>
+        <h2>6. Third-party services (GitHub and LLM Providers)</h2>
+        <p>
+          The Service depends on third-party platforms. By using the Extension, you acknowledge
+          that:
+        </p>
+        <ol>
+          <li>
+            Pull request diffs and related context are fetched from GitHub and may be sent to the
+            LLM Provider you configure to generate review plans.
+          </li>
+          <li>
+            We do not claim ownership over your code, pull request content, or any intellectual
+            property contained therein.
+          </li>
+          <li>
+            You are solely responsible for ensuring that sharing repository or pull request content
+            with an LLM Provider does not violate employer policies, confidentiality agreements, or
+            third-party rights.
+          </li>
+          <li>
+            Optional GitHub device-flow authentication enables the Extension to act on your behalf
+            within the scopes granted; you may revoke access through GitHub or by clearing Extension
+            storage.
+          </li>
+          <li>
+            Availability, accuracy, pricing, data retention, and privacy practices of GitHub and LLM
+            Providers are governed solely by those third parties. We are not responsible for
+            outages, policy changes, model errors, or data handling by those services.
+          </li>
+        </ol>
+      </section>
+
+      <section>
+        <h2>7. AI-generated content disclaimer</h2>
+        <p>
+          Review plans, summaries, ordering, and other outputs generated with the assistance of LLM
+          Providers are probabilistic and may be incomplete, incorrect, or misleading. The Service
+          is a productivity aid for human reviewers; it does not replace professional judgment,
+          security review, or compliance review. You are solely responsible for any review comments
+          you submit and any decisions you make based on AI-generated guidance.
+        </p>
+      </section>
+
+      <section>
+        <h2>8. Fees and payment</h2>
+        <p>
+          The Service is currently offered without a fee charged by us. You remain responsible for
+          any costs charged by third parties you use with the Extension, including LLM Provider
+          usage fees and GitHub or browser-related costs. We reserve the right to introduce paid
+          features or tiers in the future; if we do, we will update these Terms and disclose
+          applicable pricing before charging you.
+        </p>
+      </section>
+
+      <section>
+        <h2>9. Prohibited activities</h2>
+        <p>
+          You may not access or use the Site for any purpose other than that for which we make the
+          Site available. As a user of the Site or Extension, you agree not to:
+        </p>
+        <ol>
+          <li>
+            Use the Service to access, process, or transmit code or pull request content for which
+            you do not have authorization.
+          </li>
+          <li>
+            Use the Service to exfiltrate secrets, credentials, or personal data you are not
+            authorized to process, or to bypass security or access controls.
+          </li>
+          <li>
+            Attempt to reverse engineer, decompile, disassemble, or otherwise derive proprietary
+            non-open portions of the Service solely to create a competing commercial product, except
+            to the extent such restriction is prohibited by applicable law or permitted by an
+            open-source license covering the relevant code.
+          </li>
+          <li>
+            Systematically retrieve data or other content from the Site to create or compile a
+            collection, compilation, database, or directory without written permission from us.
+          </li>
+          <li>
+            Make any unauthorized use of the Site, including collecting usernames or email addresses
+            by electronic or other means for the purpose of sending unsolicited email.
+          </li>
+          <li>
+            Circumvent, disable, or otherwise interfere with security-related features of the Site
+            or Extension.
+          </li>
+          <li>
+            Interfere with, disrupt, or create an undue burden on the Site or the networks or
+            services connected to the Site.
+          </li>
+          <li>
+            Attempt to impersonate another user or person, or misrepresent your affiliation with any
+            person or entity.
+          </li>
+          <li>
+            Use any information obtained from the Site to harass, abuse, or harm another person.
+          </li>
+          <li>
+            Upload or transmit viruses, Trojan horses, or other malicious material that interferes
+            with any party&apos;s use and enjoyment of the Site.
+          </li>
+          <li>
+            Use the Site in a manner inconsistent with any applicable laws or regulations, including
+            but not limited to the Information Technology Act, 2000 (India) and its rules and
+            amendments.
+          </li>
+        </ol>
+      </section>
+
+      <section>
+        <h2>10. User generated contributions</h2>
+        <p>
+          The Site may allow you to submit feedback, suggestions, bug reports, or other content
+          (collectively, &quot;Contributions&quot;). When you create or make available any
+          Contributions, you represent and warrant that your Contributions are not false,
+          inaccurate, or misleading, do not violate the intellectual property rights of any third
+          party, and comply with applicable law.
+        </p>
+        <p>
+          We have the right, in our sole and absolute discretion, to edit, redact, or otherwise
+          change any Contributions, or to remove any Contributions at any time and for any reason,
+          without notice.
+        </p>
+      </section>
+
+      <section>
+        <h2>11. Contribution license</h2>
+        <p>
+          By posting your Contributions to the Site or sending them to us, you grant us an
+          unrestricted, unlimited, irrevocable, perpetual, non-exclusive, transferable,
+          royalty-free, fully-paid, worldwide right and license to use, copy, reproduce, disclose,
+          distribute, and prepare derivative works of such Contributions for any purpose, commercial
+          or otherwise, including improving the Service.
+        </p>
+        <p>
+          You retain full ownership of all of your Contributions and any intellectual property
+          rights associated with your Contributions. We do not assert ownership over your code or
+          pull request content merely because you used the Extension.
+        </p>
+      </section>
+
+      <section>
+        <h2>12. Submissions</h2>
+        <p>
+          Any questions, comments, suggestions, ideas, feedback, or other information regarding the
+          Site (&quot;Submissions&quot;) provided by you to us are non-confidential and shall become
+          our sole property to the extent permitted by law. We shall own exclusive rights, including
+          all intellectual property rights, and shall be entitled to the unrestricted use and
+          dissemination of these Submissions for any lawful purpose, without acknowledgment or
+          compensation to you. This section does not transfer ownership of open-source contributions
+          you make under a separate license agreement or pull request to a public repository, which
+          remain governed by that repository&apos;s contribution terms and license.
+        </p>
+      </section>
+
+      <section>
+        <h2>13. Third-party websites and content</h2>
+        <p>
+          The Site and Extension may contain links to or integrate with third-party websites and
+          services, including GitHub, LLM Provider APIs, and the Chrome Web Store (&quot;Third-Party
+          Websites&quot;). Such Third-Party Websites are not investigated, monitored, or checked for
+          accuracy, appropriateness, or completeness by us. We are not responsible for any
+          Third-Party Websites accessed through the Site or Extension. Your use of Third-Party
+          Websites is governed solely by the terms and policies of those third parties.
+        </p>
+      </section>
+
+      <section>
+        <h2>14. Site management</h2>
+        <p>
+          We reserve the right to: (1) monitor the Site for violations of these Terms of Use; (2)
+          take appropriate legal action against anyone who, in our sole discretion, violates the law
+          or these Terms of Use; (3) refuse, restrict access to, limit the availability of, or
+          disable any of your Contributions or any portion thereof; and (4) otherwise manage the
+          Site in a manner designed to protect our rights and property and to facilitate the proper
+          functioning of the Site.
+        </p>
+      </section>
+
+      <section>
+        <h2>15. Privacy policy</h2>
+        <p>
+          We care about data privacy and security. Please review our Privacy Policy at{" "}
+          <a href="https://guidedreview.com/privacy">https://guidedreview.com/privacy</a>. By using
+          the Site, you agree to be bound by our Privacy Policy, which is incorporated into these
+          Terms of Use. The Site may be hosted on servers located outside India. If you access the
+          Site from any region with laws governing personal data collection, use, or disclosure that
+          differ from applicable Indian laws, you agree to your data being transferred to and
+          processed in such locations to the extent necessary to operate the Site.
+        </p>
+      </section>
+
+      <section>
+        <h2>16. Data protection and repository content</h2>
+        <p>
+          You acknowledge and agree that to the extent any personal data or proprietary code is
+          processed through the Service:
+        </p>
+        <ol>
+          <li>
+            You shall ensure you have the right to process and share such data or code with GitHub
+            and your configured LLM Provider, and that doing so does not violate any third-party
+            rights or confidentiality obligations.
+          </li>
+          <li>
+            We will handle Personal Information we control in accordance with our Privacy Policy and
+            applicable data protection laws, including the Digital Personal Data Protection Act,
+            2023 (India) as applicable.
+          </li>
+          <li>
+            You are solely responsible for ensuring that pull requests and repositories you process
+            do not cause unauthorized disclosure of secrets, personal data, or third-party
+            confidential information to LLM Providers.
+          </li>
+          <li>
+            If any government authority or court of competent jurisdiction requires us to disclose
+            data we hold, we shall have the right to do so in accordance with applicable law.
+          </li>
+        </ol>
+      </section>
+
+      <section>
+        <h2>17. Term and termination</h2>
+        <p>
+          These Terms of Use shall remain in full force and effect while you use the Site or
+          Extension. You may stop using the Service at any time by uninstalling the Extension and
+          discontinuing use of the Site. We reserve the right to, in our sole discretion and without
+          notice or liability, deny access to and use of the Site (including blocking certain IP
+          addresses) for any reason, including breach of these Terms of Use or any applicable law or
+          regulation.
+        </p>
+      </section>
+
+      <section>
+        <h2>18. Modifications and interruptions</h2>
+        <p>
+          We reserve the right to change, modify, or remove the contents of the Site at any time or
+          for any reason at our sole discretion without notice. We also reserve the right to modify
+          or discontinue all or part of the Site without notice at any time. We will not be liable
+          to you or any third party for any modification, suspension, or discontinuance of the Site.
+        </p>
+        <p>
+          We cannot guarantee the Site or Extension will be available at all times. GitHub, Chrome,
+          LLM Providers, or our hosting may experience problems resulting in interruptions, delays,
+          or errors. Nothing in these Terms of Use will be construed to obligate us to maintain and
+          support the Site or Extension or to supply any corrections, updates, or releases in
+          connection therewith.
+        </p>
+      </section>
+
+      <section>
+        <h2>19. Governing law</h2>
+        <p>
+          These Terms shall be governed by and construed in accordance with the laws of India.
+          Artery Ventures, LLP and you irrevocably consent that the courts of competent jurisdiction
+          in Mumbai, Maharashtra, India shall have exclusive jurisdiction to resolve any dispute
+          which may arise in connection with these Terms.
+        </p>
+      </section>
+
+      <section>
+        <h2>20. Dispute resolution</h2>
+        <p>
+          To expedite resolution and control the cost of any dispute, controversy, or claim related
+          to these Terms of Use (each a &quot;Dispute&quot;), the parties agree to first attempt to
+          negotiate any Dispute informally for at least thirty (30) days before initiating formal
+          legal proceedings. Such informal negotiations commence upon written notice from one party
+          to the other.
+        </p>
+        <p>
+          If informal negotiations fail to resolve a Dispute, the parties agree to submit to the
+          exclusive jurisdiction of the courts in Mumbai, Maharashtra, India. Notwithstanding the
+          foregoing, either party may seek injunctive or other equitable relief in any court of
+          competent jurisdiction to prevent the actual or threatened infringement of intellectual
+          property rights.
+        </p>
+      </section>
+
+      <section>
+        <h2>21. Disclaimer</h2>
+        <p>
+          THE SITE AND EXTENSION ARE PROVIDED ON AN AS-IS AND AS-AVAILABLE BASIS. YOU AGREE THAT
+          YOUR USE OF THE SITE AND OUR SERVICES WILL BE AT YOUR SOLE RISK. TO THE FULLEST EXTENT
+          PERMITTED BY LAW, WE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED, IN CONNECTION WITH THE
+          SITE AND YOUR USE THEREOF, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
+          MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. WE MAKE NO
+          WARRANTIES OR REPRESENTATIONS ABOUT THE ACCURACY OR COMPLETENESS OF THE SITE&apos;S
+          CONTENT OR THE ACCURACY OF ANY REVIEW PLAN, SUMMARY, ORDERING, COMMENTARY, OR OTHER OUTPUT
+          GENERATED WITH THE ASSISTANCE OF LLM PROVIDERS.
+        </p>
+      </section>
+
+      <section>
+        <h2>22. Limitations of liability</h2>
+        <p>
+          IN NO EVENT WILL WE OR OUR DIRECTORS, EMPLOYEES, OR AGENTS BE LIABLE TO YOU OR ANY THIRD
+          PARTY FOR ANY DIRECT, INDIRECT, CONSEQUENTIAL, EXEMPLARY, INCIDENTAL, SPECIAL, OR PUNITIVE
+          DAMAGES, INCLUDING LOST PROFIT, LOST REVENUE, LOSS OF DATA, OR OTHER DAMAGES ARISING FROM
+          YOUR USE OF THE SITE OR THE SERVICE, EVEN IF WE HAVE BEEN ADVISED OF THE POSSIBILITY OF
+          SUCH DAMAGES. NOTWITHSTANDING ANYTHING TO THE CONTRARY CONTAINED HEREIN, OUR LIABILITY TO
+          YOU FOR ANY CAUSE WHATSOEVER WILL AT ALL TIMES BE LIMITED TO THE GREATER OF (A) THE AMOUNT
+          PAID, IF ANY, BY YOU TO US IN THE THREE (3) MONTHS PRECEDING THE EVENT GIVING RISE TO THE
+          CLAIM, OR (B) ONE HUNDRED U.S. DOLLARS (USD $100), TO THE EXTENT SUCH LIMITATION IS
+          PERMITTED BY LAW.
+        </p>
+        <p>
+          WE ARE NOT LIABLE FOR ANY LOSS OR DAMAGE ARISING FROM UNAUTHORIZED ACCESS TO YOUR BROWSER
+          PROFILE, API KEYS, OR GITHUB ACCOUNT; FROM YOUR DISCLOSURE OF CODE OR SECRETS TO LLM
+          PROVIDERS; FROM INACCURACIES IN AI-GENERATED REVIEW GUIDANCE; OR FROM OUTAGES OR ACTIONS
+          OF THIRD-PARTY SERVICES CONNECTED TO THE SITE OR EXTENSION.
+        </p>
+      </section>
+
+      <section>
+        <h2>23. Indemnification</h2>
+        <p>
+          You agree to defend, indemnify, and hold us harmless, including our subsidiaries,
+          affiliates, officers, agents, partners, and employees, from and against any loss, damage,
+          liability, claim, or demand, including reasonable attorneys&apos; fees and expenses, made
+          by any third party due to or arising out of: (1) your Contributions; (2) use of the Site
+          or Extension; (3) breach of these Terms of Use; (4) any breach of your representations and
+          warranties set forth in these Terms of Use; (5) your violation of the rights of a third
+          party, including intellectual property rights; or (6) your unauthorized sharing of
+          third-party code, secrets, or personal data through the Service or with LLM Providers.
+        </p>
+      </section>
+
+      <section>
+        <h2>24. Electronic communications, transactions, and signatures</h2>
+        <p>
+          Visiting the Site, sending us emails, and completing online forms constitute electronic
+          communications. You consent to receive electronic communications, and you agree that all
+          agreements, notices, disclosures, and other communications we provide to you
+          electronically, via email and on the Site, satisfy any legal requirement that such
+          communication be in writing, to the extent permitted by applicable law.
+        </p>
+      </section>
+
+      <section>
+        <h2>25. Corrections</h2>
+        <p>
+          There may be information on the Site that contains typographical errors, inaccuracies, or
+          omissions, including descriptions, availability, and various other information. We reserve
+          the right to correct any errors, inaccuracies, or omissions and to change or update the
+          information on the Site at any time, without prior notice.
+        </p>
+      </section>
+
+      <section>
+        <h2>26. Miscellaneous</h2>
+        <p>
+          These Terms of Use and any policies or operating rules posted by us on the Site constitute
+          the entire agreement and understanding between you and us. Our failure to exercise or
+          enforce any right or provision of these Terms of Use shall not operate as a waiver of such
+          right or provision. If any provision or part of a provision of these Terms of Use is
+          determined to be unlawful, void, or unenforceable, that provision or part of the provision
+          is deemed severable from these Terms of Use and does not affect the validity and
+          enforceability of any remaining provisions. There is no joint venture, partnership,
+          employment, or agency relationship created between you and us as a result of these Terms
+          of Use or use of the Site.
+        </p>
+      </section>
+
+      <section>
+        <h2>27. Contact us</h2>
+        <p>
+          To resolve a complaint regarding the Site or to receive further information regarding use
+          of the Site, please contact us at:
+        </p>
+        <LegalContactBlock />
+      </section>
+    </LegalDocument>
   );
 }

--- a/apps/web/components/Footer.tsx
+++ b/apps/web/components/Footer.tsx
@@ -1,53 +1,26 @@
+"use client";
+
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { GITHUB_REPO_URL } from "../lib/links";
+import { Why } from "./Why";
 
 export function Footer() {
+  const pathname = usePathname();
+  const showWhy = pathname === "/";
+
   return (
     <footer className="mt-16 border-t border-gr-border bg-gr-bg">
       <div className="mx-auto max-w-5xl px-6 py-12">
-        <h2 className="m-0 text-center text-2xl font-bold tracking-tight font-brand bg-[linear-gradient(90deg,var(--color-gr-accent),color-mix(in_srgb,var(--color-gr-accent)_55%,var(--color-gr-text)))] bg-clip-text text-transparent sm:text-3xl">
-          Why?
-        </h2>
-        <h3 className="m-0 mt-3 text-center text-xl font-bold tracking-tight text-gr-text font-brand sm:text-2xl">
-          Code review is hard,
-          <br />
-          and it&apos;s only getting harder
-        </h3>
+        {showWhy ? <Why /> : null}
 
-        <div className="mt-8 grid gap-8 text-base leading-relaxed text-gr-muted sm:grid-cols-2 sm:gap-10 sm:text-lg">
-          <div className="space-y-4">
-            <p>
-              AI agents are writing code for you, and you have PRs pending your review. You had
-              imagined when you installed the new hot code review agent on github, it is going to
-              make the job easy for you. You&apos;ll just click &quot;approve&quot; and move on to
-              the next PR.
-            </p>
-            <p>
-              Unfortunately, agents writing code, and agents reviewing code are not a replacement
-              for you (congrats, your job is safe). You have more context. You know people,
-              business, and the product better than your coding agent.
-            </p>
-            <p>
-              End of the day, you are still going to have to read the code. You are still going to
-              have to understand it, and then you have the final say.
-            </p>
-            <p>But... it&apos;s just too much code, and it&apos;s hard to review code.</p>
-          </div>
-          <div className="space-y-4">
-            <p>What if, we used AI to help us review code and not review it for us?</p>
-            <p>
-              That&apos;s why I built Guided Review. It gives you a brand new experience to review
-              pull requests. An experience that&apos;s designed for humans, and uses AI in just the
-              right places (not too little, not too much).
-            </p>
-            <p>
-              Reading your code is more important than ever, now that you cannot trust the LLM loops
-              creating the PR.
-            </p>
-          </div>
-        </div>
-
-        <div className="mt-12 flex flex-wrap items-center justify-between gap-3 border-t border-gr-border pt-8 text-sm text-gr-muted">
+        <div
+          className={
+            showWhy
+              ? "mt-12 flex flex-wrap items-center justify-between gap-3 border-t border-gr-border pt-8 text-sm text-gr-muted"
+              : "flex flex-wrap items-center justify-between gap-3 text-sm text-gr-muted"
+          }
+        >
           <p className="m-0">© {new Date().getFullYear()} Guided Review</p>
           <div className="flex gap-4">
             <a
@@ -63,6 +36,9 @@ export function Footer() {
             </Link>
             <Link href="/terms" className="transition-colors hover:text-gr-text">
               Terms
+            </Link>
+            <Link href="/cookies" className="transition-colors hover:text-gr-text">
+              Cookies
             </Link>
           </div>
         </div>

--- a/apps/web/components/LegalDocument.tsx
+++ b/apps/web/components/LegalDocument.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from "react";
+
+type LegalDocumentProps = {
+  title: string;
+  /** Subtitle line under the title (effective date, entity, contact). */
+  meta: ReactNode;
+  children: ReactNode;
+};
+
+/**
+ * Shared shell for Privacy / Terms / Cookies pages.
+ * Keeps long formal legal copy readable within the marketing site tokens.
+ */
+export function LegalDocument({ title, meta, children }: LegalDocumentProps) {
+  return (
+    <article className="mx-auto max-w-3xl px-6 py-16">
+      <h1 className="m-0 text-3xl font-bold tracking-tight">{title}</h1>
+      <p className="mt-2 text-sm text-opt-muted">{meta}</p>
+      <div className="legal-content mt-8 space-y-8 text-base leading-relaxed text-opt-text [&_a]:underline [&_a]:decoration-opt-border [&_a]:underline-offset-2 hover:[&_a]:decoration-opt-accent [&_h2]:m-0 [&_h2]:text-lg [&_h2]:font-semibold [&_h2]:tracking-tight [&_h3]:m-0 [&_h3]:mt-4 [&_h3]:text-base [&_h3]:font-semibold [&_p]:m-0 [&_p]:mt-3 [&_p]:text-opt-muted [&_ul]:m-0 [&_ul]:mt-3 [&_ul]:list-disc [&_ul]:space-y-2 [&_ul]:pl-5 [&_ul]:text-opt-muted [&_ol]:m-0 [&_ol]:mt-3 [&_ol]:list-decimal [&_ol]:space-y-2 [&_ol]:pl-5 [&_ol]:text-opt-muted [&_li]:leading-relaxed [&_strong]:font-semibold [&_strong]:text-opt-text [&_code]:rounded [&_code]:bg-opt-chrome [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[0.9em] [&_code]:text-opt-text">
+        {children}
+      </div>
+    </article>
+  );
+}
+
+export function LegalContactBlock() {
+  return (
+    <div className="mt-4 rounded-lg border border-opt-border bg-opt-chrome/40 px-4 py-4 text-sm leading-relaxed text-opt-muted">
+      <strong className="text-opt-text">Artery Ventures, LLP</strong>
+      <br />
+      FO-02, 4th Floor, 28/A, 80 Feet Rd
+      <br />
+      Indiranagar, Bengaluru, Karnataka 560038
+      <br />
+      India
+      <br />
+      <br />
+      Email: <a href="mailto:support@guidedreview.com">support@guidedreview.com</a>
+      <br />
+      Website: <a href="https://guidedreview.com">https://guidedreview.com</a>
+    </div>
+  );
+}

--- a/apps/web/components/Why.tsx
+++ b/apps/web/components/Why.tsx
@@ -1,0 +1,47 @@
+export function Why() {
+  return (
+    <>
+      <h2 className="m-0 text-center text-2xl font-bold tracking-tight font-brand bg-[linear-gradient(90deg,var(--color-gr-accent),color-mix(in_srgb,var(--color-gr-accent)_55%,var(--color-gr-text)))] bg-clip-text text-transparent sm:text-3xl">
+        Why?
+      </h2>
+      <h3 className="m-0 mt-3 text-center text-xl font-bold tracking-tight text-gr-text font-brand sm:text-2xl">
+        Code review is hard,
+        <br />
+        and it&apos;s only getting harder
+      </h3>
+
+      <div className="mt-8 grid gap-8 text-base leading-relaxed text-gr-muted sm:grid-cols-2 sm:gap-10 sm:text-lg">
+        <div className="space-y-4">
+          <p>
+            AI agents are writing code for you, and you have PRs pending your review. You had
+            imagined when you installed the new hot code review agent on github, it is going to make
+            the job easy for you. You&apos;ll just click &quot;approve&quot; and move on to the next
+            PR.
+          </p>
+          <p>
+            Unfortunately, agents writing code, and agents reviewing code are not a replacement for
+            you (congrats, your job is safe). You have more context. You know people, business, and
+            the product better than your coding agent.
+          </p>
+          <p>
+            End of the day, you are still going to have to read the code. You are still going to
+            have to understand it, and then you have the final say.
+          </p>
+          <p>But... it&apos;s just too much code, and it&apos;s hard to review code.</p>
+        </div>
+        <div className="space-y-4">
+          <p>What if, we used AI to help us review code and not review it for us?</p>
+          <p>
+            That&apos;s why I built Guided Review. It gives you a brand new experience to review
+            pull requests. An experience that&apos;s designed for humans, and uses AI in just the
+            right places (not too little, not too much).
+          </p>
+          <p>
+            Reading your code is more important than ever, now that you cannot trust the LLM loops
+            creating the PR.
+          </p>
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

- Expand Privacy Policy and Terms of Service with full formal legal copy for Artery Ventures, LLP.
- Add a Cookies Policy page at `/cookies`.
- Introduce a shared `LegalDocument` shell (title, meta line, typography) for consistent legal pages.
- Extract the homepage “Why?” section into `Why` and only render it on `/`; keep footer legal links (Privacy, Terms, Cookies) on all pages.

## Test plan

- [ ] `npm run build:web` succeeds
- [ ] Visit `/privacy`, `/terms`, and `/cookies` — layout, headings, and contact block look correct
- [ ] Footer on homepage still shows “Why?” plus legal links
- [ ] Footer on legal pages shows only copyright + legal links (no “Why?”)
- [ ] Cookie / Privacy / Terms cross-links resolve correctly