### PR TITLE
feat(extension): auto-open Guided Review on Files changed tab

### DIFF
--- a/apps/extension/src/content/index.tsx
+++ b/apps/extension/src/content/index.tsx
@@ -1,4 +1,5 @@
 import { createRoot } from "react-dom/client";
+import { getAutoOpenOnFilesTab, onAutoOpenOnFilesTabChanged } from "../lib/autoOpenOnFilesTab";
 import { parsePRUrl, type PRIdentity } from "../lib/github/diffFetch";
 import { fetchConversationDescription, scrapePRContext } from "../lib/github/prContext";
 import { requestPRDiff, streamReviewPlan } from "../lib/messaging";
@@ -6,6 +7,7 @@ import { getProviderSettings, onProviderSettingsChanged } from "../lib/settings"
 import type { ContentRequest, ParsedDiff, PRContext } from "../lib/types";
 import { ensureFallbackHost, FALLBACK_HOST_ID, findButtonAnchor } from "./buttonAnchor";
 import { Overlay } from "./overlay/Overlay";
+import { isPrFilesChangedPath } from "./overlay/prConversationUrl";
 import overlayStyles from "./overlay/styles/overlay.css?inline";
 import { useReviewStore, restoreSession, buildSessionKey } from "./overlay/store";
 
@@ -18,6 +20,15 @@ const ACCENT_HOVER = "#b6e64e";
 let currentPR: PRIdentity | null = null;
 /** Active stream cancel handle so restart / close can abort the worker. */
 let activeStreamCancel: (() => void) | null = null;
+/** Whether Options → "Automatically open when I go to Files changed tab in a PR" is enabled. */
+let autoOpenEnabled = false;
+/**
+ * Pathname of the Files/Changes tab visit we already auto-opened (or skipped
+ * because the overlay was already open). Cleared when the user leaves that tab
+ * so re-entry can open again; stays set after a manual close so we don't loop.
+ * Matches both classic `/files` and newer `/changes` PR paths.
+ */
+let autoOpenedForFilesPath: string | null = null;
 
 init();
 
@@ -36,6 +47,7 @@ function ensureButtonStyles(): void {
 function init(): void {
   ensureButtonStyles();
   tryInjectButton();
+  void hydrateAutoOpenPreference();
 
   // Toolbar icon click is handled in the background worker; when the active
   // tab is a PR page it forwards START_GUIDED_REVIEW here.
@@ -53,11 +65,54 @@ function init(): void {
     void onStartReview();
   });
 
+  onAutoOpenOnFilesTabChanged((enabled) => {
+    autoOpenEnabled = enabled;
+    // Opting in while already on Files should open once (don't treat a prior
+    // visit while the setting was off as "already handled").
+    if (enabled) autoOpenedForFilesPath = null;
+    maybeAutoOpenOnFilesTab();
+  });
+
   // GitHub is a SPA — the PR page doesn't reload between "Conversation" /
   // "Files changed" / re-renders after data loads, so watch for DOM changes
   // and re-inject if our button gets removed (or the PR identity changes).
-  const observer = new MutationObserver(() => tryInjectButton());
+  // The same observer is our cheap hook for SPA tab switches (path changes
+  // without a full navigation).
+  const observer = new MutationObserver(() => {
+    tryInjectButton();
+    maybeAutoOpenOnFilesTab();
+  });
   observer.observe(document.body, { childList: true, subtree: true });
+}
+
+async function hydrateAutoOpenPreference(): Promise<void> {
+  autoOpenEnabled = await getAutoOpenOnFilesTab();
+  maybeAutoOpenOnFilesTab();
+}
+
+/**
+ * If the preference is on and the user just landed on Files changed
+ * (`/files` or `/changes`), open (or resume) the review once for this visit.
+ */
+function maybeAutoOpenOnFilesTab(): void {
+  const pathname = window.location.pathname;
+  // Always clear when leaving Files/Changes so re-entry can open again — even
+  // if the preference is currently off (so path state doesn't go stale).
+  if (!isPrFilesChangedPath(pathname)) {
+    autoOpenedForFilesPath = null;
+    return;
+  }
+
+  if (!autoOpenEnabled) return;
+  if (autoOpenedForFilesPath === pathname) return;
+
+  if (useReviewStore.getState().isOpen) {
+    autoOpenedForFilesPath = pathname;
+    return;
+  }
+
+  autoOpenedForFilesPath = pathname;
+  void onStartReview();
 }
 
 function removeStartButton(): void {

--- a/apps/extension/src/content/overlay/prConversationUrl.test.ts
+++ b/apps/extension/src/content/overlay/prConversationUrl.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   isPrConversationPath,
+  isPrFilesChangedPath,
   navigateToPrConversation,
   prConversationUrl,
 } from "./prConversationUrl";
