### PR TITLE
fix: kbd readability, border tokens, and marketing link styles

### DIFF
--- a/apps/extension/src/content/overlay/components/FooterNav.tsx
+++ b/apps/extension/src/content/overlay/components/FooterNav.tsx
@@ -20,11 +20,7 @@ export function FooterNav({ currentIndex, total, onPrev, onNext }: FooterNavProp
     >
       <button
         type="button"
-        className={cn(
-          navBtnBase,
-          "border-gr-border bg-gr-bg text-gr-text",
-          "[&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit",
-        )}
+        className={cn(navBtnBase, "border-gr-border bg-gr-bg text-gr-text")}
         onClick={onPrev}
         disabled={currentIndex === 0 || total === 0}
         aria-label="Previous step"
@@ -49,7 +45,7 @@ export function FooterNav({ currentIndex, total, onPrev, onNext }: FooterNavProp
           navBtnBase,
           "border-gr-accent bg-gr-accent text-gr-accent-on transition-colors",
           "not-disabled:hover:border-gr-accent-hover not-disabled:hover:bg-gr-accent-hover",
-          "[&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit",
+          "[&_[data-slot=kbd]]:bg-[rgba(13,8,6,0.12)] [&_[data-slot=kbd]]:text-inherit",
         )}
         onClick={onNext}
         disabled={total === 0 || currentIndex >= total - 1}

