### PR TITLE
fix: strip GitHub token from auth messages and escape highlight fallback

### DIFF
--- a/apps/extension/src/background/index.test.ts
+++ b/apps/extension/src/background/index.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import type { GitHubAuthState } from "../lib/types";
+import { setGitHubAuth } from "../lib/github/authStorage";
+
+// background/index.ts registers chrome.runtime listeners as an import-time
+// side effect, so it must be imported lazily (after the global chromeMock
+// beforeEach in src/test/setup.ts has installed `chrome`) rather than at
+// module top-level, which would run before that hook fires.
+async function loadHandleGitHubAuthGet() {
+  const { handleGitHubAuthGet } = await import("./index");
+  return handleGitHubAuthGet;
+}
+
+describe("handleGitHubAuthGet", () => {
+  it("never returns the access token or token type to the caller", async () => {
+    const auth: GitHubAuthState = {
+      accessToken: "gho_supersecret",
+      tokenType: "bearer",
+      scope: "repo read:user",
+      login: "octocat",
+      avatarUrl: "https://example.com/a.png",
+      name: "The Octocat",
+    };
+    await setGitHubAuth(auth);
+
+    const handleGitHubAuthGet = await loadHandleGitHubAuthGet();
+    const response = await handleGitHubAuthGet();
+
+    expect(response).toEqual({
+      ok: true,
+      auth: {
+        scope: "repo read:user",
+        login: "octocat",
+        avatarUrl: "https://example.com/a.png",
+        name: "The Octocat",
+      },
+    });
+    expect(response.auth).not.toHaveProperty("accessToken");
+    expect(response.auth).not.toHaveProperty("tokenType");
+    expect(JSON.stringify(response)).not.toContain("gho_supersecret");
+  });
+
+  it("returns auth: null when signed out, without throwing", async () => {
+    const handleGitHubAuthGet = await loadHandleGitHubAuthGet();
+    await expect(handleGitHubAuthGet()).resolves.toEqual({ ok: true, auth: null });
+  });
+});