@@ -30,6 +31,32 @@ describe("isPrConversationPath", () => {
   it("rejects other PRs", () => {
     expect(isPrConversationPath("/acme/widgets/pull/2", pr)).toBe(false);
     expect(isPrConversationPath("/other/widgets/pull/1", pr)).toBe(false);
+  });
+});
+
+describe("isPrFilesChangedPath", () => {
+  it("matches the classic Files changed tab (/files)", () => {
+    expect(isPrFilesChangedPath("/acme/widgets/pull/1/files")).toBe(true);
+    expect(isPrFilesChangedPath("/acme/widgets/pull/1/files/")).toBe(true);
+    expect(isPrFilesChangedPath("/acme/widgets/pull/42/files")).toBe(true);
+  });
+
+  it("matches the new PR UI Changes tab (/changes)", () => {
+    expect(isPrFilesChangedPath("/acme/widgets/pull/1/changes")).toBe(true);
+    expect(isPrFilesChangedPath("/acme/widgets/pull/1/changes/")).toBe(true);
+    expect(isPrFilesChangedPath("/acme/widgets/pull/42/changes")).toBe(true);
+  });
+
+  it("rejects conversation and other PR tabs", () => {
+    expect(isPrFilesChangedPath("/acme/widgets/pull/1")).toBe(false);
+    expect(isPrFilesChangedPath("/acme/widgets/pull/1/commits")).toBe(false);
+    expect(isPrFilesChangedPath("/acme/widgets/pull/1/checks")).toBe(false);
+    expect(isPrFilesChangedPath("/acme/widgets/issues/1")).toBe(false);
+  });
+
+  it("rejects paths that only contain files/changes as a prefix of another segment", () => {
+    expect(isPrFilesChangedPath("/acme/widgets/pull/1/filesx")).toBe(false);
+    expect(isPrFilesChangedPath("/acme/widgets/pull/1/changesx")).toBe(false);
   });
 });
 