--- a/apps/extension/src/content/overlay/components/KeyboardShortcuts.tsx
+++ b/apps/extension/src/content/overlay/components/KeyboardShortcuts.tsx
@@ -1,3 +1,4 @@
+import { Kbd, KbdGroup } from "@guided-review/ui";
 import { ShortcutKeys, type ShortcutJoin } from "./ShortcutKeys";
 
 /**
@@ -43,13 +44,15 @@ function ShortcutRowKeys({ row }: { row: ShortcutRow }) {
   if ("chordWithAlternatives" in row) {
     const { modifier, alternatives } = row.chordWithAlternatives;
     return (
-      <span className="inline-flex items-center gap-1">
-        <ShortcutKeys keys={[modifier]} join="none" />
+      <KbdGroup>
+        <Kbd>{modifier}</Kbd>
         <span className="text-xs opacity-70" aria-hidden="true">
           +
         </span>
-        <ShortcutKeys keys={alternatives} join="none" />
-      </span>
+        {alternatives.map((key) => (
+          <Kbd key={key}>{key}</Kbd>
+        ))}
+      </KbdGroup>
     );
   }
   return <ShortcutKeys keys={row.keys} join={row.join} />;

--- a/apps/extension/src/content/overlay/components/ProgressHeader.tsx
+++ b/apps/extension/src/content/overlay/components/ProgressHeader.tsx
@@ -72,7 +72,7 @@ export function ProgressHeader({
         <div className="flex shrink-0 items-center gap-3">
           <button
             type="button"
-            className={`${headerBtn} border-gr-accent bg-gr-accent text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover [&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit`}
+            className={`${headerBtn} border-gr-accent bg-gr-accent text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover [&_[data-slot=kbd]]:bg-[rgba(13,8,6,0.12)] [&_[data-slot=kbd]]:text-inherit`}
             onClick={onSubmitReview}
             data-testid="submit-review-button"
           >

--- a/apps/extension/src/content/overlay/components/ShortcutKeys.tsx
+++ b/apps/extension/src/content/overlay/components/ShortcutKeys.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from "react";
+import { Kbd, KbdGroup } from "@guided-review/ui";
 import { modKeyLabel } from "../platform";
-import { Kbd } from "@guided-review/ui";
 
 /**
  * Token for a key badge. Pass `"mod"` for the OS-aware primary modifier
@@ -33,7 +33,7 @@ export function ShortcutKeys({ keys, join = "none", className }: ShortcutKeysPro
   const showPlus = join === "chord";
 
   return (
-    <span className={className ?? "inline-flex items-center gap-1"}>
+    <KbdGroup className={className}>
       {keys.map((key, i) => (
         <Fragment key={`${key}-${i}`}>
           {showPlus && i > 0 ? (
@@ -44,7 +44,7 @@ export function ShortcutKeys({ keys, join = "none", className }: ShortcutKeysPro
           <Kbd>{resolveKey(key)}</Kbd>
         </Fragment>
       ))}
-    </span>
+    </KbdGroup>
   );
 }
 

--- a/apps/extension/src/content/overlay/components/SubmitReviewModal.tsx
+++ b/apps/extension/src/content/overlay/components/SubmitReviewModal.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 import type { ReviewEvent, ReviewSubmission } from "../commentTypes";
 import { CloseButton } from "./CloseButton";
-import { Button, Kbd, Textarea } from "@guided-review/ui";
+import { Button, Kbd, KbdGroup, Textarea } from "@guided-review/ui";
 import { ModalShell } from "./ModalShell";
 import { ModEnterChord } from "./ShortcutKeys";
 
@@ -283,8 +283,10 @@ export function SubmitReviewModal({
               })}
             </div>
             <div className="flex items-center gap-2 text-sm text-gr-faint">
-              <Kbd>↑</Kbd>
-              <Kbd>↓</Kbd>
+              <KbdGroup>
+                <Kbd>↑</Kbd>
+                <Kbd>↓</Kbd>
+              </KbdGroup>
               <span>to choose</span>
               <span className="opacity-50">·</span>
               <Kbd>Enter</Kbd>

--- a/apps/extension/src/content/overlay/useOverlayKeyboard.ts
+++ b/apps/extension/src/content/overlay/useOverlayKeyboard.ts
@@ -1,4 +1,4 @@
-import { useEffect, type MutableRefObject, type RefObject } from "react";
+import { useEffect, useRef, type MutableRefObject, type RefObject } from "react";
 import { confirmationHandlesKey, getConfirmationDialogElement } from "./components/confirmation";
 import type { SelectableLine } from "./commentTypes";
 import { trapTabKey } from "./focusTrap";
@@ -73,7 +73,8 @@ export function useOverlayKeyboard({
   currentUnitId,
   submitReviewOpen,
   connectGitHubOpen,
-  submittingReview,
+  // Kept in the options API for callers; close guards live in useSubmitReviewFlow.
+  submittingReview: _submittingReview,
   submitSuccess,
   submitReviewActionRef,
   submitReviewKeyRef,
@@ -85,6 +86,27 @@ export function useOverlayKeyboard({
   confirmationOpen,
   requestExit,
 }: UseOverlayKeyboardOptions): void {
+  // Mirror modal flags into refs on every render so the capture listener never
+  // sees a stale open state between React commit (modal paints) and this
+  // effect re-running. Without this, Esc right after open can fall through to
+  // requestExit while the modal is already visible.
+  const submitReviewOpenRef = useRef(submitReviewOpen);
+  submitReviewOpenRef.current = submitReviewOpen;
+  const connectGitHubOpenRef = useRef(connectGitHubOpen);
+  connectGitHubOpenRef.current = connectGitHubOpen;
+  const submitSuccessRef = useRef(submitSuccess);
+  submitSuccessRef.current = submitSuccess;
+  const exitAfterSubmitRef = useRef(exitAfterSubmit);
+  exitAfterSubmitRef.current = exitAfterSubmit;
+  const closeSubmitReviewModalRef = useRef(closeSubmitReviewModal);
+  closeSubmitReviewModalRef.current = closeSubmitReviewModal;
+  const setConnectGitHubOpenRef = useRef(setConnectGitHubOpen);
+  setConnectGitHubOpenRef.current = setConnectGitHubOpen;
+  const requestOpenSubmitReviewRef = useRef(requestOpenSubmitReview);
+  requestOpenSubmitReviewRef.current = requestOpenSubmitReview;
+  const requestExitRef = useRef(requestExit);
+  requestExitRef.current = requestExit;
+
   useEffect(() => {
     if (!isOpen) return;
 
@@ -103,7 +125,7 @@ export function useOverlayKeyboard({
       const confirmDialog = getConfirmationDialogElement();
       const trapRoot = confirmDialog
         ? confirmDialog
-        : submitReviewOpen
+        : submitReviewOpenRef.current
           ? submitModalDialogRef.current
           : overlayRef.current;
       if (trapRoot) trapTabKey(event, trapRoot);
@@ -124,27 +146,27 @@ export function useOverlayKeyboard({
       }
 
       // Success modal: Enter / Esc exit the review (single CTA dialog).
-      if (submitSuccess) {
+      if (submitSuccessRef.current) {
         viewChordRef.current = null;
         if (event.key === "Enter" && !event.metaKey && !event.ctrlKey && !event.altKey) {
           event.preventDefault();
-          exitAfterSubmit();
+          exitAfterSubmitRef.current();
           return true;
         }
         if (event.key === "Escape") {
           event.preventDefault();
-          exitAfterSubmit();
+          exitAfterSubmitRef.current();
           return true;
         }
         return true;
       }
 
       // Connect GitHub modal: Esc closes; Enter runs Connect / Try again / open GitHub.
-      if (connectGitHubOpen) {
+      if (connectGitHubOpenRef.current) {
         viewChordRef.current = null;
         if (event.key === "Escape") {
           event.preventDefault();
-          setConnectGitHubOpen(false);
+          setConnectGitHubOpenRef.current(false);
           return true;
         }
         if (event.key === "Enter" && !event.metaKey && !event.ctrlKey && !event.altKey) {
@@ -157,11 +179,11 @@ export function useOverlayKeyboard({
       // Submit-review modal: Esc closes the dialog only (not the whole overlay).
       // ⌘/Ctrl+Enter submits on the compose step; ↑/↓/Enter drive the choose step.
       // Handled here because capture stopPropagation blocks element React handlers.
-      if (submitReviewOpen) {
+      if (submitReviewOpenRef.current) {
         viewChordRef.current = null;
         if (event.key === "Escape") {
           event.preventDefault();
-          closeSubmitReviewModal();
+          closeSubmitReviewModalRef.current();
           return true;
         }
         if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
@@ -263,7 +285,7 @@ export function useOverlayKeyboard({
         case "Escape":
           event.preventDefault();
           viewChordRef.current = null;
-          requestExit();
+          requestExitRef.current();
           return;
         case "ArrowRight":
           event.preventDefault();
@@ -325,7 +347,7 @@ export function useOverlayKeyboard({
       if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
         event.preventDefault();
         viewChordRef.current = null;
-        void requestOpenSubmitReview();
+        void requestOpenSubmitReviewRef.current();
         return;
       }
 
@@ -345,15 +367,10 @@ export function useOverlayKeyboard({
     isOpen,
     selectableForUnit,
     currentUnitId,
-    submitReviewOpen,
-    connectGitHubOpen,
-    submittingReview,
-    submitSuccess,
-    exitAfterSubmit,
-    requestOpenSubmitReview,
-    closeSubmitReviewModal,
+    // Modal open flags / callbacks are read from refs (updated each render) so
+    // the listener is current as soon as state commits — not only after effect.
+    // confirmationOpen forces a rebind when the confirm dialog mounts (Tab trap).
     confirmationOpen,
-    requestExit,
     overlayRef,
     submitModalDialogRef,
     codeColRef,
@@ -361,6 +378,5 @@ export function useOverlayKeyboard({
     submitReviewActionRef,
     submitReviewKeyRef,
     connectGitHubActionRef,
-    setConnectGitHubOpen,
   ]);
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -40,7 +40,19 @@ body::before {
 
 @layer base {
   a {
-    color: inherit;
+    color: var(--opt-accent, #caff57);
+    text-decoration: none;
+  }
+
+  /* Text links: brand color + bottom border on hover.
+     Button-styled anchors use `inline-flex` via buttonClassName and keep their own chrome. */
+  a:not(.inline-flex) {
+    border-bottom: 1px solid transparent;
+    transition: border-color 0.15s ease;
+  }
+
+  a:not(.inline-flex):hover {
+    border-bottom-color: currentColor;
   }
 }
 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -44,7 +44,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <div className="mx-auto flex max-w-5xl items-center justify-between gap-4 px-6 py-3.5">
             <Link
               href="/"