--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -347,7 +347,12 @@ async function handleGitHubDevicePoll(
 
 async function handleGitHubAuthGet(): Promise<GitHubAuthGetResponse> {
   const auth = await getGitHubAuth();
-  return { ok: true, auth };
+  if (!auth) return { ok: true, auth: null };
+  // Strip the access token before it leaves the background worker — neither
+  // the options page nor the content script needs it; SUBMIT_REVIEW reads it
+  // from storage directly, background-side.
+  const { accessToken: _accessToken, tokenType: _tokenType, ...publicAuth } = auth;
+  return { ok: true, auth: publicAuth };
 }
 
 async function handleGitHubAuthClear(): Promise<GitHubAuthClearResponse> {

--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -345,7 +345,7 @@ async function handleGitHubDevicePoll(
   }
 }
 
-async function handleGitHubAuthGet(): Promise<GitHubAuthGetResponse> {
+export async function handleGitHubAuthGet(): Promise<GitHubAuthGetResponse> {
   const auth = await getGitHubAuth();
   if (!auth) return { ok: true, auth: null };
   // Strip the access token before it leaves the background worker — neither

--- a/apps/extension/src/lib/github/oauthConfig.ts
+++ b/apps/extension/src/lib/github/oauthConfig.ts
@@ -7,7 +7,17 @@
 export const GITHUB_OAUTH_CLIENT_ID: string =
   (import.meta.env.VITE_GITHUB_CLIENT_ID as string | undefined)?.trim() ?? "";
 
-/** Classic OAuth scopes: private/public repo access + profile for connected UI. */
+/**
+ * Classic OAuth scopes: private/public repo access + profile for connected UI.
+ *
+ * `repo` is intentionally broad (read/write on all of the user's repos,
+ * public and private) because the extension supports submitting reviews on
+ * private org PRs (see submitReview.ts's SSO-authorization hint) — classic
+ * OAuth has no finer-grained scope for "review PRs on private repos only".
+ * If that's ever narrowed, migrate to a GitHub App with fine-grained,
+ * per-repo `pull_requests: write` permissions instead of downgrading to
+ * `public_repo` (which would silently break private-repo review).
+ */
 export const GITHUB_OAUTH_SCOPES = "repo read:user";
 
 export function isGitHubOAuthConfigured(): boolean {

--- a/apps/extension/src/lib/highlight.test.ts
+++ b/apps/extension/src/lib/highlight.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import hljs from "highlight.js/lib/core";
+import { highlightToLines } from "./highlight";
+
+describe("highlightToLines", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("HTML-escapes code when hljs.highlight throws, instead of returning it raw", () => {
+    // Diff content is attacker-controlled (any PR author writes it), and every
+    // returned line is rendered via dangerouslySetInnerHTML in hunkHighlight.tsx
+    // — a highlight failure must never fall back to unescaped HTML.
+    vi.spyOn(hljs, "highlight").mockImplementation(() => {
+      throw new Error("simulated highlight.js failure");
+    });
+
+    const malicious = "<img src=x onerror=alert(document.cookie)>";
+    const lines = highlightToLines(malicious, "javascript");
+
+    expect(lines).toEqual(["&lt;img src=x onerror=alert(document.cookie)&gt;"]);
+    expect(lines[0]).not.toContain("<img");
+  });
+
+  it("escapes each line independently and preserves line count on fallback", () => {
+    vi.spyOn(hljs, "highlight").mockImplementation(() => {
+      throw new Error("simulated highlight.js failure");
+    });
+
+    const lines = highlightToLines("<b>one</b>\n<i>two</i> & three", "javascript");
+
+    expect(lines).toEqual(["&lt;b&gt;one&lt;/b&gt;", "&lt;i&gt;two&lt;/i&gt; &amp; three"]);
+  });
+
+  it("still returns real highlight.js markup on the non-throwing path", () => {
+    const lines = highlightToLines("const x = 1;", "javascript");
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("<span");
+    expect(lines[0]).not.toContain("&lt;span");
+  });
+});

--- a/apps/extension/src/lib/highlight.ts
+++ b/apps/extension/src/lib/highlight.ts
@@ -131,6 +131,10 @@ export function languageForPath(path: string): string | undefined {
   return lang;
 }
 
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
 /**
  * Highlight `code` as `language` and split the result into one HTML string
  * per source line, re-opening any `<span>` tags that were left open across a
@@ -142,7 +146,10 @@ export function highlightToLines(code: string, language: string): string[] {
   try {
     highlighted = hljs.highlight(code, { language, ignoreIllegals: true }).value;
   } catch {
-    return code.split("\n");
+    // Diff content is attacker-controlled (any PR author writes it), and the
+    // caller renders every returned line via dangerouslySetInnerHTML — escape
+    // this fallback so a highlight failure can't become an HTML injection.
+    return code.split("\n").map(escapeHtml);
   }
 
   const rawLines = highlighted.split("\n");

--- a/apps/extension/src/lib/types.ts
+++ b/apps/extension/src/lib/types.ts
@@ -106,6 +106,15 @@ export interface GitHubAuthState {
   name?: string;
 }
 
+/**
+ * `GitHubAuthState` without the access token. `GITHUB_AUTH_GET` is answered
+ * from the background worker for both the options page and the content
+ * script — neither needs the raw token (submission goes through
+ * `SUBMIT_REVIEW`, which reads it from storage background-side), so it's
+ * never sent across that boundary.
+ */
+export type GitHubPublicAuthState = Omit<GitHubAuthState, "accessToken" | "tokenType">;
+
 // ---- Messaging protocol (content <-> background) -----------------------------
 
 /** First message on the `annotate-review` port from content → background. */
@@ -196,7 +205,7 @@ export interface GitHubAuthGetRequest {
 
 export interface GitHubAuthGetResponse {
   ok: true;
-  auth: GitHubAuthState | null;
+  auth: GitHubPublicAuthState | null;
 }
 
 export interface GitHubAuthClearRequest {

--- a/apps/extension/src/options/GitHubAuthSection.tsx
+++ b/apps/extension/src/options/GitHubAuthSection.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import type { GitHubAuthState } from "../lib/types";
+import type { GitHubPublicAuthState } from "../lib/types";
 import { isGitHubOAuthConfigured } from "../lib/github/oauthConfig";
 import { openVerificationUri, useGitHubDeviceAuth } from "../lib/github/useGitHubDeviceAuth";
 import { clearGitHubAuthSession, getGitHubAuthStatus } from "../lib/messaging";
@@ -7,7 +7,9 @@ import { confirm, ConfirmationHost } from "../content/overlay/components/confirm
 import { Button, Spinner, cn } from "@guided-review/ui";
 
 type SessionState =
-  { kind: "loading" } | { kind: "disconnected" } | { kind: "connected"; auth: GitHubAuthState };
+  | { kind: "loading" }
+  | { kind: "disconnected" }
+  | { kind: "connected"; auth: GitHubPublicAuthState };
 
 /**
  * Options section: GitHub device OAuth connect / disconnect.


### PR DESCRIPTION
## Summary
- Stop returning the GitHub access token (and token type) from `GITHUB_AUTH_GET` — options/content only get public profile fields; submit-review still reads the token from storage in the background.
- HTML-escape the highlight.js failure fallback so attacker-controlled diff content cannot be injected via `dangerouslySetInnerHTML`.
- Document why the OAuth scope stays at `repo read:user` (private-repo review needs it; finer scope would need a GitHub App).
- Add unit tests for both security paths so they do not regress.

## Test plan
- [ ] Run `npm test` (background auth strip + highlight fallback cases)
- [ ] Connect GitHub in options and confirm UI still shows login/avatar/name with no token in the response
- [ ] Submit a review on a public PR still works (token read background-side)
- [ ] Open a PR with code that would stress highlight.js; confirm no raw HTML renders on failure path