--- a/apps/extension/src/content/overlay/prConversationUrl.ts
+++ b/apps/extension/src/content/overlay/prConversationUrl.ts
@@ -17,6 +17,16 @@ export function isPrConversationPath(
 }
 
 /**
+ * True when `pathname` is the PR Files changed / Changes tab
+ * (`.../pull/N/files` or `.../pull/N/changes`, optional trailing segments).
+ * GitHub's classic UI uses `/files`; the newer PR UI uses `/changes`.
+ */
+export function isPrFilesChangedPath(pathname: string): boolean {
+  const normalized = pathname.replace(/\/+$/, "") || "/";
+  return /\/pull\/\d+\/(?:files|changes)(?:\/|$)/.test(normalized);
+}
+
+/**
  * Navigate to the conversation tab if the user is on another PR tab.
  * No-op when already on conversation. Uses a full navigation so GitHub's
  * SPA shell reliably shows the default PR surface after overlay exit.

--- a/apps/extension/src/lib/autoOpenOnFilesTab.test.ts
+++ b/apps/extension/src/lib/autoOpenOnFilesTab.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_AUTO_OPEN_ON_FILES_TAB,
+  getAutoOpenOnFilesTab,
+  onAutoOpenOnFilesTabChanged,
+  setAutoOpenOnFilesTab,
+} from "./autoOpenOnFilesTab";
+
+describe("autoOpenOnFilesTab", () => {
+  beforeEach(async () => {
+    await chrome.storage.local.clear();
+  });
+
+  it("returns the default when nothing is stored", async () => {
+    await expect(getAutoOpenOnFilesTab()).resolves.toBe(DEFAULT_AUTO_OPEN_ON_FILES_TAB);
+    expect(DEFAULT_AUTO_OPEN_ON_FILES_TAB).toBe(false);
+  });
+
+  it("round-trips a saved value", async () => {
+    await setAutoOpenOnFilesTab(true);
+    await expect(getAutoOpenOnFilesTab()).resolves.toBe(true);
+    await setAutoOpenOnFilesTab(false);
+    await expect(getAutoOpenOnFilesTab()).resolves.toBe(false);
+  });
+
+  it("ignores invalid stored values", async () => {
+    await chrome.storage.local.set({ "guidedReview.autoOpenOnFilesTab": "yes" });
+    await expect(getAutoOpenOnFilesTab()).resolves.toBe(DEFAULT_AUTO_OPEN_ON_FILES_TAB);
+  });
+
+  it("onAutoOpenOnFilesTabChanged fires on save", async () => {
+    const listener = vi.fn();
+    const unsubscribe = onAutoOpenOnFilesTabChanged(listener);
+
+    await setAutoOpenOnFilesTab(true);
+    expect(listener).toHaveBeenCalledWith(true);
+
+    unsubscribe();
+    await setAutoOpenOnFilesTab(false);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("onAutoOpenOnFilesTabChanged ignores unrelated keys", async () => {
+    const listener = vi.fn();
+    const unsubscribe = onAutoOpenOnFilesTabChanged(listener);
+
+    await chrome.storage.local.set({ "guidedReview.somethingElse": 1 });
+    expect(listener).not.toHaveBeenCalled();
+
+    unsubscribe();
+  });
+});

--- a/apps/extension/src/lib/autoOpenOnFilesTab.ts
+++ b/apps/extension/src/lib/autoOpenOnFilesTab.ts
@@ -1,0 +1,44 @@
+const STORAGE_KEY = "guidedReview.autoOpenOnFilesTab";
+
+/** Default: off — opt-in so the overlay never surprises first-time users. */
+export const DEFAULT_AUTO_OPEN_ON_FILES_TAB = false;
+
+/** Read whether Guided Review should open on the Files changed / Changes tab. */
+export async function getAutoOpenOnFilesTab(): Promise<boolean> {
+  try {
+    const result = await chrome.storage.local.get(STORAGE_KEY);
+    const stored = result[STORAGE_KEY];
+    return typeof stored === "boolean" ? stored : DEFAULT_AUTO_OPEN_ON_FILES_TAB;
+  } catch {
+    return DEFAULT_AUTO_OPEN_ON_FILES_TAB;
+  }
+}
+
+/** Persist the auto-open preference. Failures are non-fatal. */
+export async function setAutoOpenOnFilesTab(enabled: boolean): Promise<void> {
+  try {
+    await chrome.storage.local.set({ [STORAGE_KEY]: enabled });
+  } catch (error) {
+    console.warn("Guided Review: failed to persist auto-open preference", error);
+  }
+}
+
+/**
+ * Watch for changes to the auto-open preference (e.g. options page while a
+ * PR tab is open). Returns an unsubscribe function.
+ */
+export function onAutoOpenOnFilesTabChanged(listener: (enabled: boolean) => void): () => void {
+  const handler = (
+    changes: Record<string, chrome.storage.StorageChange>,
+    areaName: string,
+  ): void => {
+    if (areaName !== "local") return;
+    const change = changes[STORAGE_KEY];
+    if (!change) return;
+    const next = change.newValue;
+    listener(typeof next === "boolean" ? next : DEFAULT_AUTO_OPEN_ON_FILES_TAB);
+  };
+
+  chrome.storage.onChanged.addListener(handler);
+  return () => chrome.storage.onChanged.removeListener(handler);
+}

--- a/apps/extension/src/options/Options.test.tsx
+++ b/apps/extension/src/options/Options.test.tsx
@@ -173,4 +173,33 @@ describe("Options", () => {
     const about = screen.getByRole("link", { name: /about guided review/i });
     expect(about).toHaveAttribute("href", "#about");
   });