-              className="rounded-sm no-underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gr-accent"
+              className="rounded-sm border-b-0 no-underline hover:border-b-transparent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gr-accent"
               aria-label="Guided Review home"
             >
               <img
@@ -55,12 +55,15 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 height={49}
               />
             </Link>
-            <nav className="flex items-center gap-5 text-base text-gr-muted" aria-label="Primary">
+            <nav className="flex items-center gap-5 text-base" aria-label="Primary">
               <Link
                 href="/#features"
-                className="hidden transition-colors hover:text-gr-text sm:inline"
+                className="hidden text-gr-text hover:text-gr-accent sm:inline"
               >
                 Features
+              </Link>
+              <Link href="/#faqs" className="hidden text-gr-text hover:text-gr-accent sm:inline">
+                FAQ
               </Link>
               <StarOnGitHubButton size="sm" surface="overlay" compact />
               <InstallButton size="sm" surface="overlay" compact />

--- a/apps/web/components/Faqs.tsx
+++ b/apps/web/components/Faqs.tsx
@@ -8,12 +8,7 @@ type Faq = {
 
 function FaqLink({ href, children }: { href: string; children: ReactNode }) {
   return (
-    <a
-      href={href}
-      className="text-opt-text underline decoration-opt-border underline-offset-2 transition-colors hover:decoration-opt-accent"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
+    <a href={href} target="_blank" rel="noopener noreferrer">
       {children}
     </a>
   );
@@ -87,8 +82,8 @@ export function Faqs() {
         <ul className="mt-14 m-0 grid list-none grid-cols-1 gap-4 p-0 sm:mt-20">
           {faqs.map((faq) => (
             <li key={faq.question}>
-              <details className="group rounded-3xl border border-opt-border bg-opt-subtle/60 p-6 transition-all duration-300 hover:border-opt-accent/60 hover:bg-opt-subtle sm:p-8 [&_summary::-webkit-details-marker]:hidden">
-                <summary className="flex cursor-pointer list-none items-center justify-between gap-4 text-lg font-semibold tracking-tight sm:text-xl">
+              <details className="group rounded-3xl border border-opt-border bg-opt-subtle/60 transition-all duration-300 hover:border-opt-accent/60 hover:bg-opt-subtle [&_summary::-webkit-details-marker]:hidden">
+                <summary className="flex cursor-pointer list-none items-center justify-between gap-4 p-6 text-lg font-semibold tracking-tight sm:p-8 sm:text-xl">
                   {faq.question}
                   <svg
                     aria-hidden="true"
@@ -103,7 +98,7 @@ export function Faqs() {
                     <path d="m6 9 6 6 6-6" />
                   </svg>
                 </summary>
-                <div className="mt-4 space-y-3 text-base leading-relaxed text-opt-muted sm:text-lg">
+                <div className="space-y-3 px-6 pb-6 text-base leading-relaxed text-opt-muted sm:px-8 sm:pb-8 sm:text-lg">
                   {faq.answer.map((paragraph, index) => (
                     <p key={index} className="m-0">
                       {paragraph}

--- a/apps/web/components/Footer.tsx
+++ b/apps/web/components/Footer.tsx
@@ -23,23 +23,12 @@ export function Footer() {
         >
           <p className="m-0">© {new Date().getFullYear()} Guided Review</p>
           <div className="flex gap-4">
-            <a
-              href={GITHUB_REPO_URL}
-              className="transition-colors hover:text-gr-text"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
+            <a href={GITHUB_REPO_URL} target="_blank" rel="noopener noreferrer">
               GitHub
             </a>
-            <Link href="/privacy" className="transition-colors hover:text-gr-text">
-              Privacy
-            </Link>
-            <Link href="/terms" className="transition-colors hover:text-gr-text">
-              Terms
-            </Link>
-            <Link href="/cookies" className="transition-colors hover:text-gr-text">
-              Cookies
-            </Link>
+            <Link href="/privacy">Privacy</Link>
+            <Link href="/terms">Terms</Link>
+            <Link href="/cookies">Cookies</Link>
           </div>
         </div>
       </div>

--- a/apps/web/components/LegalDocument.tsx
+++ b/apps/web/components/LegalDocument.tsx
@@ -16,7 +16,7 @@ export function LegalDocument({ title, meta, children }: LegalDocumentProps) {
     <article className="mx-auto max-w-3xl px-6 py-16">
       <h1 className="m-0 text-3xl font-bold tracking-tight">{title}</h1>
       <p className="mt-2 text-sm text-opt-muted">{meta}</p>
-      <div className="legal-content mt-8 space-y-8 text-base leading-relaxed text-opt-text [&_a]:underline [&_a]:decoration-opt-border [&_a]:underline-offset-2 hover:[&_a]:decoration-opt-accent [&_h2]:m-0 [&_h2]:text-lg [&_h2]:font-semibold [&_h2]:tracking-tight [&_h3]:m-0 [&_h3]:mt-4 [&_h3]:text-base [&_h3]:font-semibold [&_p]:m-0 [&_p]:mt-3 [&_p]:text-opt-muted [&_ul]:m-0 [&_ul]:mt-3 [&_ul]:list-disc [&_ul]:space-y-2 [&_ul]:pl-5 [&_ul]:text-opt-muted [&_ol]:m-0 [&_ol]:mt-3 [&_ol]:list-decimal [&_ol]:space-y-2 [&_ol]:pl-5 [&_ol]:text-opt-muted [&_li]:leading-relaxed [&_strong]:font-semibold [&_strong]:text-opt-text [&_code]:rounded [&_code]:bg-opt-chrome [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[0.9em] [&_code]:text-opt-text">
+      <div className="legal-content mt-8 space-y-8 text-base leading-relaxed text-opt-text [&_h2]:m-0 [&_h2]:text-lg [&_h2]:font-semibold [&_h2]:tracking-tight [&_h3]:m-0 [&_h3]:mt-4 [&_h3]:text-base [&_h3]:font-semibold [&_p]:m-0 [&_p]:mt-3 [&_p]:text-opt-muted [&_ul]:m-0 [&_ul]:mt-3 [&_ul]:list-disc [&_ul]:space-y-2 [&_ul]:pl-5 [&_ul]:text-opt-muted [&_ol]:m-0 [&_ol]:mt-3 [&_ol]:list-decimal [&_ol]:space-y-2 [&_ol]:pl-5 [&_ol]:text-opt-muted [&_li]:leading-relaxed [&_strong]:font-semibold [&_strong]:text-opt-text [&_code]:rounded [&_code]:bg-opt-chrome [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[0.9em] [&_code]:text-opt-text">
         {children}
       </div>
     </article>

--- a/apps/web/components/ShortcutChord.tsx
+++ b/apps/web/components/ShortcutChord.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Fragment, useSyncExternalStore } from "react";
-import { Kbd } from "@guided-review/ui";
+import { Kbd, KbdGroup } from "@guided-review/ui";
 import { isMacPlatform } from "../lib/platform";
 
 function subscribe() {
@@ -21,7 +21,7 @@ export function ShortcutChord({ keyLabel }: { keyLabel: string }) {
   const keys = [isMac ? "⌘" : "Ctrl", keyLabel.toUpperCase()];
 
   return (
-    <span className="inline-flex items-center gap-1" aria-hidden="true">
+    <KbdGroup aria-hidden="true">
       {keys.map((key, i) => (
         <Fragment key={`${key}-${i}`}>
           {i > 0 ? (
@@ -29,9 +29,9 @@ export function ShortcutChord({ keyLabel }: { keyLabel: string }) {
               +
             </span>
           ) : null}
-          <Kbd>{key}</Kbd>
+          <Kbd surface="app">{key}</Kbd>
         </Fragment>
       ))}
-    </span>
+    </KbdGroup>
   );
 }

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -33,8 +33,8 @@ const appVariants: Record<ButtonVariant, string> = {
     "border-opt-accent bg-opt-accent font-semibold text-opt-accent-on",
     "not-disabled:hover:border-opt-accent-hover not-disabled:hover:bg-opt-accent-hover",
     "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-opt-accent",
-    // Nested keyboard chords on accent fill need inverted kbd chrome.
-    "[&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit",
+    // Nested keyboard keys on accent fill need inverted kbd chrome.
+    "[&_[data-slot=kbd]]:bg-[rgba(13,8,6,0.12)] [&_[data-slot=kbd]]:text-inherit",
   ),
   secondary: cn(
     "border-opt-border bg-opt-subtle font-semibold text-opt-text",
@@ -58,8 +58,8 @@ const overlayVariants: Record<ButtonVariant, string> = {
     "border-gr-accent bg-gr-accent font-medium text-gr-accent-on",
     "not-disabled:hover:border-gr-accent-hover not-disabled:hover:bg-gr-accent-hover",
     "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gr-accent",
-    // Nested keyboard chords on accent fill need inverted kbd chrome.
-    "[&_kbd]:border-[rgba(13,8,6,0.25)] [&_kbd]:bg-[rgba(13,8,6,0.08)] [&_kbd]:text-inherit",
+    // Nested keyboard keys on accent fill need inverted kbd chrome.
+    "[&_[data-slot=kbd]]:bg-[rgba(13,8,6,0.12)] [&_[data-slot=kbd]]:text-inherit",
   ),
   secondary: cn(
     "border-gr-border bg-gr-bg text-gr-muted",

--- a/packages/ui/src/components/Kbd.test.tsx
+++ b/packages/ui/src/components/Kbd.test.tsx
@@ -1,11 +1,49 @@
 import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { Kbd } from "./Kbd";
+import { Kbd, KbdGroup } from "./Kbd";
 
 describe("Kbd", () => {
   it("renders children inside a kbd element", () => {
     render(<Kbd>Esc</Kbd>);
     const el = screen.getByText("Esc");
     expect(el.tagName).toBe("KBD");
+    expect(el).toHaveAttribute("data-slot", "kbd");
+  });
+
+  it("applies overlay tokens by default", () => {
+    render(<Kbd>Esc</Kbd>);
+    const el = screen.getByText("Esc");
+    expect(el.className).toContain("border-gr-border");
+    expect(el.className).toContain("bg-gr-subtle");
+    expect(el.className).toContain("text-gr-muted");
+  });
+
+  it("applies app tokens when surface is app", () => {
+    render(<Kbd surface="app">⌘</Kbd>);
+    const el = screen.getByText("⌘");
+    expect(el.className).toContain("border-opt-border");
+    expect(el.className).toContain("bg-opt-subtle");
+    expect(el.className).toContain("text-opt-muted");
+  });
+
+  it("merges className", () => {
+    render(<Kbd className="opacity-80">A</Kbd>);
+    expect(screen.getByText("A").className).toContain("opacity-80");
+  });
+});
+
+describe("KbdGroup", () => {
+  it("groups keys with data-slot kbd-group", () => {
+    render(
+      <KbdGroup data-testid="group">
+        <Kbd>Ctrl</Kbd>
+        <Kbd>B</Kbd>
+      </KbdGroup>,
+    );
+    const group = screen.getByTestId("group");
+    expect(group.tagName).toBe("KBD");
+    expect(group).toHaveAttribute("data-slot", "kbd-group");
+    expect(screen.getByText("Ctrl")).toBeInTheDocument();
+    expect(screen.getByText("B")).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/Kbd.tsx
+++ b/packages/ui/src/components/Kbd.tsx
@@ -1,13 +1,47 @@
-import type { ReactNode } from "react";
+import type { ComponentProps } from "react";
+import { cn } from "../cn";
+import type { Surface } from "../surface";
 
-interface KbdProps {
-  children: ReactNode;
-}
+export type KbdProps = ComponentProps<"kbd"> & {
+  /**
+   * Token set: `app` (options + marketing, opt-*) or `overlay` (dark review UI, gr-*).
+   * Defaults to `overlay` for back-compat with existing review UI usage.
+   */
+  surface?: Surface;
+};
 
-export function Kbd({ children }: KbdProps) {
+/**
+ * Keyboard key badge — mirrors shadcn/ui `Kbd`.
+ * @see https://ui.shadcn.com/docs/components/kbd
+ */
+function Kbd({ className, surface = "overlay", ...props }: KbdProps) {
   return (
-    <kbd className="inline-flex h-[18px] min-w-[18px] items-center justify-center rounded border border-gr-border border-b-2 bg-gr-subtle px-[5px] font-mono text-xs leading-none text-gr-muted">
-      {children}
-    </kbd>
+    <kbd
+      data-slot="kbd"
+      className={cn(
+        "pointer-events-none inline-flex h-5 w-fit min-w-5 select-none items-center justify-center gap-1 rounded-sm border px-1 font-sans text-sm",
+        "[&_svg:not([class*='size-'])]:size-3 opacity-75",
+        surface === "app"
+          ? "border-opt-border bg-opt-subtle text-opt-muted"
+          : "border-gr-border bg-gr-subtle text-gr-muted",
+        className,
+      )}
+      {...props}
+    />
   );
 }
+
+/**
+ * Groups adjacent key badges — mirrors shadcn/ui `KbdGroup`.
+ */
+function KbdGroup({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <kbd
+      data-slot="kbd-group"
+      className={cn("inline-flex items-center gap-1", className)}
+      {...props}
+    />
+  );
+}
+
+export { Kbd, KbdGroup };

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -2,7 +2,8 @@ export { cn } from "./cn";
 export type { Surface } from "./surface";
 
 export { Spinner } from "./components/Spinner";
-export { Kbd } from "./components/Kbd";
+export { Kbd, KbdGroup } from "./components/Kbd";
+export type { KbdProps } from "./components/Kbd";
 export { BrandMark } from "./components/BrandMark";
 export type { BrandMarkProps } from "./components/BrandMark";
 

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -12,7 +12,7 @@
   --color-gr-canvas: #16120f;
   --color-gr-subtle: #1c1814;
   /* Borders ≥ 3:1 against gr-bg/gr-chrome for WCAG 1.4.11 UI contrast */
-  --color-gr-border: #6b635a;
+  --color-gr-border: #312d29;
   --color-gr-border-muted: #4a433c;
   --color-gr-text: #fefefe;
   --color-gr-muted: #8b949e;
@@ -103,7 +103,7 @@
   :root {
     --opt-bg: #0d0806;
     --opt-subtle: #16120f;
-    --opt-border: #6b635a;
+    --opt-border: #312d29;
     --opt-text: #fefefe;
     --opt-muted: #8b949e;
     --opt-accent: #caff57;


### PR DESCRIPTION
## Summary

- Improve shared `Kbd` / add `KbdGroup` (surface tokens, `data-slot` selectors, better contrast on accent buttons) and wire them through extension overlay + marketing shortcut UI.
- Soften border tokens (`gr-border` / `opt-border`) so UI chrome is less harsh.
- Marketing site: brand-colored text links with hover underline, FAQ nav item, and simplified FAQ/footer/legal link styling.

## Test plan

- [ ] Load extension from `apps/extension/dist` and open a guided review — confirm shortcut badges (footer nav, progress header submit, keyboard help, submit modal) render clearly on both default and accent backgrounds
- [ ] Confirm `Kbd` unit tests pass (`packages/ui`)
- [ ] Marketing site: check header nav (Features, FAQ), footer links, FAQ external links, and legal pages for accent color + hover bottom border; button-style anchors should not get the text-link underline