+
+  it("defaults the Files changed auto-open checkbox to off", async () => {
+    render(<Options />);
+
+    const checkbox = await screen.findByRole("checkbox", {
+      name: /automatically open when i go to files changed tab in a pr/i,
+    });
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it("hydrates and persists the Files changed auto-open preference", async () => {
+    const user = userEvent.setup();
+    await chrome.storage.local.set({ "guidedReview.autoOpenOnFilesTab": true });
+
+    render(<Options />);
+
+    const checkbox = await screen.findByRole("checkbox", {
+      name: /automatically open when i go to files changed tab in a pr/i,
+    });
+    expect(checkbox).toBeChecked();
+
+    await user.click(checkbox);
+    expect(checkbox).not.toBeChecked();
+
+    await waitFor(async () => {
+      const stored = await chrome.storage.local.get("guidedReview.autoOpenOnFilesTab");
+      expect(stored["guidedReview.autoOpenOnFilesTab"]).toBe(false);
+    });
+  });
 });

--- a/apps/extension/src/options/Options.tsx
+++ b/apps/extension/src/options/Options.tsx
@@ -6,6 +6,7 @@ import {
   modelsForProvider,
   PROVIDERS,
 } from "../lib/providers/catalog";
+import { getAutoOpenOnFilesTab, setAutoOpenOnFilesTab } from "../lib/autoOpenOnFilesTab";
 import { getProviderSettings, setProviderSettings } from "../lib/settings";
 import { testConnection } from "../lib/messaging";
 import { ProviderIcon } from "./components/ProviderIcon";
@@ -30,11 +31,13 @@ function OptionRow({ icon, label }: { icon: ProviderId; label: string }) {
 
 export function Options() {
   const [settings, setSettings] = useState<ProviderSettings | null>(null);
+  const [autoOpenOnFilesTab, setAutoOpenOnFilesTabState] = useState(false);
   const [saveStatus, setSaveStatus] = useState<ActionStatus>({ kind: "idle" });
   const [connection, setConnection] = useState<ActionStatus>({ kind: "idle" });
 
   useEffect(() => {
     void getProviderSettings().then(setSettings);
+    void getAutoOpenOnFilesTab().then(setAutoOpenOnFilesTabState);
   }, []);
 
   const providerOptions: SelectOption<ProviderId>[] = useMemo(
@@ -88,6 +91,11 @@ export function Options() {
       const message = error instanceof Error ? error.message : "Failed to save settings.";
       setSaveStatus({ kind: "error", message });
     }
+  };
+
+  const onAutoOpenChange = async (enabled: boolean) => {
+    setAutoOpenOnFilesTabState(enabled);
+    await setAutoOpenOnFilesTab(enabled);
   };
 
   const onTestConnection = async () => {
@@ -201,6 +209,29 @@ export function Options() {
               : statusMessage.message}
           </span>
         )}
+      </div>
+
+      <h2 className="mb-4 mt-8 text-base font-semibold text-opt-text">Review</h2>
+      <div className="mb-2">
+        <label className="flex cursor-pointer items-start gap-3">
+          <input
+            id="autoOpenOnFilesTab"
+            type="checkbox"
+            className="mt-1 size-4 shrink-0 rounded border-opt-border accent-opt-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-opt-accent"
+            checked={autoOpenOnFilesTab}
+            onChange={(e) => void onAutoOpenChange(e.target.checked)}
+            aria-describedby="autoOpenOnFilesTab-hint"
+          />
+          <span className="min-w-0">
+            <span className="block text-base font-semibold text-opt-text">
+              Automatically open when I go to Files changed tab in a PR
+            </span>
+            <span id="autoOpenOnFilesTab-hint" className="mt-1 block text-sm text-opt-muted">
+              When enabled, Guided Review opens (or resumes) automatically on a PR’s Files changed /
+              Changes tab. You can still start it from the button anytime.
+            </span>
+          </span>
+        </label>
       </div>
 
       <nav className="mt-8 border-t border-opt-border pt-6" aria-label="About">

--- a/apps/web/content/help/configure-provider.mdx
+++ b/apps/web/content/help/configure-provider.mdx
@@ -57,10 +57,11 @@ If the test fails, step through [Troubleshooting → Provider and API key](/docs
 
 ## Where settings live
 
-| Setting                  | Storage                  | Used by                          |
-| ------------------------ | ------------------------ | -------------------------------- |
-| Provider, model, API key | `chrome.storage.local`   | Background worker                |
-| Active review session    | `chrome.storage.session` | Content overlay (session-scoped) |
+| Setting                               | Storage                  | Used by                          |
+| ------------------------------------- | ------------------------ | -------------------------------- |
+| Provider, model, API key              | `chrome.storage.local`   | Background worker                |
+| Automatically open on Files changed   | `chrome.storage.local`   | Content script (auto-open)       |
+| Active review session                 | `chrome.storage.session` | Content overlay (session-scoped) |
 
 Session resume behavior: [Your first review → Resume later](/docs/first-review#resume-later) and [Troubleshooting](/docs/troubleshooting#session-and-resume).
 

--- a/apps/web/content/help/configure-provider.mdx
+++ b/apps/web/content/help/configure-provider.mdx
@@ -57,11 +57,11 @@ If the test fails, step through [Troubleshooting → Provider and API key](/docs
 
 ## Where settings live
 
-| Setting                               | Storage                  | Used by                          |
-| ------------------------------------- | ------------------------ | -------------------------------- |
-| Provider, model, API key              | `chrome.storage.local`   | Background worker                |
-| Automatically open on Files changed   | `chrome.storage.local`   | Content script (auto-open)       |
-| Active review session                 | `chrome.storage.session` | Content overlay (session-scoped) |
+| Setting                             | Storage                  | Used by                          |
+| ----------------------------------- | ------------------------ | -------------------------------- |
+| Provider, model, API key            | `chrome.storage.local`   | Background worker                |
+| Automatically open on Files changed | `chrome.storage.local`   | Content script (auto-open)       |
+| Active review session               | `chrome.storage.session` | Content overlay (session-scoped) |
 
 Session resume behavior: [Your first review → Resume later](/docs/first-review#resume-later) and [Troubleshooting](/docs/troubleshooting#session-and-resume).
 

--- a/apps/web/content/help/first-review.mdx
+++ b/apps/web/content/help/first-review.mdx
@@ -25,6 +25,8 @@ No button? See [Troubleshooting](/docs/troubleshooting#no-start-guided-review-bu
 3. The extension fetches the PR diff, builds a prompt, and streams a [review plan](/docs/how-it-works) from your configured provider.
 4. Units appear progressively as the stream completes each chunk; the final merged plan is what you step through.
 
+Optional: in Options, enable **Automatically open when I go to Files changed tab in a PR** to start (or resume) the review automatically when you open that tab (classic `/files` or the newer `/changes` path). Off by default.
+
 > **No provider configured?** You’ll be prompted to open Options and [add an API key](/docs/configure-provider) first. Connection failures: [Troubleshooting](/docs/troubleshooting#provider-and-api-key).
 
 ## Walk the plan


### PR DESCRIPTION
## Summary

Adds an opt-in Options setting that opens (or resumes) Guided Review when you land on a PR’s **Files changed** / **Changes** tab — classic `/files` and the newer `/changes` path.

- **Default off** so first-time users aren’t surprised by the overlay.
- Content script tracks one auto-open per Files-tab visit: leaving the tab resets so re-entry can open again; staying after a manual close does not loop.
- Preference lives in `chrome.storage.local` and updates live if Options is changed while a PR tab is open.
- Docs and unit tests cover storage, path matching, and the Options checkbox.

## Test plan

- [ ] Load unpacked build from `apps/extension/dist`; open Options and confirm the new **Review** checkbox is off by default
- [ ] Enable the setting; on a PR, open Files changed (`/files` or `/changes`) and confirm the overlay starts/resumes once
- [ ] Close the overlay while still on Files; confirm it does not auto-reopen until you leave Files and come back
- [ ] Leave Files for Conversation/Commits, return to Files; confirm auto-open runs again
- [ ] Disable the setting; confirm Files tab visits no longer open the overlay (button still works)
- [ ] Toggle the setting while already on Files; confirm enabling opens once
- [ ] `npm test` (extension unit tests including new auto-open + path helpers)