### PR TITLE
Auto-open on Files tab, provider refactor, and misc cleanup

### DIFF
--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -26,6 +26,7 @@ import { clearGitHubAuth, getGitHubAuth, setGitHubAuth } from "../lib/github/aut
 import { fetchGitHubUser, pollAccessToken, requestDeviceCode } from "../lib/github/deviceOAuth";
 import {
   GITHUB_OAUTH_CLIENT_ID,
+  GITHUB_OAUTH_NOT_CONFIGURED,
   GITHUB_OAUTH_SCOPES,
   isGitHubOAuthConfigured,
 } from "../lib/github/oauthConfig";
@@ -287,11 +288,7 @@ async function handleFetchDiff(request: FetchDiffRequest): Promise<FetchDiffResp
 
 async function handleGitHubDeviceStart(): Promise<GitHubDeviceStartResponse> {
   if (!isGitHubOAuthConfigured()) {
-    return {
-      ok: false,
-      error:
-        "GitHub connection isn’t configured in this build. Set VITE_GITHUB_CLIENT_ID and rebuild.",
-    };
+    return { ok: false, error: GITHUB_OAUTH_NOT_CONFIGURED };
   }
 
   const device = await requestDeviceCode(GITHUB_OAUTH_CLIENT_ID, GITHUB_OAUTH_SCOPES);
@@ -309,12 +306,7 @@ async function handleGitHubDevicePoll(
   request: GitHubDevicePollRequest,
 ): Promise<GitHubDevicePollResponse> {
   if (!isGitHubOAuthConfigured()) {
-    return {
-      ok: false,
-      status: "error",
-      error:
-        "GitHub connection isn’t configured in this build. Set VITE_GITHUB_CLIENT_ID and rebuild.",
-    };
+    return { ok: false, status: "error", error: GITHUB_OAUTH_NOT_CONFIGURED };
   }
 
   const result = await pollAccessToken(GITHUB_OAUTH_CLIENT_ID, request.deviceCode);

--- a/apps/extension/src/background/providers/anthropic.ts
+++ b/apps/extension/src/background/providers/anthropic.ts
@@ -1,65 +1,50 @@
 import type { ProviderSettings } from "../../lib/types";
 import { buildUserPrompt, SYSTEM_PROMPT } from "../../lib/review/buildPrompt";
 import { REVIEW_PLAN_JSON_SCHEMA } from "../../lib/review/reviewSchema";
-import { isAbortError, parseProviderHttpError } from "./http";
+import { postProviderJson } from "./http";
 import { readSseJsonStream } from "./sse";
 import type { AnnotateReviewInput, AnnotateStreamEvent, ProviderClient } from "./types";
 import { ProviderError } from "./types";
 
 const API_URL = "https://api.anthropic.com/v1/messages";
-const ANTHROPIC_VERSION = "2023-06-01";
+
+function headers(apiKey: string): Record<string, string> {
+  return {
+    "x-api-key": apiKey,
+    "anthropic-version": "2023-06-01",
+    // Documented "bring your own API key" browser-CORS opt-in, which lets the
+    // background worker call the Messages API directly.
+    "anthropic-dangerous-direct-browser-access": "true",
+  };
+}
 
 /**
- * Claude implementation. Uses `anthropic-dangerous-direct-browser-access` to
- * call the Messages API directly from the extension's background worker
- * (this is the documented "bring your own API key" browser-CORS opt-in) and
- * `output_config.format` to force a schema-valid ReviewPlan rather than
- * parsing free text. Streams text deltas so the UI can surface units early.
+ * Claude implementation. Uses `output_config.format` to force a schema-valid
+ * ReviewPlan rather than parsing free text, and streams text deltas so the UI
+ * can surface units early.
  */
 export const anthropicProvider: ProviderClient = {
   async *annotateReviewStream(
     { diff, prContext, settings }: AnnotateReviewInput,
     options?: { signal?: AbortSignal },
   ): AsyncGenerator<AnnotateStreamEvent, void, unknown> {
-    const body = {
-      model: settings.model,
-      max_tokens: 8000,
-      stream: true,
-      system: SYSTEM_PROMPT,
-      output_config: {
-        effort: "medium",
-        format: { type: "json_schema", schema: REVIEW_PLAN_JSON_SCHEMA },
-      },
-      messages: [{ role: "user", content: buildUserPrompt(diff, prContext) }],
-    };
-
-    let response: Response;
-    try {
-      response = await fetch(API_URL, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "x-api-key": settings.apiKey,
-          "anthropic-version": ANTHROPIC_VERSION,
-          "anthropic-dangerous-direct-browser-access": "true",
+    const response = await postProviderJson(
+      API_URL,
+      headers(settings.apiKey),
+      {
+        model: settings.model,
+        max_tokens: 8000,
+        stream: true,
+        system: SYSTEM_PROMPT,
+        output_config: {
+          effort: "medium",
+          format: { type: "json_schema", schema: REVIEW_PLAN_JSON_SCHEMA },
         },
-        body: JSON.stringify(body),
-        signal: options?.signal,
-      });
-    } catch (error) {
-      if (isAbortError(error)) throw error;
-      throw new ProviderError(
-        error instanceof Error ? error.message : "Failed to reach the Claude API.",
-      );
-    }
-
-    if (!response.ok) {
-      const detail = await parseProviderHttpError(response);
-      throw new ProviderError(detail.message, {
-        statusCode: response.status,
-        code: detail.code,
-      });
-    }
+        messages: [{ role: "user", content: buildUserPrompt(diff, prContext) }],
+      },
+      "Claude",
+      options?.signal,
+    );
 
     if (!response.body) {
       throw new ProviderError("Claude returned an empty stream.");
@@ -99,36 +84,15 @@ export const anthropicProvider: ProviderClient = {
   },
 
   async testConnection(settings: ProviderSettings): Promise<void> {
-    let response: Response;
-    try {
-      response = await fetch(API_URL, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "x-api-key": settings.apiKey,
-          "anthropic-version": ANTHROPIC_VERSION,
-          "anthropic-dangerous-direct-browser-access": "true",
-        },
-        body: JSON.stringify({
-          model: settings.model,
-          max_tokens: 8,
-          messages: [{ role: "user", content: "Reply with OK." }],
-        }),
-      });
-    } catch (error) {
-      // Same wrapping as the streaming path: a bare fetch rejection would
-      // surface as "Failed to fetch" with no hint of which provider failed.
-      throw new ProviderError(
-        error instanceof Error ? error.message : "Failed to reach the Claude API.",
-      );
-    }
-
-    if (!response.ok) {
-      const detail = await parseProviderHttpError(response);
-      throw new ProviderError(detail.message, {
-        statusCode: response.status,
-        code: detail.code,
-      });
-    }
+    await postProviderJson(
+      API_URL,
+      headers(settings.apiKey),
+      {
+        model: settings.model,
+        max_tokens: 8,
+        messages: [{ role: "user", content: "Reply with OK." }],
+      },
+      "Claude",
+    );
   },
 };

--- a/apps/extension/src/background/providers/anthropic.ts
+++ b/apps/extension/src/background/providers/anthropic.ts
@@ -99,20 +99,29 @@ export const anthropicProvider: ProviderClient = {
   },
 
   async testConnection(settings: ProviderSettings): Promise<void> {
-    const response = await fetch(API_URL, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-api-key": settings.apiKey,
-        "anthropic-version": ANTHROPIC_VERSION,
-        "anthropic-dangerous-direct-browser-access": "true",
-      },
-      body: JSON.stringify({
-        model: settings.model,
-        max_tokens: 8,
-        messages: [{ role: "user", content: "Reply with OK." }],
-      }),
-    });
+    let response: Response;
+    try {
+      response = await fetch(API_URL, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": settings.apiKey,
+          "anthropic-version": ANTHROPIC_VERSION,
+          "anthropic-dangerous-direct-browser-access": "true",
+        },
+        body: JSON.stringify({
+          model: settings.model,
+          max_tokens: 8,
+          messages: [{ role: "user", content: "Reply with OK." }],
+        }),
+      });
+    } catch (error) {
+      // Same wrapping as the streaming path: a bare fetch rejection would
+      // surface as "Failed to fetch" with no hint of which provider failed.
+      throw new ProviderError(
+        error instanceof Error ? error.message : "Failed to reach the Claude API.",
+      );
+    }
 
     if (!response.ok) {
       const detail = await parseProviderHttpError(response);

--- a/apps/extension/src/background/providers/http.ts
+++ b/apps/extension/src/background/providers/http.ts
@@ -2,7 +2,9 @@
  * Shared fetch/error helpers for provider HTTP clients.
  */
 
-export interface ProviderHttpErrorDetail {
+import { ProviderError } from "./types";
+
+interface ProviderHttpErrorDetail {
   /** Exact provider message when present; otherwise statusText or a fallback. */
   message: string;
   /** Provider error code/type when present (e.g. invalid_api_key, authentication_error). */
@@ -45,6 +47,47 @@ export async function parseProviderHttpError(response: Response): Promise<Provid
   }
 }
 
-export function isAbortError(error: unknown): boolean {
+function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === "AbortError";
+}
+
+/**
+ * POST a JSON body to a provider endpoint and return the successful response.
+ *
+ * Throws `ProviderError` for both transport failures and non-2xx responses — a
+ * bare fetch rejection would otherwise surface as "Failed to fetch" with no
+ * hint of which provider failed. Abort errors pass through untouched so
+ * cancellation stays distinguishable from a real failure.
+ */
+export async function postProviderJson(
+  url: string,
+  headers: Record<string, string>,
+  body: unknown,
+  providerName: string,
+  signal?: AbortSignal,
+): Promise<Response> {
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json", ...headers },
+      body: JSON.stringify(body),
+      signal,
+    });
+  } catch (error) {
+    if (isAbortError(error)) throw error;
+    throw new ProviderError(
+      error instanceof Error ? error.message : `Failed to reach the ${providerName} API.`,
+    );
+  }
+
+  if (!response.ok) {
+    const detail = await parseProviderHttpError(response);
+    throw new ProviderError(detail.message, {
+      statusCode: response.status,
+      code: detail.code,
+    });
+  }
+
+  return response;
 }

--- a/apps/extension/src/background/providers/http.ts
+++ b/apps/extension/src/background/providers/http.ts
@@ -45,12 +45,6 @@ export async function parseProviderHttpError(response: Response): Promise<Provid
   }
 }
 
-/** @deprecated Prefer parseProviderHttpError — kept for any residual callers. */
-export async function safeErrorDetail(response: Response): Promise<string> {
-  const detail = await parseProviderHttpError(response);
-  return detail.message;
-}
-
 export function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === "AbortError";
 }

--- a/apps/extension/src/background/providers/openaiCompatible.ts
+++ b/apps/extension/src/background/providers/openaiCompatible.ts
@@ -101,18 +101,27 @@ export function createOpenAICompatibleProvider(
     },
 
     async testConnection(settings: ProviderSettings): Promise<void> {
-      const response = await fetch(chatUrl, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          authorization: `Bearer ${settings.apiKey}`,
-        },
-        body: JSON.stringify({
-          model: settings.model,
-          max_tokens: 8,
-          messages: [{ role: "user", content: "Reply with OK." }],
-        }),
-      });
+      let response: Response;
+      try {
+        response = await fetch(chatUrl, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${settings.apiKey}`,
+          },
+          body: JSON.stringify({
+            model: settings.model,
+            max_tokens: 8,
+            messages: [{ role: "user", content: "Reply with OK." }],
+          }),
+        });
+      } catch (error) {
+        // Same wrapping as the streaming path: a bare fetch rejection would
+        // surface as "Failed to fetch" with no hint of which provider failed.
+        throw new ProviderError(
+          error instanceof Error ? error.message : `Failed to reach the ${displayName} API.`,
+        );
+      }
 
       if (!response.ok) {
         const detail = await parseProviderHttpError(response);

--- a/apps/extension/src/background/providers/openaiCompatible.ts
+++ b/apps/extension/src/background/providers/openaiCompatible.ts
@@ -1,7 +1,7 @@
 import type { ProviderSettings } from "../../lib/types";
 import { buildUserPrompt, SYSTEM_PROMPT } from "../../lib/review/buildPrompt";
 import { REVIEW_PLAN_JSON_SCHEMA } from "../../lib/review/reviewSchema";
-import { isAbortError, parseProviderHttpError } from "./http";
+import { postProviderJson } from "./http";
 import { readSseJsonStream } from "./sse";
 import type { AnnotateReviewInput, AnnotateStreamEvent, ProviderClient } from "./types";
 import { ProviderError } from "./types";
@@ -20,52 +20,35 @@ export function createOpenAICompatibleProvider(
   displayName: string,
 ): ProviderClient {
   const chatUrl = `${baseUrl}/chat/completions`;
+  const headers = (apiKey: string) => ({ authorization: `Bearer ${apiKey}` });
 
   return {
     async *annotateReviewStream(
       { diff, prContext, settings }: AnnotateReviewInput,
       options?: { signal?: AbortSignal },
     ): AsyncGenerator<AnnotateStreamEvent, void, unknown> {
-      let response: Response;
-      try {
-        response = await fetch(chatUrl, {
-          method: "POST",
-          headers: {
-            "content-type": "application/json",
-            authorization: `Bearer ${settings.apiKey}`,
-          },
-          body: JSON.stringify({
-            model: settings.model,
-            stream: true,
-            messages: [
-              { role: "system", content: SYSTEM_PROMPT },
-              { role: "user", content: buildUserPrompt(diff, prContext) },
-            ],
-            response_format: {
-              type: "json_schema",
-              json_schema: {
-                name: "review_plan",
-                schema: REVIEW_PLAN_JSON_SCHEMA,
-                strict: true,
-              },
+      const response = await postProviderJson(
+        chatUrl,
+        headers(settings.apiKey),
+        {
+          model: settings.model,
+          stream: true,
+          messages: [
+            { role: "system", content: SYSTEM_PROMPT },
+            { role: "user", content: buildUserPrompt(diff, prContext) },
+          ],
+          response_format: {
+            type: "json_schema",
+            json_schema: {
+              name: "review_plan",
+              schema: REVIEW_PLAN_JSON_SCHEMA,
+              strict: true,
             },
-          }),
-          signal: options?.signal,
-        });
-      } catch (error) {
-        if (isAbortError(error)) throw error;
-        throw new ProviderError(
-          error instanceof Error ? error.message : `Failed to reach the ${displayName} API.`,
-        );
-      }
-
-      if (!response.ok) {
-        const detail = await parseProviderHttpError(response);
-        throw new ProviderError(detail.message, {
-          statusCode: response.status,
-          code: detail.code,
-        });
-      }
+          },
+        },
+        displayName,
+        options?.signal,
+      );
 
       if (!response.body) {
         throw new ProviderError(`${displayName} returned an empty stream.`);
@@ -101,35 +84,16 @@ export function createOpenAICompatibleProvider(
     },
 
     async testConnection(settings: ProviderSettings): Promise<void> {
-      let response: Response;
-      try {
-        response = await fetch(chatUrl, {
-          method: "POST",
-          headers: {
-            "content-type": "application/json",
-            authorization: `Bearer ${settings.apiKey}`,
-          },
-          body: JSON.stringify({
-            model: settings.model,
-            max_tokens: 8,
-            messages: [{ role: "user", content: "Reply with OK." }],
-          }),
-        });
-      } catch (error) {
-        // Same wrapping as the streaming path: a bare fetch rejection would
-        // surface as "Failed to fetch" with no hint of which provider failed.
-        throw new ProviderError(
-          error instanceof Error ? error.message : `Failed to reach the ${displayName} API.`,
-        );
-      }
-
-      if (!response.ok) {
-        const detail = await parseProviderHttpError(response);
-        throw new ProviderError(detail.message, {
-          statusCode: response.status,
-          code: detail.code,
-        });
-      }
+      await postProviderJson(
+        chatUrl,
+        headers(settings.apiKey),
+        {
+          model: settings.model,
+          max_tokens: 8,
+          messages: [{ role: "user", content: "Reply with OK." }],
+        },
+        displayName,
+      );
     },
   };
 }

--- a/apps/extension/src/background/providers/sse.test.ts
+++ b/apps/extension/src/background/providers/sse.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { readSseJsonStream } from "./sse";
+
+/** Build a ReadableStream that emits each string as one chunk, as the network would. */
+function streamOf(...chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
+async function collect(stream: ReadableStream<Uint8Array>, signal?: AbortSignal) {
+  const out: unknown[] = [];
+  for await (const event of readSseJsonStream(stream, { signal })) out.push(event);
+  return out;
+}
+
+describe("readSseJsonStream", () => {
+  it("yields parsed JSON from each data line", async () => {
+    const events = await collect(streamOf('data: {"a":1}\n', 'data: {"a":2}\n'));
+
+    expect(events).toEqual([{ a: 1 }, { a: 2 }]);
+  });
+
+  it("reassembles a frame split across chunk boundaries", async () => {
+    // Providers routinely split a single SSE frame mid-token.
+    const events = await collect(streamOf('data: {"text":"hel', 'lo"}\n'));
+
+    expect(events).toEqual([{ text: "hello" }]);
+  });
+
+  it("stops at [DONE] and ignores anything after it", async () => {
+    const events = await collect(streamOf('data: {"a":1}\n', "data: [DONE]\n", 'data: {"a":2}\n'));
+
+    expect(events).toEqual([{ a: 1 }]);
+  });
+
+  it("handles CRLF line endings", async () => {
+    const events = await collect(streamOf('data: {"a":1}\r\ndata: {"a":2}\r\n'));
+
+    expect(events).toEqual([{ a: 1 }, { a: 2 }]);
+  });
+
+  it("skips comments, event names, and blank lines", async () => {
+    const events = await collect(
+      streamOf(": keep-alive\n", "event: message\n", "\n", 'data: {"a":1}\n'),
+    );
+
+    expect(events).toEqual([{ a: 1 }]);
+  });
+
+  it("skips a malformed data line rather than aborting the stream", async () => {
+    const events = await collect(streamOf("data: {not json}\n", 'data: {"a":1}\n'));
+
+    expect(events).toEqual([{ a: 1 }]);
+  });
+
+  it("flushes a trailing data line that never got a final newline", async () => {
+    const events = await collect(streamOf('data: {"a":1}\n', 'data: {"a":2}'));
+
+    expect(events).toEqual([{ a: 1 }, { a: 2 }]);
+  });
+
+  it("throws AbortError when the signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(collect(streamOf('data: {"a":1}\n'), controller.signal)).rejects.toMatchObject({
+      name: "AbortError",
+    });
+  });
+});

--- a/apps/extension/src/content/index.test.tsx
+++ b/apps/extension/src/content/index.test.tsx
@@ -1,0 +1,188 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChromeMock, MockPort } from "../test/chromeMock";
+import type { FetchDiffResponse, ParsedDiff } from "../lib/types";
+import { setProviderSettings } from "../lib/settings";
+import { useReviewStore } from "./overlay/store";
+
+// The overlay itself is covered by Overlay.test.tsx; these tests are about the
+// start/restore/no-provider orchestration, so keep rendering out of the way.
+vi.mock("./overlay/styles/overlay.css?inline", () => ({ default: "" }));
+vi.mock("./overlay/Overlay", () => ({ Overlay: () => null }));
+
+const PR_URL = "https://github.com/acme/web/pull/42";
+const SESSION_KEY = "guidedReview.session.acme/web#42";
+
+function diffFixture(): ParsedDiff {
+  return {
+    files: [
+      {
+        path: "src/foo.ts",
+        status: "modified",
+        isBinaryOrElided: false,
+        hunks: [
+          {
+            id: "src/foo.ts#0",
+            header: "@@ -1,1 +1,1 @@",
+            oldStart: 1,
+            oldLines: 1,
+            newStart: 1,
+            newLines: 1,
+            lines: [{ type: "add", content: "const a = 1;", newLine: 1 }],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function chromeMock(): ChromeMock {
+  return globalThis.chrome as unknown as ChromeMock;
+}
+
+/** Answer FETCH_DIFF with `response`; every other message resolves undefined. */
+function stubDiffResponse(response: FetchDiffResponse | { ok: false; error: string }): void {
+  chromeMock().runtime.sendMessage.mockImplementation(async (message: unknown) => {
+    if ((message as { type?: string })?.type === "FETCH_DIFF") return response;
+    return undefined;
+  });
+}
+
+/**
+ * The content script registers its onMessage listener as an import-time side
+ * effect, but `src/test/setup.ts` installs a fresh chrome mock before every
+ * test — so capture the listeners from the one import and reuse them. Their
+ * bodies read `chrome.*` at call time, which resolves to the current mock.
+ */
+let messageListeners: MessageListener[] | null = null;
+
+type MessageListener = (
+  message: unknown,
+  sender: unknown,
+  sendResponse: (response?: unknown) => void,
+) => boolean | void;
+
+async function loadContentScript(): Promise<MessageListener[]> {
+  if (!messageListeners) {
+    await import("./index");
+    messageListeners = [...chromeMock().runtime.onMessage.__listeners] as MessageListener[];
+  }
+  return messageListeners;
+}
+
+/** Fire START_GUIDED_REVIEW at the content script and wait for the flow to settle. */
+async function startReview(): Promise<void> {
+  const listeners = await loadContentScript();
+  for (const listener of listeners) {
+    listener({ type: "START_GUIDED_REVIEW" }, {}, () => {});
+  }
+  // Let the awaited storage reads / diff fetch inside onStartReview settle.
+  await vi.waitFor(() => {
+    expect(useReviewStore.getState().status).not.toBe("loading");
+  });
+}
+
+describe("content script review orchestration", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: new URL(PR_URL),
+    });
+    // The description scrape falls back to fetching the Conversation tab.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("", { status: 404 })),
+    );
+    useReviewStore.setState({
+      status: "idle",
+      error: null,
+      needsProvider: false,
+      diff: null,
+      plan: null,
+      prContext: null,
+      currentUnitIndex: 0,
+      sessionKey: null,
+      draftComments: [],
+    });
+    stubDiffResponse({ ok: true, diff: diffFixture() });
+  });
+
+  afterEach(async () => {
+    document.body.replaceChildren();
+    await Promise.resolve();
+  });
+
+  afterAll(async () => {
+    // The content script observes document.body for the lifetime of the module.
+    // Swap in a fresh, unobserved body so teardown mutations don't re-enter
+    // tryInjectButton after jsdom has torn `window` down.
+    document.documentElement.replaceChild(document.createElement("body"), document.body);
+    await Promise.resolve();
+  });
+
+  it("streams an AI plan when a provider is configured and there is no saved session", async () => {
+    await setProviderSettings({ provider: "anthropic", model: "claude-opus-4-8", apiKey: "sk-1" });
+
+    await startReview();
+
+    const state = useReviewStore.getState();
+    expect(state.status).toBe("streaming");
+    expect(state.diff?.files[0].path).toBe("src/foo.ts");
+    expect(state.sessionKey).toBe("acme/web#42");
+    expect(state.needsProvider).toBe(false);
+
+    // The annotate port is opened and handed the diff to work on.
+    expect(chromeMock().runtime.connect).toHaveBeenCalledWith({ name: "annotate-review" });
+    const port = chromeMock().runtime.connect.mock.results.at(-1)?.value as MockPort;
+    expect(port.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "ANNOTATE_REVIEW" }),
+    );
+  });
+
+  it("falls back to a file-per-unit plan when no provider key is configured", async () => {
+    await setProviderSettings({ provider: "anthropic", model: "claude-opus-4-8", apiKey: "" });
+
+    await startReview();
+
+    const state = useReviewStore.getState();
+    expect(state.needsProvider).toBe(true);
+    expect(state.status).toBe("ready");
+    expect(state.plan?.units.map((u) => u.title)).toEqual(["src/foo.ts"]);
+    // No provider means no annotate call at all.
+    expect(chromeMock().runtime.connect).not.toHaveBeenCalled();
+  });
+
+  it("restores a saved session instead of refetching the diff", async () => {
+    await setProviderSettings({ provider: "anthropic", model: "claude-opus-4-8", apiKey: "sk-1" });
+    await chrome.storage.session.set({
+      [SESSION_KEY]: {
+        diff: diffFixture(),
+        plan: { units: [{ id: "u1", title: "Saved unit", context: "why", files: [] }] },
+        prContext: null,
+        currentUnitIndex: 1,
+        draftComments: [],
+      },
+    });
+
+    await startReview();
+
+    const state = useReviewStore.getState();
+    expect(state.status).toBe("ready");
+    expect(state.plan?.units[0].title).toBe("Saved unit");
+    expect(state.currentUnitIndex).toBe(1);
+    expect(chromeMock().runtime.sendMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "FETCH_DIFF" }),
+    );
+  });
+
+  it("surfaces a diff fetch failure as an error state", async () => {
+    await setProviderSettings({ provider: "anthropic", model: "claude-opus-4-8", apiKey: "sk-1" });
+    stubDiffResponse({ ok: false, error: "Could not fetch the diff for this PR (HTTP 404)." });
+
+    await startReview();
+
+    const state = useReviewStore.getState();
+    expect(state.status).toBe("error");
+    expect(state.error?.message).toContain("HTTP 404");
+    expect(chromeMock().runtime.connect).not.toHaveBeenCalled();
+  });
+});

--- a/apps/extension/src/content/index.tsx
+++ b/apps/extension/src/content/index.tsx
@@ -49,8 +49,8 @@ function init(): void {
   tryInjectButton();
   void hydrateAutoOpenPreference();
 
-  // Toolbar icon click is handled in the background worker; when the active
-  // tab is a PR page it forwards START_GUIDED_REVIEW here.
+  // The toolbar icon opens the action popup (`src/popup/`); when the active tab
+  // is a PR page it sends START_GUIDED_REVIEW here instead of rendering.
   chrome.runtime.onMessage.addListener((message: ContentRequest) => {
     if (message?.type === "START_GUIDED_REVIEW") {
       void onStartReview();
@@ -269,10 +269,6 @@ async function onStartReview(): Promise<void> {
   const streamGeneration = useReviewStore.getState().streamGeneration;
 
   try {
-    // Checked before the restore so a resumed session still knows whether the
-    // AI features are available.
-    const hasProvider = Boolean((await getProviderSettings()).apiKey);
-
     const restored = await restoreSession(sessionKey);
     if (restored) return;
 
@@ -293,7 +289,9 @@ async function onStartReview(): Promise<void> {
         });
     }
 
-    const diffResponse = await requestPRDiff(pr);
+    // Neither depends on the other, and the provider check only matters once
+    // the diff has landed — so pay for one round-trip, not two.
+    const [diffResponse, settings] = await Promise.all([requestPRDiff(pr), getProviderSettings()]);
     if (!diffResponse.ok) {
       useReviewStore.getState().setError(diffResponse.error, streamGeneration);
       return;
@@ -306,7 +304,7 @@ async function onStartReview(): Promise<void> {
 
     // Without a provider there's no plan to stream: fall back to one unit per
     // changed file so the diff, comments and submit flow all still work.
-    if (!hasProvider) {
+    if (!settings.apiKey) {
       useReviewStore.getState().setNeedsProvider();
       return;
     }

--- a/apps/extension/src/content/overlay/Overlay.test.tsx
+++ b/apps/extension/src/content/overlay/Overlay.test.tsx
@@ -1024,6 +1024,19 @@ describe("Overlay", () => {
       expect(screen.getByTestId("diff-view-split")).toBeInTheDocument();
     });
 
+    it("disarms a pending v when an unrelated key lands inside the chord window", () => {
+      seedReadyReview(1);
+      render(<Overlay />);
+
+      fireEvent.keyDown(window, { key: "v" });
+      // Unrelated key: consumes the leader rather than staying armed for it.
+      fireEvent.keyDown(window, { key: "x" });
+      fireEvent.keyDown(window, { key: "u" });
+
+      expect(useReviewStore.getState().diffViewMode).toBe("split");
+      expect(screen.getByTestId("diff-view-split")).toBeInTheDocument();
+    });
+
     it("does not switch when the second key arrives after the chord window", () => {
       vi.useFakeTimers();
       try {

--- a/apps/extension/src/content/overlay/Overlay.test.tsx
+++ b/apps/extension/src/content/overlay/Overlay.test.tsx
@@ -4,7 +4,6 @@ import { Overlay } from "./Overlay";
 import { resetConfirmationQueueForTests } from "./components/confirmation";
 import { DEFAULT_DIFF_VIEW_MODE } from "./diffViewMode";
 import { useReviewStore } from "./store";
-import { PR_DESCRIPTION_UNIT_TITLE } from "./displayUnits";
 import { VIEW_CHORD_WINDOW_MS } from "./viewModeChord";
 import { buildFileReviewPlan } from "../../lib/review/fileReviewPlan";
 import type { ParsedDiff, PRContext, ReviewPlan } from "../../lib/types";
@@ -157,7 +156,7 @@ describe("Overlay", () => {
     render(<Overlay />);
 
     // Title in left pane + entry in the unit list.
-    expect(screen.getAllByText(PR_DESCRIPTION_UNIT_TITLE).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("PR Description").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("This PR adds a feature.")).toBeInTheDocument();
     expect(screen.getByText(/building remaining units/i)).toBeInTheDocument();
     expect(screen.getByRole("status", { name: /building remaining units/i })).toBeInTheDocument();
@@ -258,7 +257,7 @@ describe("Overlay", () => {
     expect(screen.getByTestId("error-message")).toHaveTextContent("Invalid API key");
     expect(screen.getByTestId("error-status-code")).toHaveTextContent("401");
     expect(screen.getByTestId("error-code")).toHaveTextContent("authentication_error");
-    expect(screen.getAllByText(PR_DESCRIPTION_UNIT_TITLE).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("PR Description").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("This PR adds a feature.")).toBeInTheDocument();
 
     screen.getByRole("button", { name: /^retry$/i }).click();
@@ -285,7 +284,7 @@ describe("Overlay", () => {
     expect(screen.queryAllByTestId("unit-skeleton")).toHaveLength(0);
 
     // Description unit still shows the PR body and the Changes summary.
-    expect(screen.getAllByText(PR_DESCRIPTION_UNIT_TITLE).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("PR Description").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("This PR adds a feature.")).toBeInTheDocument();
     expect(screen.getByLabelText(/diff summary/i)).toBeInTheDocument();
 
@@ -340,7 +339,7 @@ describe("Overlay", () => {
       currentUnitIndex: 0,
     });
     render(<Overlay />);
-    expect(screen.getAllByText(PR_DESCRIPTION_UNIT_TITLE).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("PR Description").length).toBeGreaterThanOrEqual(1);
     expect(screen.queryByText(/no review units were generated/i)).not.toBeInTheDocument();
   });
 
@@ -354,7 +353,7 @@ describe("Overlay", () => {
       currentUnitIndex: 1,
     });
     render(<Overlay />);
-    expect(screen.getAllByText(PR_DESCRIPTION_UNIT_TITLE).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("PR Description").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByTestId("diff-unit-title")).toHaveTextContent("Update foo");
     expect(screen.getByText("because it needed updating")).toBeInTheDocument();
   });

--- a/apps/extension/src/content/overlay/Overlay.tsx
+++ b/apps/extension/src/content/overlay/Overlay.tsx
@@ -174,7 +174,6 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
     currentUnitId,
     submitReviewOpen,
     connectGitHubOpen,
-    submittingReview,
     submitSuccess,
     submitReviewActionRef,
     submitReviewKeyRef,
@@ -262,6 +261,7 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
               files={resolvedFiles}
               unitTitle={currentReviewUnit?.title ?? ""}
               unitId={currentReviewUnit?.id}
+              selectableForUnit={selectableForUnit}
             />
           )}
         </main>

--- a/apps/extension/src/content/overlay/commentTypes.ts
+++ b/apps/extension/src/content/overlay/commentTypes.ts
@@ -58,13 +58,6 @@ export function displayLineNumber(line: SelectableLine): number | undefined {
   return line.side === "LEFT" ? line.oldLine : line.newLine;
 }
 
-export function selectionBounds(sel: LineSelection): { start: number; end: number } {
-  return {
-    start: Math.min(sel.anchorIndex, sel.focusIndex),
-    end: Math.max(sel.anchorIndex, sel.focusIndex),
-  };
-}
-
 /**
  * Lines included in the current selection: same file + side as the anchor,
  * with flat indices between anchor and focus (inclusive).
@@ -73,7 +66,8 @@ export function linesInSelection(lines: SelectableLine[], sel: LineSelection): S
   if (lines.length === 0) return [];
   const anchor = lines[sel.anchorIndex];
   if (!anchor) return [];
-  const { start, end } = selectionBounds(sel);
+  const start = Math.min(sel.anchorIndex, sel.focusIndex);
+  const end = Math.max(sel.anchorIndex, sel.focusIndex);
   return lines
     .slice(start, end + 1)
     .filter((l) => l.filePath === anchor.filePath && l.side === anchor.side);

--- a/apps/extension/src/content/overlay/components/ConnectGitHubModal.test.tsx
+++ b/apps/extension/src/content/overlay/components/ConnectGitHubModal.test.tsx
@@ -11,7 +11,10 @@ vi.mock("../../../lib/messaging", () => ({
   pollGitHubDeviceAuth: vi.fn(),
 }));
 
-vi.mock("../../../lib/github/oauthConfig", () => ({
+// Only the configured check is stubbed — the copy constants come from the real
+// module so a wording/name change is caught here rather than mocked away.
+vi.mock("../../../lib/github/oauthConfig", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../lib/github/oauthConfig")>()),
   isGitHubOAuthConfigured: vi.fn(() => true),
 }));
 

--- a/apps/extension/src/content/overlay/components/ConnectGitHubModal.tsx
+++ b/apps/extension/src/content/overlay/components/ConnectGitHubModal.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useId, useRef, useState, type MutableRefObject } from "react";
-import { isGitHubOAuthConfigured } from "../../../lib/github/oauthConfig";
+import { useEffect, useId, useRef, type MutableRefObject } from "react";
+import { GITHUB_CLIENT_ID_ENV_VAR, isGitHubOAuthConfigured } from "../../../lib/github/oauthConfig";
+import { useCopyToClipboard } from "../../../lib/useCopyToClipboard";
 import { openVerificationUri, useGitHubDeviceAuth } from "../../../lib/github/useGitHubDeviceAuth";
 import { CloseButton } from "./CloseButton";
 import { Button, Kbd, Spinner } from "@guided-review/ui";
@@ -50,7 +51,7 @@ export function ConnectGitHubModal({
 }: ConnectGitHubModalProps) {
   const titleId = useId();
   const configured = isGitHubOAuthConfigured();
-  const [copied, setCopied] = useState(false);
+  const { copied, copy: copyUserCode, resetCopied } = useCopyToClipboard();
   const connectButtonRef = useRef<HTMLButtonElement>(null);
 
   const { flow, busy, startConnect, cancel, reset } = useGitHubDeviceAuth({
@@ -64,9 +65,9 @@ export function ConnectGitHubModal({
   useEffect(() => {
     if (!open) {
       reset();
-      setCopied(false);
+      resetCopied();
     }
-  }, [open, reset]);
+  }, [open, reset, resetCopied]);
 
   useEffect(() => {
     if (!open) return;
@@ -110,18 +111,8 @@ export function ConnectGitHubModal({
 
   const onCancel = () => {
     cancel();
-    setCopied(false);
+    resetCopied();
     onClose();
-  };
-
-  const onCopyCode = async (code: string) => {
-    try {
-      await navigator.clipboard.writeText(code);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 2000);
-    } catch {
-      setCopied(false);
-    }
   };
 
   return (
@@ -160,7 +151,7 @@ export function ConnectGitHubModal({
           >
             GitHub connection isn’t configured in this build. Set{" "}
             <code className="rounded bg-gr-bg px-1 py-0.5 text-sm text-gr-text">
-              VITE_GITHUB_CLIENT_ID
+              {GITHUB_CLIENT_ID_ENV_VAR}
             </code>{" "}
             and rebuild.
           </p>
@@ -185,7 +176,7 @@ export function ConnectGitHubModal({
                 surface="overlay"
                 variant="secondary"
                 size="sm"
-                onClick={() => void onCopyCode(flow.userCode)}
+                onClick={() => void copyUserCode(flow.userCode)}
                 data-testid="connect-github-copy-code"
               >
                 {copied ? "Copied" : "Copy Code"}

--- a/apps/extension/src/content/overlay/components/ContextPanel.tsx
+++ b/apps/extension/src/content/overlay/components/ContextPanel.tsx
@@ -4,8 +4,6 @@ import { KeyboardShortcuts } from "./KeyboardShortcuts";
 import { Button, Spinner } from "@guided-review/ui";
 import { missingMetadataHint, PR_DESCRIPTION_HINT } from "../missingMetadata";
 
-export { missingMetadataHint, PR_DESCRIPTION_HINT } from "../missingMetadata";
-
 interface ContextPanelProps {
   /** When null, the synthetic PR-description unit is active. */
   unit: ReviewUnit | null;

--- a/apps/extension/src/content/overlay/components/DiffPane.test.tsx
+++ b/apps/extension/src/content/overlay/components/DiffPane.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { sha256Hex } from "../../../lib/github/prFileDiffUrl";
 import type { DiffFile, DiffHunk, PRContext } from "../../../lib/types";
+import { buildSelectableLines } from "../buildSelectableLines";
 import { DEFAULT_DIFF_VIEW_MODE } from "../diffViewMode";
 import { resetDiffViewModeHydrationForTests, useReviewStore } from "../store";
 import type { ResolvedUnitFile } from "../selectors";
@@ -84,9 +85,21 @@ describe("DiffPane", () => {
     resetStore();
   });
 
-  function renderPane(files = resolvedFiles(), unitTitle = "Update foo") {
-    return render(<DiffPane files={files} unitTitle={unitTitle} />);
+  function renderPane(
+    files = resolvedFiles(),
+    unitTitle = "Update foo",
+    selectableForUnit = buildSelectableLines(files, useReviewStore.getState().diffViewMode),
+  ) {
+    return render(
+      <DiffPane files={files} unitTitle={unitTitle} selectableForUnit={selectableForUnit} />,
+    );
   }
+
+  it("disables the add-comment button when the unit has no selectable lines", () => {
+    renderPane(resolvedFiles(), "Update foo", []);
+
+    expect(screen.getByTestId("enter-comment-mode")).toBeDisabled();
+  });
 
   it("renders the unit title on the left and the toggle on the right", async () => {
     renderPane(resolvedFiles(), "Wire up the new auth path");

--- a/apps/extension/src/content/overlay/components/DiffPane.test.tsx
+++ b/apps/extension/src/content/overlay/components/DiffPane.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { sha256Hex } from "../../../lib/github/prFileDiffUrl";
+import { buildPRFileDiffUrl } from "../../../lib/github/prFileDiffUrl";
 import type { DiffFile, DiffHunk, PRContext } from "../../../lib/types";
 import { buildSelectableLines } from "../buildSelectableLines";
 import { DEFAULT_DIFF_VIEW_MODE } from "../diffViewMode";
@@ -231,7 +231,10 @@ describe("DiffPane", () => {
 
   it("links binary/elided files to the GitHub Files changed deep link", async () => {
     const filePath = "assets/logo.png";
-    const expectedHex = await sha256Hex(filePath);
+    const expectedHref = await buildPRFileDiffUrl(
+      { owner: "acme", repo: "widgets", number: 42 },
+      filePath,
+    );
     useReviewStore.setState({ prContext: prContextFixture() });
     const file = fileFixture({
       path: filePath,
@@ -244,10 +247,7 @@ describe("DiffPane", () => {
     // URL is built async via crypto.subtle — wait for the link to appear.
     const link = await screen.findByTestId("binary-elided-github-link");
 
-    expect(link).toHaveAttribute(
-      "href",
-      `https://github.com/acme/widgets/pull/42/files#diff-${expectedHex}`,
-    );
+    expect(link).toHaveAttribute("href", expectedHref);
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
     expect(link).toHaveTextContent("View File Diff on GitHub");

--- a/apps/extension/src/content/overlay/components/DiffPane.tsx
+++ b/apps/extension/src/content/overlay/components/DiffPane.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useMemo, useRef } from "react";
 
 import { languageForPath } from "../../../lib/highlight";
-import { buildSelectableLines } from "../buildSelectableLines";
-import { displayLineNumber, linesInSelection } from "../commentTypes";
+import { displayLineNumber, linesInSelection, type SelectableLine } from "../commentTypes";
 import { hydrateDiffViewMode, useReviewStore } from "../store";
 import type { ResolvedUnitFile } from "../selectors";
 import { AddCommentButton, CommentModeChip, DiffViewToggle } from "./diff/DiffToolbar";
@@ -17,9 +16,15 @@ interface DiffPaneProps {
   unitTitle: string;
   /** Review unit id for associating saved drafts. */
   unitId?: string;
+  /**
+   * Flat selectable-line list for `files` in the active view mode. Owned by
+   * Overlay (which also feeds it to the keyboard handler) so entering comment
+   * mode from the button and from `c` always operate on the same list.
+   */
+  selectableForUnit: SelectableLine[];
 }
 
-export function DiffPane({ files, unitTitle, unitId }: DiffPaneProps) {
+export function DiffPane({ files, unitTitle, unitId, selectableForUnit }: DiffPaneProps) {
   const diffViewMode = useReviewStore((s) => s.diffViewMode);
   const setDiffViewMode = useReviewStore((s) => s.setDiffViewMode);
   const uiMode = useReviewStore((s) => s.uiMode);
@@ -33,11 +38,6 @@ export function DiffPane({ files, unitTitle, unitId }: DiffPaneProps) {
   useEffect(() => {
     void hydrateDiffViewMode();
   }, []);
-
-  const unitSelectableLines = useMemo(
-    () => buildSelectableLines(files, diffViewMode),
-    [files, diffViewMode],
-  );
 
   const filePaths = useMemo(() => new Set(files.map((f) => f.file.path)), [files]);
 
@@ -58,12 +58,12 @@ export function DiffPane({ files, unitTitle, unitId }: DiffPaneProps) {
   }, [uiMode, focusId, lineSelection?.focusIndex]);
 
   const commentModeActive = uiMode === "comment";
-  const commentModeDisabled = unitSelectableLines.length === 0;
+  const commentModeDisabled = selectableForUnit.length === 0;
 
   // Announce focused/selected lines so comment mode is not color-only (1.4.1 / 4.1.3).
   const selectionAnnouncement = useMemo(() => {
     if (uiMode !== "comment" || !lineSelection) return "";
-    const lines = selectableLines.length > 0 ? selectableLines : unitSelectableLines;
+    const lines = selectableLines.length > 0 ? selectableLines : selectableForUnit;
     const focused = lines[lineSelection.focusIndex];
     if (!focused) return "Comment mode. No line focused.";
     const selected = linesInSelection(lines, lineSelection);
@@ -76,7 +76,7 @@ export function DiffPane({ files, unitTitle, unitId }: DiffPaneProps) {
       return `Comment mode. ${focused.filePath}, lines ${start ?? "?"} to ${end ?? "?"} selected.`;
     }
     return `Comment mode. ${focused.filePath}, line ${focusNum ?? "?"}.`;
-  }, [uiMode, lineSelection, selectableLines, unitSelectableLines]);
+  }, [uiMode, lineSelection, selectableLines, selectableForUnit]);
 
   return (
     <div ref={rootRef}>
@@ -103,7 +103,7 @@ export function DiffPane({ files, unitTitle, unitId }: DiffPaneProps) {
           ) : (
             <AddCommentButton
               disabled={commentModeDisabled}
-              onEnter={() => enterCommentMode(unitSelectableLines)}
+              onEnter={() => enterCommentMode(selectableForUnit)}
             />
           )}
           <DiffViewToggle mode={diffViewMode} onChange={setDiffViewMode} />

--- a/apps/extension/src/content/overlay/components/confirmation.test.tsx
+++ b/apps/extension/src/content/overlay/components/confirmation.test.tsx
@@ -4,7 +4,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ConfirmationHost,
   confirm,
-  confirmationHandlesKey,
   getConfirmationDialogElement,
   isConfirmationOpen,
   resetConfirmationQueueForTests,
@@ -18,11 +17,17 @@ function OpenProbe() {
 
 describe("confirmation", () => {
   beforeEach(() => {
-    resetConfirmationQueueForTests();
+    // Notify subscribers (ConfirmationHost) under act so residual queue state
+    // never re-renders outside React's test act boundary.
+    act(() => {
+      resetConfirmationQueueForTests();
+    });
   });
 
   afterEach(() => {
-    resetConfirmationQueueForTests();
+    act(() => {
+      resetConfirmationQueueForTests();
+    });
   });
 
   it("does not throw when confirm is called without a host", () => {
@@ -245,7 +250,14 @@ describe("confirmation", () => {
     consoleError.mockRestore();
   });
 
-  it("handles Enter as OK and Escape as cancel via confirmationHandlesKey", async () => {
+  /** Dispatch a real window keydown, the way the browser delivers one. */
+  function pressKey(init: KeyboardEventInit): void {
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, ...init }));
+    });
+  }
+
+  it("handles Enter as OK and Escape as cancel", async () => {
     const okButtonHandler = vi.fn();
     const cancelButtonHandler = vi.fn();
     render(<ConfirmationHost />);
@@ -262,10 +274,7 @@ describe("confirmation", () => {
     await screen.findByTestId("confirmation-dialog");
     expect(getConfirmationDialogElement()).toBeInstanceOf(HTMLElement);
 
-    act(() => {
-      const handled = confirmationHandlesKey(new KeyboardEvent("keydown", { key: "Escape" }));
-      expect(handled).toBe(true);
-    });
+    pressKey({ key: "Escape" });
 
     await waitFor(() => {
       expect(cancelButtonHandler).toHaveBeenCalledTimes(1);
@@ -282,10 +291,7 @@ describe("confirmation", () => {
 
     await screen.findByTestId("confirmation-dialog");
 
-    act(() => {
-      const handled = confirmationHandlesKey(new KeyboardEvent("keydown", { key: "Enter" }));
-      expect(handled).toBe(true);
-    });
+    pressKey({ key: "Enter" });
 
     await waitFor(() => {
       expect(okButtonHandler).toHaveBeenCalledTimes(1);
@@ -306,17 +312,31 @@ describe("confirmation", () => {
 
     await screen.findByTestId("confirmation-dialog");
 
-    act(() => {
-      expect(
-        confirmationHandlesKey(new KeyboardEvent("keydown", { key: "Enter", metaKey: true })),
-      ).toBe(false);
-      expect(
-        confirmationHandlesKey(new KeyboardEvent("keydown", { key: "Enter", ctrlKey: true })),
-      ).toBe(false);
-    });
+    pressKey({ key: "Enter", metaKey: true });
+    pressKey({ key: "Enter", ctrlKey: true });
+    pressKey({ key: "Enter", altKey: true });
 
     expect(okButtonHandler).not.toHaveBeenCalled();
     expect(screen.getByTestId("confirmation-dialog")).toBeInTheDocument();
+  });
+
+  it("runs the handler only once when Enter is pressed repeatedly", async () => {
+    const okButtonHandler = vi.fn();
+    render(<ConfirmationHost />);
+
+    act(() => {
+      confirm({ title: "Once", body: "Only once", okButtonHandler });
+    });
+
+    await screen.findByTestId("confirmation-dialog");
+
+    pressKey({ key: "Enter" });
+    pressKey({ key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("confirmation-dialog")).not.toBeInTheDocument();
+    });
+    expect(okButtonHandler).toHaveBeenCalledTimes(1);
   });
 
   it("useConfirmationOpen tracks queue state", async () => {

--- a/apps/extension/src/content/overlay/components/confirmation.tsx
+++ b/apps/extension/src/content/overlay/components/confirmation.tsx
@@ -36,8 +36,6 @@ const queueListeners = new Set<() => void>();
 const openListeners = new Set<() => void>();
 
 let dialogElement: HTMLElement | null = null;
-let okAction: (() => void) | null = null;
-let cancelAction: (() => void) | null = null;
 
 function notifyQueue(): void {
   for (const l of queueListeners) l();
@@ -120,33 +118,11 @@ export function getConfirmationDialogElement(): HTMLElement | null {
   return dialogElement;
 }
 
-/**
- * Handle overlay-level keyboard when a confirmation is open.
- * Returns true if the event was consumed (caller should preventDefault / return).
- */
-export function confirmationHandlesKey(event: KeyboardEvent): boolean {
-  if (confirmationQueue.length === 0) return false;
-
-  if (event.key === "Escape") {
-    cancelAction?.();
-    return true;
-  }
-
-  if (event.key === "Enter" && !event.metaKey && !event.ctrlKey && !event.altKey) {
-    okAction?.();
-    return true;
-  }
-
-  return false;
-}
-
 /** Test helper: drain the queue without running handlers. */
 export function resetConfirmationQueueForTests(): void {
   const hadItems = confirmationQueue.length > 0;
   confirmationQueue = [];
   dialogElement = null;
-  okAction = null;
-  cancelAction = null;
   // Only notify when something was cleared — avoids noisy re-renders in parallel tests.
   if (hadItems) {
     notifyQueue();
@@ -191,6 +167,7 @@ function ConfirmationDialog({
   cancelHandlerRef.current = cancelButtonHandler;
   onCloseRef.current = onClose;
 
+  /** Set once the dialog has resolved, so a second Enter/Esc can't re-run a handler. */
   const settledRef = useRef(false);
 
   const handleOk = useCallback(async () => {
@@ -220,24 +197,19 @@ function ConfirmationDialog({
     onCloseRef.current();
   }, []);
 
-  // Register dialog + actions for overlay keyboard / Tab trap.
+  // Register the panel element for the overlay's Tab focus trap.
   useEffect(() => {
-    dialogElement = dialogRef.current;
-    okAction = () => {
-      void handleOk();
-    };
-    cancelAction = () => {
-      void handleCancel();
-    };
+    const panel = dialogRef.current;
+    dialogElement = panel;
     return () => {
-      if (dialogElement === dialogRef.current) dialogElement = null;
-      okAction = null;
-      cancelAction = null;
+      // Only clear if a newer dialog hasn't already claimed the slot.
+      if (dialogElement === panel) dialogElement = null;
     };
-  }, [handleOk, handleCancel]);
+  }, []);
 
-  // Own capture listener so Enter/Esc work outside the overlay (e.g. options page).
-  // Overlay also routes keys via confirmationHandlesKey; settledRef prevents double-fire.
+  // Sole Enter/Esc handler for the dialog. Capture phase so it works both under
+  // the overlay (which stops propagation on every key) and on the options page,
+  // where there is no overlay keyboard at all.
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent): void {
       if (event.key === "Escape") {

--- a/apps/extension/src/content/overlay/diffViewMode.ts
+++ b/apps/extension/src/content/overlay/diffViewMode.ts
@@ -1,29 +1,21 @@
+import { readLocal, writeLocal } from "../../lib/storage";
+
 export type DiffViewMode = "unified" | "split";
 
 export const DEFAULT_DIFF_VIEW_MODE: DiffViewMode = "split";
 
 const STORAGE_KEY = "guidedReview.diffViewMode";
 
-function isDiffViewMode(value: unknown): value is DiffViewMode {
-  return value === "unified" || value === "split";
+function parseMode(raw: unknown): DiffViewMode {
+  return raw === "unified" || raw === "split" ? raw : DEFAULT_DIFF_VIEW_MODE;
 }
 
 /** Read the saved diff view mode from chrome.storage.local. */
-export async function getStoredDiffViewMode(): Promise<DiffViewMode> {
-  try {
-    const result = await chrome.storage.local.get(STORAGE_KEY);
-    const stored = result[STORAGE_KEY];
-    return isDiffViewMode(stored) ? stored : DEFAULT_DIFF_VIEW_MODE;
-  } catch {
-    return DEFAULT_DIFF_VIEW_MODE;
-  }
+export function getStoredDiffViewMode(): Promise<DiffViewMode> {
+  return readLocal(STORAGE_KEY, parseMode);
 }
 
 /** Persist the diff view mode. Failures are non-fatal. */
-export async function setStoredDiffViewMode(mode: DiffViewMode): Promise<void> {
-  try {
-    await chrome.storage.local.set({ [STORAGE_KEY]: mode });
-  } catch (error) {
-    console.warn("Guided Review: failed to persist diff view mode", error);
-  }
+export function setStoredDiffViewMode(mode: DiffViewMode): Promise<void> {
+  return writeLocal(STORAGE_KEY, mode);
 }

--- a/apps/extension/src/content/overlay/displayUnits.test.ts
+++ b/apps/extension/src/content/overlay/displayUnits.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  PR_DESCRIPTION_UNIT_ID,
-  PR_DESCRIPTION_UNIT_TITLE,
-  buildDisplayUnits,
-  displayUnitCount,
-} from "./displayUnits";
+import { buildDisplayUnits, displayUnitCount } from "./displayUnits";
 import type { ReviewPlan } from "../../lib/types";
 
 const plan: ReviewPlan = {
@@ -17,7 +12,7 @@ const plan: ReviewPlan = {
 describe("displayUnits", () => {
   it("always includes the PR description unit first", () => {
     expect(buildDisplayUnits(null)).toEqual([
-      { kind: "pr_description", id: PR_DESCRIPTION_UNIT_ID, title: PR_DESCRIPTION_UNIT_TITLE },
+      { kind: "pr_description", id: "__pr_description", title: "PR Description" },
     ]);
   });
 

--- a/apps/extension/src/content/overlay/displayUnits.ts
+++ b/apps/extension/src/content/overlay/displayUnits.ts
@@ -1,14 +1,7 @@
 import type { ReviewPlan, ReviewUnit } from "../../lib/types";
 
-export const PR_DESCRIPTION_UNIT_ID = "__pr_description";
-export const PR_DESCRIPTION_UNIT_TITLE = "PR Description";
-
 export type DisplayUnit =
-  | {
-      kind: "pr_description";
-      id: typeof PR_DESCRIPTION_UNIT_ID;
-      title: typeof PR_DESCRIPTION_UNIT_TITLE;
-    }
+  | { kind: "pr_description"; id: "__pr_description"; title: "PR Description" }
   | { kind: "review"; id: string; title: string; unit: ReviewUnit; planIndex: number };
 
 /**
@@ -20,8 +13,8 @@ export type DisplayUnit =
 export function buildDisplayUnits(plan: ReviewPlan | null): DisplayUnit[] {
   const description: DisplayUnit = {
     kind: "pr_description",
-    id: PR_DESCRIPTION_UNIT_ID,
-    title: PR_DESCRIPTION_UNIT_TITLE,
+    id: "__pr_description",
+    title: "PR Description",
   };
 
   if (!plan) return [description];

--- a/apps/extension/src/content/overlay/platform.test.ts
+++ b/apps/extension/src/content/overlay/platform.test.ts
@@ -1,64 +1,22 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { isMacPlatform, modKeyLabel } from "./platform";
-
-function mockNavigator(partial: {
-  platform?: string;
-  userAgent?: string;
-  userAgentData?: { platform?: string };
-}) {
-  vi.stubGlobal("navigator", {
-    platform: partial.platform ?? "",
-    userAgent: partial.userAgent ?? "",
-    userAgentData: partial.userAgentData,
-  });
-}
-
-describe("isMacPlatform", () => {
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
-  it("detects macOS from navigator.platform", () => {
-    mockNavigator({ platform: "MacIntel" });
-    expect(isMacPlatform()).toBe(true);
-  });
-
-  it("detects macOS from userAgentData.platform", () => {
-    mockNavigator({ platform: "Win32", userAgentData: { platform: "macOS" } });
-    expect(isMacPlatform()).toBe(true);
-  });
-
-  it("detects macOS from userAgent fallback", () => {
-    mockNavigator({
-      platform: "",
-      userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
-    });
-    expect(isMacPlatform()).toBe(true);
-  });
-
-  it("returns false for Windows", () => {
-    mockNavigator({ platform: "Win32", userAgent: "Windows NT 10.0" });
-    expect(isMacPlatform()).toBe(false);
-  });
-
-  it("returns false for Linux", () => {
-    mockNavigator({ platform: "Linux x86_64", userAgent: "X11; Linux x86_64" });
-    expect(isMacPlatform()).toBe(false);
-  });
-});
+import { modKeyLabel } from "./platform";
 
 describe("modKeyLabel", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
+  function mockPlatform(platform: string) {
+    vi.stubGlobal("navigator", { platform, userAgent: "", userAgentData: undefined });
+  }
+
   it("returns ⌘ on macOS", () => {
-    mockNavigator({ platform: "MacIntel" });
+    mockPlatform("MacIntel");
     expect(modKeyLabel()).toBe("⌘");
   });
 
   it("returns Ctrl on non-macOS", () => {
-    mockNavigator({ platform: "Win32" });
+    mockPlatform("Win32");
     expect(modKeyLabel()).toBe("Ctrl");
   });
 });

--- a/apps/extension/src/content/overlay/platform.ts
+++ b/apps/extension/src/content/overlay/platform.ts
@@ -1,18 +1,4 @@
-/**
- * OS detection for keyboard-shortcut labels (⌘ vs Ctrl).
- * Content-script safe — reads navigator only at call time.
- */
-
-export function isMacPlatform(): boolean {
-  if (typeof navigator === "undefined") return false;
-
-  const nav = navigator as Navigator & {
-    userAgentData?: { platform?: string };
-  };
-  const platform = nav.userAgentData?.platform ?? nav.platform ?? "";
-  if (/Mac|iPhone|iPod|iPad/i.test(platform)) return true;
-  return /Mac OS X|Macintosh/i.test(nav.userAgent ?? "");
-}
+import { isMacPlatform } from "@guided-review/ui";
 
 /** Primary modifier label for this OS: ⌘ on Apple platforms, Ctrl elsewhere. */
 export function modKeyLabel(): "⌘" | "Ctrl" {

--- a/apps/extension/src/content/overlay/prConversationUrl.test.ts
+++ b/apps/extension/src/content/overlay/prConversationUrl.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  isPrConversationPath,
   isPrFilesChangedPath,
   navigateToPrConversation,
   prConversationUrl,
@@ -11,26 +10,6 @@ describe("prConversationUrl", () => {
     expect(prConversationUrl({ owner: "acme", repo: "widgets", number: 42 })).toBe(
       "https://github.com/acme/widgets/pull/42",
     );
-  });
-});
-
-describe("isPrConversationPath", () => {
-  const pr = { owner: "acme", repo: "widgets", number: 1 };
-
-  it("matches the conversation path", () => {
-    expect(isPrConversationPath("/acme/widgets/pull/1", pr)).toBe(true);
-    expect(isPrConversationPath("/acme/widgets/pull/1/", pr)).toBe(true);
-  });
-
-  it("rejects other PR tabs", () => {
-    expect(isPrConversationPath("/acme/widgets/pull/1/files", pr)).toBe(false);
-    expect(isPrConversationPath("/acme/widgets/pull/1/commits", pr)).toBe(false);
-    expect(isPrConversationPath("/acme/widgets/pull/1/checks", pr)).toBe(false);
-  });
-
-  it("rejects other PRs", () => {
-    expect(isPrConversationPath("/acme/widgets/pull/2", pr)).toBe(false);
-    expect(isPrConversationPath("/other/widgets/pull/1", pr)).toBe(false);
   });
 });
 
@@ -80,13 +59,41 @@ describe("navigateToPrConversation", () => {
     expect(assign).not.toHaveBeenCalled();
   });
 
-  it("navigates from the files tab", () => {
+  it("treats a trailing slash as already on the conversation tab", () => {
     const assign = vi.fn();
     Object.defineProperty(window, "location", {
       configurable: true,
-      value: { pathname: "/acme/widgets/pull/1/files", assign },
+      value: { pathname: "/acme/widgets/pull/1/", assign },
     });
     navigateToPrConversation({ owner: "acme", repo: "widgets", number: 1 });
-    expect(assign).toHaveBeenCalledWith("https://github.com/acme/widgets/pull/1");
+    expect(assign).not.toHaveBeenCalled();
+  });
+
+  it("navigates from every other PR tab", () => {
+    for (const pathname of [
+      "/acme/widgets/pull/1/files",
+      "/acme/widgets/pull/1/commits",
+      "/acme/widgets/pull/1/checks",
+    ]) {
+      const assign = vi.fn();
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: { pathname, assign },
+      });
+      navigateToPrConversation({ owner: "acme", repo: "widgets", number: 1 });
+      expect(assign, pathname).toHaveBeenCalledWith("https://github.com/acme/widgets/pull/1");
+    }
+  });
+
+  it("navigates when the path is a different PR or repo", () => {
+    for (const pathname of ["/acme/widgets/pull/2", "/other/widgets/pull/1"]) {
+      const assign = vi.fn();
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: { pathname, assign },
+      });
+      navigateToPrConversation({ owner: "acme", repo: "widgets", number: 1 });
+      expect(assign, pathname).toHaveBeenCalledWith("https://github.com/acme/widgets/pull/1");
+    }
   });
 });

--- a/apps/extension/src/content/overlay/prConversationUrl.ts
+++ b/apps/extension/src/content/overlay/prConversationUrl.ts
@@ -4,19 +4,6 @@ export function prConversationUrl(pr: { owner: string; repo: string; number: num
 }
 
 /**
- * True when `pathname` is already the PR conversation tab
- * (not /files, /commits, /checks, etc.).
- */
-export function isPrConversationPath(
-  pathname: string,
-  pr: { owner: string; repo: string; number: number },
-): boolean {
-  const normalized = pathname.replace(/\/+$/, "") || "/";
-  const expected = `/${pr.owner}/${pr.repo}/pull/${pr.number}`;
-  return normalized === expected;
-}
-
-/**
  * True when `pathname` is the PR Files changed / Changes tab
  * (`.../pull/N/files` or `.../pull/N/changes`, optional trailing segments).
  * GitHub's classic UI uses `/files`; the newer PR UI uses `/changes`.
@@ -36,6 +23,8 @@ export function navigateToPrConversation(pr: {
   repo: string;
   number: number;
 }): void {
-  if (isPrConversationPath(window.location.pathname, pr)) return;
+  // Already on the conversation tab (not /files, /commits, /checks, …).
+  const normalized = window.location.pathname.replace(/\/+$/, "") || "/";
+  if (normalized === `/${pr.owner}/${pr.repo}/pull/${pr.number}`) return;
   window.location.assign(prConversationUrl(pr));
 }

--- a/apps/extension/src/content/overlay/store.ts
+++ b/apps/extension/src/content/overlay/store.ts
@@ -28,9 +28,6 @@ import {
 export type ReviewStatus = "idle" | "loading" | "streaming" | "ready" | "error";
 export type { DiffViewMode };
 
-/** Stable identity for a PR, independent of which GitHub tab/URL the user is on. */
-export type SessionPRIdentity = PRIdentity;
-
 interface PersistedSession {
   diff: ParsedDiff;
   plan: ReviewPlan;
@@ -47,10 +44,6 @@ const COMMENT_UI_RESET = {
   composerOpen: false,
   selectableLines: [] as SelectableLine[],
 };
-
-function normalizeError(error: ReviewErrorInfo | string): ReviewErrorInfo {
-  return typeof error === "string" ? { message: error } : error;
-}
 
 interface ReviewState {
   isOpen: boolean;
@@ -133,7 +126,7 @@ interface ReviewState {
  * Build a stable session key for a PR. Same PR on Conversation vs Files changed
  * (or any other tab URL) must map to the same key so resume works.
  */
-export function buildSessionKey(pr: SessionPRIdentity): string {
+export function buildSessionKey(pr: PRIdentity): string {
   return `${pr.owner}/${pr.repo}#${pr.number}`;
 }
 
@@ -146,10 +139,6 @@ function newDraftId(): string {
     return crypto.randomUUID();
   }
   return `draft-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
-}
-
-function clearCommentUi(): typeof COMMENT_UI_RESET {
-  return { ...COMMENT_UI_RESET };
 }
 
 export const useReviewStore = create<ReviewState>((set, get) => ({
@@ -171,7 +160,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   draftComments: [],
 
   open: () => set({ isOpen: true }),
-  close: () => set({ isOpen: false, ...clearCommentUi() }),
+  close: () => set({ isOpen: false, ...COMMENT_UI_RESET }),
 
   startLoading: (sessionKey) =>
     set((state) => ({
@@ -184,7 +173,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
       sessionKey,
       streamGeneration: state.streamGeneration + 1,
       draftComments: [],
-      ...clearCommentUi(),
+      ...COMMENT_UI_RESET,
     })),
 
   setPRContext: (prContext) => set({ prContext }),
@@ -207,7 +196,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
       // prompt must not survive into the new attempt.
       needsProvider: false,
       plan: hasDiff ? { units: [] } : null,
-      ...clearCommentUi(),
+      ...COMMENT_UI_RESET,
     });
     return nextGeneration;
   },
@@ -244,7 +233,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
 
   setError: (error, generation) => {
     if (generation !== undefined && get().streamGeneration !== generation) return;
-    const normalized = normalizeError(error);
+    const normalized = typeof error === "string" ? { message: error } : error;
     // A missing provider key isn't a failure the user should read as an error —
     // both the content-script pre-check and the background backstop land here.
     if (normalized.code === NO_API_KEY_ERROR_CODE) {
@@ -268,28 +257,28 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
       status: "ready",
       plan: buildFileReviewPlan(diff),
       currentUnitIndex: 0,
-      ...clearCommentUi(),
+      ...COMMENT_UI_RESET,
     });
   },
 
   goToUnit: (index) => {
     const total = displayUnitCount(get().plan);
     if (index < 0 || index >= total) return;
-    set({ currentUnitIndex: index, ...clearCommentUi() });
+    set({ currentUnitIndex: index, ...COMMENT_UI_RESET });
   },
 
   goNext: () => {
     const { currentUnitIndex, plan } = get();
     const total = displayUnitCount(plan);
     if (currentUnitIndex < total - 1) {
-      set({ currentUnitIndex: currentUnitIndex + 1, ...clearCommentUi() });
+      set({ currentUnitIndex: currentUnitIndex + 1, ...COMMENT_UI_RESET });
     }
   },
 
   goPrev: () => {
     const { currentUnitIndex } = get();
     if (currentUnitIndex > 0) {
-      set({ currentUnitIndex: currentUnitIndex - 1, ...clearCommentUi() });
+      set({ currentUnitIndex: currentUnitIndex - 1, ...COMMENT_UI_RESET });
     }
   },
 
@@ -311,7 +300,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
     });
   },
 
-  exitCommentMode: () => set(clearCommentUi()),
+  exitCommentMode: () => set({ ...COMMENT_UI_RESET }),
 
   setSelectableLines: (lines) => {
     const { uiMode, lineSelection, selectableLines: prevLines } = get();
@@ -320,7 +309,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
       return;
     }
     if (lines.length === 0) {
-      set(clearCommentUi());
+      set({ ...COMMENT_UI_RESET });
       return;
     }
 
@@ -543,7 +532,7 @@ export async function restoreSession(sessionKey: string): Promise<boolean> {
     sessionKey,
     error: null,
     draftComments: saved.draftComments ?? [],
-    ...clearCommentUi(),
+    ...COMMENT_UI_RESET,
   });
   return true;
 }

--- a/apps/extension/src/content/overlay/store.ts
+++ b/apps/extension/src/content/overlay/store.ts
@@ -7,6 +7,7 @@ import type {
   ReviewUnit,
 } from "../../lib/types";
 import { NO_API_KEY_ERROR_CODE } from "../../lib/types";
+import type { PRIdentity } from "../../lib/github/diffFetch";
 import { buildFileReviewPlan } from "../../lib/review/fileReviewPlan";
 import {
   displayLineNumber,
@@ -28,11 +29,7 @@ export type ReviewStatus = "idle" | "loading" | "streaming" | "ready" | "error";
 export type { DiffViewMode };
 
 /** Stable identity for a PR, independent of which GitHub tab/URL the user is on. */
-export interface SessionPRIdentity {
-  owner: string;
-  repo: string;
-  number: number;
-}
+export type SessionPRIdentity = PRIdentity;
 
 interface PersistedSession {
   diff: ParsedDiff;
@@ -206,6 +203,9 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
       streamGeneration: nextGeneration,
       status: hasDiff ? "streaming" : "loading",
       error: null,
+      // A retry always re-runs the annotate call, so the connect-provider
+      // prompt must not survive into the new attempt.
+      needsProvider: false,
       plan: hasDiff ? { units: [] } : null,
       ...clearCommentUi(),
     });

--- a/apps/extension/src/content/overlay/useOverlayKeyboard.ts
+++ b/apps/extension/src/content/overlay/useOverlayKeyboard.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, type MutableRefObject, type RefObject } from "react";
-import { confirmationHandlesKey, getConfirmationDialogElement } from "./components/confirmation";
+import { getConfirmationDialogElement, isConfirmationOpen } from "./components/confirmation";
 import type { SelectableLine } from "./commentTypes";
 import { trapTabKey } from "./focusTrap";
 import { recordViewChordKey, type ViewChordPending } from "./viewModeChord";
@@ -143,11 +143,10 @@ export function useOverlayKeyboard({
      * it doesn't act on), so any true here means the caller should return.
      */
     function handleModalKeys(event: KeyboardEvent): boolean {
-      // Confirmation dialog: Enter = OK, Esc = cancel (highest priority modal).
-      if (confirmationHandlesKey(event)) {
-        event.preventDefault();
-        return true;
-      }
+      // Confirmation dialog owns every key while open (highest priority modal).
+      // It runs Enter/Esc from its own capture listener, so we only need to stop
+      // the key here before it reaches the other modals or navigate mode.
+      if (isConfirmationOpen()) return true;
 
       // Success modal: Enter / Esc exit the review (single CTA dialog).
       if (submitSuccessRef.current) {

--- a/apps/extension/src/content/overlay/useOverlayKeyboard.ts
+++ b/apps/extension/src/content/overlay/useOverlayKeyboard.ts
@@ -41,7 +41,6 @@ interface UseOverlayKeyboardOptions {
   currentUnitId: string | undefined;
   submitReviewOpen: boolean;
   connectGitHubOpen: boolean;
-  submittingReview: boolean;
   /** Truthy while the post-submit success modal should own the keyboard. */
   submitSuccess: object | null;
   submitReviewActionRef: MutableRefObject<(() => void) | null>;
@@ -60,8 +59,10 @@ interface UseOverlayKeyboardOptions {
  * (confirmation → success → connect-GitHub → submit-review), the comment
  * composer, view-mode chords (`v u` / `v s`), and navigate/comment mode keys.
  *
- * Extracted from Overlay as-is — the capture-on-window design and dependency
- * list are unchanged; only the location moved.
+ * Listens on window in the capture phase so the overlay sees keys before
+ * GitHub's own document-level shortcuts, and always stops propagation while
+ * open. Modal open flags are read through refs so the listener is current as
+ * soon as state commits, not only after the effect re-runs.
  */
 export function useOverlayKeyboard({
   isOpen,
@@ -73,8 +74,6 @@ export function useOverlayKeyboard({
   currentUnitId,
   submitReviewOpen,
   connectGitHubOpen,
-  // Kept in the options API for callers; close guards live in useSubmitReviewFlow.
-  submittingReview: _submittingReview,
   submitSuccess,
   submitReviewActionRef,
   submitReviewKeyRef,
@@ -111,7 +110,13 @@ export function useOverlayKeyboard({
     if (!isOpen) return;
 
     const SCROLL_STEP = 120;
-    viewChordRef.current = null;
+
+    /** Disarm a pending `v` leader so it cannot complete a chord later. */
+    function clearViewChord(): void {
+      viewChordRef.current = null;
+    }
+
+    clearViewChord();
 
     type Store = ReturnType<typeof useReviewStore.getState>;
 
@@ -141,13 +146,11 @@ export function useOverlayKeyboard({
       // Confirmation dialog: Enter = OK, Esc = cancel (highest priority modal).
       if (confirmationHandlesKey(event)) {
         event.preventDefault();
-        viewChordRef.current = null;
         return true;
       }
 
       // Success modal: Enter / Esc exit the review (single CTA dialog).
       if (submitSuccessRef.current) {
-        viewChordRef.current = null;
         if (event.key === "Enter" && !event.metaKey && !event.ctrlKey && !event.altKey) {
           event.preventDefault();
           exitAfterSubmitRef.current();
@@ -163,7 +166,6 @@ export function useOverlayKeyboard({
 
       // Connect GitHub modal: Esc closes; Enter runs Connect / Try again / open GitHub.
       if (connectGitHubOpenRef.current) {
-        viewChordRef.current = null;
         if (event.key === "Escape") {
           event.preventDefault();
           setConnectGitHubOpenRef.current(false);
@@ -180,7 +182,6 @@ export function useOverlayKeyboard({
       // ⌘/Ctrl+Enter submits on the compose step; ↑/↓/Enter drive the choose step.
       // Handled here because capture stopPropagation blocks element React handlers.
       if (submitReviewOpenRef.current) {
-        viewChordRef.current = null;
         if (event.key === "Escape") {
           event.preventDefault();
           closeSubmitReviewModalRef.current();
@@ -209,7 +210,6 @@ export function useOverlayKeyboard({
       const editable = isEditableEvent(event);
       if (!store.composerOpen && !editable) return false;
 
-      viewChordRef.current = null;
       if (event.key === "Escape") {
         event.preventDefault();
         if (store.composerOpen) store.closeComposer();
@@ -228,7 +228,7 @@ export function useOverlayKeyboard({
     /** View-mode chords: v+u (unified), v+s (split). Both navigate and comment mode. */
     function handleViewModeChord(event: KeyboardEvent, store: Store): boolean {
       if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
-        viewChordRef.current = null;
+        clearViewChord();
         return false;
       }
       const { next, mode, consumed } = recordViewChordKey(
@@ -247,32 +247,26 @@ export function useOverlayKeyboard({
       switch (event.key) {
         case "Escape":
           event.preventDefault();
-          viewChordRef.current = null;
           store.exitCommentMode();
           return;
         case "ArrowUp":
           event.preventDefault();
-          viewChordRef.current = null;
           store.moveLineCursor(-1, event.shiftKey);
           return;
         case "ArrowDown":
           event.preventDefault();
-          viewChordRef.current = null;
           store.moveLineCursor(1, event.shiftKey);
           return;
         case "Enter":
           event.preventDefault();
-          viewChordRef.current = null;
           store.openComposer();
           return;
         case "ArrowRight":
           event.preventDefault();
-          viewChordRef.current = null;
           store.goNext();
           return;
         case "ArrowLeft":
           event.preventDefault();
-          viewChordRef.current = null;
           store.goPrev();
           return;
         default:
@@ -284,17 +278,14 @@ export function useOverlayKeyboard({
       switch (event.key) {
         case "Escape":
           event.preventDefault();
-          viewChordRef.current = null;
           requestExitRef.current();
           return;
         case "ArrowRight":
           event.preventDefault();
-          viewChordRef.current = null;
           store.goNext();
           return;
         case "ArrowLeft":
           event.preventDefault();
-          viewChordRef.current = null;
           store.goPrev();
           return;
         case "ArrowUp":
@@ -317,7 +308,6 @@ export function useOverlayKeyboard({
         case "C":
           if (event.metaKey || event.ctrlKey || event.altKey) return;
           event.preventDefault();
-          viewChordRef.current = null;
           if (selectableForUnit.length > 0) {
             store.enterCommentMode(selectableForUnit);
           }
@@ -337,16 +327,27 @@ export function useOverlayKeyboard({
       event.stopPropagation();
 
       if (handleTabTrap(event)) return;
-      if (handleModalKeys(event)) return;
+
+      // A key claimed by a modal, the composer, or the submit shortcut never
+      // reaches handleViewModeChord, so those three paths disarm a pending `v`
+      // themselves. Everything else does reach it, and recordViewChordKey
+      // returns a null pending state for every key except `v`.
+      if (handleModalKeys(event)) {
+        clearViewChord();
+        return;
+      }
 
       const store = useReviewStore.getState();
 
-      if (handleComposerKeys(event, store)) return;
+      if (handleComposerKeys(event, store)) {
+        clearViewChord();
+        return;
+      }
 
       // ⌘/Ctrl+Enter opens Submit Review (or Connect GitHub if unauthenticated).
       if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
         event.preventDefault();
-        viewChordRef.current = null;
+        clearViewChord();
         void requestOpenSubmitReviewRef.current();
         return;
       }

--- a/apps/extension/src/content/overlay/useSubmitReviewFlow.ts
+++ b/apps/extension/src/content/overlay/useSubmitReviewFlow.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from "react";
 import { getGitHubAuthStatus, submitPullRequestReview } from "../../lib/messaging";
 import type { PRContext } from "../../lib/types";
+import { EMPTY_REVIEW_BODY_MESSAGE } from "../../lib/types";
 import type { DraftComment, ReviewEvent, ReviewSubmission } from "./commentTypes";
 import { mapDraftsToReviewComments } from "./mapDraftComments";
 import { navigateToPrConversation } from "./prConversationUrl";
@@ -118,11 +119,7 @@ export function useSubmitReviewFlow({
         (submission.event === "COMMENT" || submission.event === "REQUEST_CHANGES") &&
         trimmedBody.length === 0
       ) {
-        setSubmitReviewError(
-          submission.event === "COMMENT"
-            ? "Add a review comment before submitting."
-            : "Add a summary explaining the requested changes before submitting.",
-        );
+        setSubmitReviewError(EMPTY_REVIEW_BODY_MESSAGE[submission.event]);
         return;
       }
 
@@ -138,12 +135,14 @@ export function useSubmitReviewFlow({
       setSubmittingReview(true);
       setSubmitReviewError(null);
 
+      const comments = mapDraftsToReviewComments(draftComments);
+
       try {
         const result = await submitPullRequestReview(
           { owner: pr.owner, repo: pr.repo, number: pr.number },
           trimmedBody,
           submission.event,
-          mapDraftsToReviewComments(draftComments),
+          comments,
         );
 
         if (generation !== submitGenerationRef.current) return;
@@ -153,11 +152,10 @@ export function useSubmitReviewFlow({
           return;
         }
 
-        const commentCount = mapDraftsToReviewComments(draftComments).length;
         clearDraftComments();
         setSubmitReviewOpen(false);
         setSubmitReviewError(null);
-        setSubmitSuccess({ event: submission.event, commentCount });
+        setSubmitSuccess({ event: submission.event, commentCount: comments.length });
       } catch (error: unknown) {
         if (generation !== submitGenerationRef.current) return;
         const message = error instanceof Error ? error.message : "Could not submit the review.";

--- a/apps/extension/src/lib/autoOpenOnFilesTab.test.ts
+++ b/apps/extension/src/lib/autoOpenOnFilesTab.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  DEFAULT_AUTO_OPEN_ON_FILES_TAB,
   getAutoOpenOnFilesTab,
   onAutoOpenOnFilesTabChanged,
   setAutoOpenOnFilesTab,
@@ -11,9 +10,8 @@ describe("autoOpenOnFilesTab", () => {
     await chrome.storage.local.clear();
   });
 
-  it("returns the default when nothing is stored", async () => {
-    await expect(getAutoOpenOnFilesTab()).resolves.toBe(DEFAULT_AUTO_OPEN_ON_FILES_TAB);
-    expect(DEFAULT_AUTO_OPEN_ON_FILES_TAB).toBe(false);
+  it("defaults to off when nothing is stored", async () => {
+    await expect(getAutoOpenOnFilesTab()).resolves.toBe(false);
   });
 
   it("round-trips a saved value", async () => {
@@ -25,7 +23,7 @@ describe("autoOpenOnFilesTab", () => {
 
   it("ignores invalid stored values", async () => {
     await chrome.storage.local.set({ "guidedReview.autoOpenOnFilesTab": "yes" });
-    await expect(getAutoOpenOnFilesTab()).resolves.toBe(DEFAULT_AUTO_OPEN_ON_FILES_TAB);
+    await expect(getAutoOpenOnFilesTab()).resolves.toBe(false);
   });
 
   it("onAutoOpenOnFilesTabChanged fires on save", async () => {

--- a/apps/extension/src/lib/autoOpenOnFilesTab.ts
+++ b/apps/extension/src/lib/autoOpenOnFilesTab.ts
@@ -1,26 +1,20 @@
+import { readLocal, watchLocal, writeLocal } from "./storage";
+
 const STORAGE_KEY = "guidedReview.autoOpenOnFilesTab";
 
 /** Default: off — opt-in so the overlay never surprises first-time users. */
-export const DEFAULT_AUTO_OPEN_ON_FILES_TAB = false;
+function parseEnabled(raw: unknown): boolean {
+  return typeof raw === "boolean" ? raw : false;
+}
 
 /** Read whether Guided Review should open on the Files changed / Changes tab. */
-export async function getAutoOpenOnFilesTab(): Promise<boolean> {
-  try {
-    const result = await chrome.storage.local.get(STORAGE_KEY);
-    const stored = result[STORAGE_KEY];
-    return typeof stored === "boolean" ? stored : DEFAULT_AUTO_OPEN_ON_FILES_TAB;
-  } catch {
-    return DEFAULT_AUTO_OPEN_ON_FILES_TAB;
-  }
+export function getAutoOpenOnFilesTab(): Promise<boolean> {
+  return readLocal(STORAGE_KEY, parseEnabled);
 }
 
 /** Persist the auto-open preference. Failures are non-fatal. */
-export async function setAutoOpenOnFilesTab(enabled: boolean): Promise<void> {
-  try {
-    await chrome.storage.local.set({ [STORAGE_KEY]: enabled });
-  } catch (error) {
-    console.warn("Guided Review: failed to persist auto-open preference", error);
-  }
+export function setAutoOpenOnFilesTab(enabled: boolean): Promise<void> {
+  return writeLocal(STORAGE_KEY, enabled);
 }
 
 /**
@@ -28,17 +22,5 @@ export async function setAutoOpenOnFilesTab(enabled: boolean): Promise<void> {
  * PR tab is open). Returns an unsubscribe function.
  */
 export function onAutoOpenOnFilesTabChanged(listener: (enabled: boolean) => void): () => void {
-  const handler = (
-    changes: Record<string, chrome.storage.StorageChange>,
-    areaName: string,
-  ): void => {
-    if (areaName !== "local") return;
-    const change = changes[STORAGE_KEY];
-    if (!change) return;
-    const next = change.newValue;
-    listener(typeof next === "boolean" ? next : DEFAULT_AUTO_OPEN_ON_FILES_TAB);
-  };
-
-  chrome.storage.onChanged.addListener(handler);
-  return () => chrome.storage.onChanged.removeListener(handler);
+  return watchLocal(STORAGE_KEY, parseEnabled, listener);
 }

--- a/apps/extension/src/lib/github/diffParser.ts
+++ b/apps/extension/src/lib/github/diffParser.ts
@@ -43,8 +43,8 @@ export function parseUnifiedDiff(raw: string): ParsedDiff {
       } else if (l.startsWith("rename from ")) {
         status = "renamed";
         previousPath = l.slice("rename from ".length);
-      } else if (l.startsWith("rename to ")) {
-        // pathB already carries the new path from the "diff --git" line
+        // No "rename to" branch: pathB already carries the new path from the
+        // "diff --git" line.
       } else if (l.startsWith("Binary files ") || l.startsWith("GIT binary patch")) {
         isBinaryOrElided = true;
       } else if (l.startsWith("--- ")) {

--- a/apps/extension/src/lib/github/oauthConfig.ts
+++ b/apps/extension/src/lib/github/oauthConfig.ts
@@ -23,3 +23,13 @@ export const GITHUB_OAUTH_SCOPES = "repo read:user";
 export function isGitHubOAuthConfigured(): boolean {
   return GITHUB_OAUTH_CLIENT_ID.length > 0;
 }
+
+/** Build-time env var that carries the client id. Referenced in user-facing copy. */
+export const GITHUB_CLIENT_ID_ENV_VAR = "VITE_GITHUB_CLIENT_ID";
+
+/**
+ * Shown when a build ships without a client id. The options page and the
+ * overlay modal render the same wording as JSX (with the env var in a `code`
+ * element); this is the plain-text form for message responses.
+ */
+export const GITHUB_OAUTH_NOT_CONFIGURED = `GitHub connection isn’t configured in this build. Set ${GITHUB_CLIENT_ID_ENV_VAR} and rebuild.`;

--- a/apps/extension/src/lib/github/prFileDiffUrl.test.ts
+++ b/apps/extension/src/lib/github/prFileDiffUrl.test.ts
@@ -1,16 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildPRFileDiffUrl, sha256Hex } from "./prFileDiffUrl";
-
-describe("sha256Hex", () => {
-  it("matches GitHub’s documented hash for a sample path", async () => {
-    // https://github.com/orgs/community/discussions/43908
-    await expect(sha256Hex("src/index.js")).resolves.toBe(
-      "bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556",
-    );
-  });
-});
+import { buildPRFileDiffUrl } from "./prFileDiffUrl";
 
 describe("buildPRFileDiffUrl", () => {
+  // Hash matches GitHub's documented `#diff-` fragment for this path:
+  // https://github.com/orgs/community/discussions/43908
   it("builds a Files-changed deep link with the path hash", async () => {
     const url = await buildPRFileDiffUrl(
       { owner: "acme", repo: "widgets", number: 42 },

--- a/apps/extension/src/lib/github/prFileDiffUrl.ts
+++ b/apps/extension/src/lib/github/prFileDiffUrl.ts
@@ -12,15 +12,6 @@ export interface PRFileDiffIdentity {
   number: number;
 }
 
-/** SHA-256 hex digest of UTF-8 `text` (GitHub’s `#diff-` fragment body). */
-export async function sha256Hex(text: string): Promise<string> {
-  const data = new TextEncoder().encode(text);
-  const digest = await crypto.subtle.digest("SHA-256", data);
-  return Array.from(new Uint8Array(digest))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-}
-
 /**
  * URL that opens the PR Files tab scrolled to `filePath`.
  * Use the file's current path (new path after renames) — that is what GitHub hashes.
@@ -29,6 +20,9 @@ export async function buildPRFileDiffUrl(
   pr: PRFileDiffIdentity,
   filePath: string,
 ): Promise<string> {
-  const hex = await sha256Hex(filePath);
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(filePath));
+  const hex = Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
   return `https://github.com/${pr.owner}/${pr.repo}/pull/${pr.number}/files#diff-${hex}`;
 }

--- a/apps/extension/src/lib/github/submitReview.ts
+++ b/apps/extension/src/lib/github/submitReview.ts
@@ -6,10 +6,10 @@
  */
 
 import type { ReviewCommentInput, ReviewEvent, SubmitReviewResponse } from "../types";
+import { EMPTY_REVIEW_BODY_MESSAGE } from "../types";
+import type { PRIdentity } from "./diffFetch";
 
 type SubmitReviewFailure = Extract<SubmitReviewResponse, { ok: false }>;
-
-type PRIdentity = { owner: string; repo: string; number: number };
 
 const API_VERSION = "2022-11-28";
 const ACCEPT = "application/vnd.github+json";
@@ -39,10 +39,7 @@ export async function submitPullRequestReview(
     return {
       ok: false,
       code: "validation",
-      error:
-        event === "COMMENT"
-          ? "Add a review comment before submitting."
-          : "Add a summary explaining the requested changes before submitting.",
+      error: EMPTY_REVIEW_BODY_MESSAGE[event],
     };
   }
 

--- a/apps/extension/src/lib/highlight.test.ts
+++ b/apps/extension/src/lib/highlight.test.ts
@@ -38,4 +38,32 @@ describe("highlightToLines", () => {
     expect(lines[0]).toContain("<span");
     expect(lines[0]).not.toContain("&lt;span");
   });
+
+  it("re-opens spans that straddle a newline so each line stands alone", () => {
+    const lines = highlightToLines("/* one\n two\n three */\nconst x = 1;", "javascript");
+
+    expect(lines).toHaveLength(4);
+    // Each line of the block comment must be independently valid HTML: the
+    // continuation lines re-open the comment span and close it at line end.
+    for (const line of lines.slice(0, 3)) {
+      expect(countOccurrences(line, "<span")).toBe(countOccurrences(line, "</span>"));
+    }
+    expect(lines[1]).toContain("<span");
+    expect(lines[1]).toContain("two");
+  });
+
+  it("handles a very long single line without truncating or reordering tags", () => {
+    // Guards the tag scanner: it walks per character, so a long line must not
+    // change the result (and must not degrade to quadratic slicing).
+    const long = `const s = "${"a".repeat(20_000)}";`;
+    const lines = highlightToLines(long, "javascript");
+
+    expect(lines).toHaveLength(1);
+    expect(countOccurrences(lines[0], "<span")).toBe(countOccurrences(lines[0], "</span>"));
+    expect(lines[0]).toContain("a".repeat(20_000));
+  });
 });
+
+function countOccurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}

--- a/apps/extension/src/lib/highlight.ts
+++ b/apps/extension/src/lib/highlight.ts
@@ -153,7 +153,9 @@ export function highlightToLines(code: string, language: string): string[] {
   }
 
   const rawLines = highlighted.split("\n");
-  const openTagRe = /^<span class="([^"]*)">/;
+  // Sticky so it matches at `idx` without slicing the line on every character —
+  // this runs over every rendered diff line, and slicing made it quadratic.
+  const openTagRe = /<span class="([^"]*)">/y;
   const lines: string[] = [];
   let openStack: string[] = [];
 
@@ -164,13 +166,14 @@ export function highlightToLines(code: string, language: string): string[] {
     const stack = [...openStack];
     let idx = 0;
     while (idx < rawLine.length) {
-      const openMatch = openTagRe.exec(rawLine.slice(idx));
+      openTagRe.lastIndex = idx;
+      const openMatch = openTagRe.exec(rawLine);
       if (openMatch) {
         stack.push(openMatch[1]);
-        idx += openMatch[0].length;
+        idx = openTagRe.lastIndex;
         continue;
       }
-      if (rawLine.slice(idx).startsWith("</span>")) {
+      if (rawLine.startsWith("</span>", idx)) {
         stack.pop();
         idx += "</span>".length;
         continue;

--- a/apps/extension/src/lib/providers/catalog.test.ts
+++ b/apps/extension/src/lib/providers/catalog.test.ts
@@ -1,15 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
-  DEFAULT_MODELS,
   defaultModelFor,
-  getModel,
   getProvider,
-  isKnownProvider,
   modelsForProvider,
   MODELS,
   normalizeProviderSettings,
   PROVIDERS,
-  resolveModelForProvider,
 } from "./catalog";
 
 describe("provider catalog", () => {
@@ -19,10 +15,9 @@ describe("provider catalog", () => {
 
   it("exposes a default model for every provider that exists in MODELS", () => {
     for (const provider of PROVIDERS) {
-      const model = getModel(provider.defaultModelId);
+      const model = MODELS.find((m) => m.id === provider.defaultModelId);
       expect(model, `default for ${provider.id}`).toBeDefined();
       expect(model!.provider).toBe(provider.id);
-      expect(DEFAULT_MODELS[provider.id]).toBe(provider.defaultModelId);
       expect(defaultModelFor(provider.id)).toBe(provider.defaultModelId);
     }
   });
@@ -34,44 +29,52 @@ describe("provider catalog", () => {
     expect(openai.some((m) => m.id === "gpt-4.1")).toBe(true);
   });
 
-  it("narrows known provider ids", () => {
-    expect(isKnownProvider("anthropic")).toBe(true);
-    expect(isKnownProvider("gemini")).toBe(false);
-  });
-
-  it("looks up providers and models by id", () => {
+  it("looks up providers by id", () => {
     expect(getProvider("grok").displayName).toContain("Grok");
-    expect(getModel("claude-opus-4-8")?.displayName).toBe("Claude Opus 4.8");
-    expect(getModel("does-not-exist")).toBeUndefined();
   });
 
-  it("resolves stale model ids to the provider default", () => {
-    expect(resolveModelForProvider("openai", "gpt-4.1")).toBe("gpt-4.1");
-    expect(resolveModelForProvider("openai", "retired-model")).toBe(DEFAULT_MODELS.openai);
-    expect(resolveModelForProvider("anthropic", "gpt-4.1")).toBe(DEFAULT_MODELS.anthropic);
-    expect(resolveModelForProvider("grok", undefined)).toBe(DEFAULT_MODELS.grok);
+  it("keeps a stored model that still exists for its provider", () => {
+    expect(normalizeProviderSettings({ provider: "openai", model: "gpt-4.1" }).model).toBe(
+      "gpt-4.1",
+    );
+  });
+
+  it("resolves stale, cross-provider and missing model ids to the provider default", () => {
+    expect(normalizeProviderSettings({ provider: "openai", model: "retired-model" }).model).toBe(
+      defaultModelFor("openai"),
+    );
+    // A real model id, but belonging to a different provider.
+    expect(normalizeProviderSettings({ provider: "anthropic", model: "gpt-4.1" }).model).toBe(
+      defaultModelFor("anthropic"),
+    );
+    expect(normalizeProviderSettings({ provider: "grok" }).model).toBe(defaultModelFor("grok"));
   });
 
   it("normalizes partial stored settings", () => {
     expect(normalizeProviderSettings({})).toEqual({
       provider: "anthropic",
-      model: DEFAULT_MODELS.anthropic,
+      model: defaultModelFor("anthropic"),
       apiKey: "",
     });
     expect(
       normalizeProviderSettings({ provider: "openai", model: "gone", apiKey: "sk-x" }),
     ).toEqual({
       provider: "openai",
-      model: DEFAULT_MODELS.openai,
+      model: defaultModelFor("openai"),
       apiKey: "sk-x",
     });
-    expect(normalizeProviderSettings({ provider: "nope", model: "x" }).provider).toBe("anthropic");
   });
 
-  it("gives every model a non-empty display name", () => {
+  it("falls back to anthropic for an unrecognized provider id", () => {
+    expect(normalizeProviderSettings({ provider: "nope", model: "x" }).provider).toBe("anthropic");
+    expect(normalizeProviderSettings({ provider: "gemini" }).provider).toBe("anthropic");
+  });
+
+  it("gives every model a non-empty display name and a known provider", () => {
+    const knownProviderIds = PROVIDERS.map((p) => p.id);
     for (const model of MODELS) {
       expect(model.displayName.length).toBeGreaterThan(0);
-      expect(isKnownProvider(model.provider)).toBe(true);
+      expect(knownProviderIds).toContain(model.provider);
     }
   });
 });

--- a/apps/extension/src/lib/providers/catalog.ts
+++ b/apps/extension/src/lib/providers/catalog.ts
@@ -83,15 +83,6 @@ export const MODELS: readonly ModelDefinition[] = [
   { id: "grok-3-mini", displayName: "Grok 3 Mini", provider: "grok" },
 ] as const;
 
-/** Default model id per provider (derived from PROVIDERS). */
-export const DEFAULT_MODELS: Record<ProviderId, string> = Object.fromEntries(
-  PROVIDERS.map((p) => [p.id, p.defaultModelId]),
-) as Record<ProviderId, string>;
-
-export function isKnownProvider(id: string): id is ProviderId {
-  return PROVIDERS.some((p) => p.id === id);
-}
-
 export function getProvider(id: ProviderId): ProviderDefinition {
   const found = PROVIDERS.find((p) => p.id === id);
   if (!found) {
@@ -109,22 +100,6 @@ export function defaultModelFor(id: ProviderId): string {
   return getProvider(id).defaultModelId;
 }
 
-export function getModel(id: string): ModelDefinition | undefined {
-  return MODELS.find((m) => m.id === id);
-}
-
-/**
- * Resolve a stored model id for a provider: keep it if it still exists in the
- * catalog for that provider, otherwise fall back to the provider default.
- */
-export function resolveModelForProvider(provider: ProviderId, modelId: string | undefined): string {
-  if (modelId) {
-    const model = getModel(modelId);
-    if (model && model.provider === provider) return model.id;
-  }
-  return defaultModelFor(provider);
-}
-
 /**
  * Normalize partially stored settings against the catalog (unknown provider →
  * anthropic; unknown/stale model → provider default).
@@ -134,11 +109,12 @@ export function normalizeProviderSettings(stored: {
   model?: string;
   apiKey?: string;
 }): { provider: ProviderId; model: string; apiKey: string } {
-  const raw = stored.provider ?? "";
-  const provider: ProviderId = isKnownProvider(raw) ? raw : "anthropic";
+  const provider = PROVIDERS.find((p) => p.id === stored.provider)?.id ?? "anthropic";
+  // Keep the stored model only if it still exists for this provider.
+  const model = MODELS.find((m) => m.id === stored.model && m.provider === provider);
   return {
     provider,
-    model: resolveModelForProvider(provider, stored.model),
+    model: model?.id ?? defaultModelFor(provider),
     apiKey: stored.apiKey ?? "",
   };
 }

--- a/apps/extension/src/lib/review/buildPrompt.test.ts
+++ b/apps/extension/src/lib/review/buildPrompt.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildUserPrompt, chunkDiffByFile, renderDiffForPrompt } from "./buildPrompt";
+import { buildUserPrompt, chunkDiffByFile } from "./buildPrompt";
 import type { DiffFile, ParsedDiff, PRContext } from "../types";
 
 function fileFixture(path: string, extraLineCount = 0): DiffFile {
@@ -27,31 +27,6 @@ function fileFixture(path: string, extraLineCount = 0): DiffFile {
     ],
   };
 }
-
-describe("renderDiffForPrompt", () => {
-  it("annotates each hunk with its stable id", () => {
-    const diff: ParsedDiff = { files: [fileFixture("src/foo.ts")] };
-    const text = renderDiffForPrompt(diff);
-    expect(text).toContain("[hunk id: src/foo.ts#0]");
-    expect(text).toContain("### File: src/foo.ts (modified)");
-  });
-
-  it("marks binary files without dumping hunk content", () => {
-    const diff: ParsedDiff = {
-      files: [{ path: "logo.png", status: "modified", isBinaryOrElided: true, hunks: [] }],
-    };
-    const text = renderDiffForPrompt(diff);
-    expect(text).toContain("binary or elided");
-  });
-
-  it("labels a renamed file with both paths", () => {
-    const diff: ParsedDiff = {
-      files: [{ ...fileFixture("new.ts"), status: "renamed", previousPath: "old.ts" }],
-    };
-    const text = renderDiffForPrompt(diff);
-    expect(text).toContain("renamed from old.ts to new.ts");
-  });
-});
 
 describe("chunkDiffByFile", () => {
   it("keeps small diffs in a single chunk", () => {
@@ -133,5 +108,27 @@ describe("buildUserPrompt", () => {
   it("omits the merge line when either ref is missing", () => {
     const prompt = buildUserPrompt({ files: [] }, { ...prContext, baseRef: "", headRef: "" });
     expect(prompt).not.toContain("Merging");
+  });
+
+  it("annotates each hunk with its stable id", () => {
+    const prompt = buildUserPrompt({ files: [fileFixture("src/foo.ts")] }, prContext);
+    expect(prompt).toContain("[hunk id: src/foo.ts#0]");
+    expect(prompt).toContain("### File: src/foo.ts (modified)");
+  });
+
+  it("marks binary files without dumping hunk content", () => {
+    const prompt = buildUserPrompt(
+      { files: [{ path: "logo.png", status: "modified", isBinaryOrElided: true, hunks: [] }] },
+      prContext,
+    );
+    expect(prompt).toContain("binary or elided");
+  });
+
+  it("labels a renamed file with both paths", () => {
+    const prompt = buildUserPrompt(
+      { files: [{ ...fileFixture("new.ts"), status: "renamed", previousPath: "old.ts" }] },
+      prContext,
+    );
+    expect(prompt).toContain("renamed from old.ts to new.ts");
   });
 });

--- a/apps/extension/src/lib/review/buildPrompt.ts
+++ b/apps/extension/src/lib/review/buildPrompt.ts
@@ -17,7 +17,22 @@ export function renderDiffForPrompt(diff: ParsedDiff): string {
   return diff.files.map(renderFile).join("\n\n");
 }
 
+/**
+ * Rendering is pure per file, and chunkDiffByFile measures every file before
+ * buildUserPrompt renders the same files again — cache so a large diff is
+ * only walked once.
+ */
+const renderedFiles = new WeakMap<DiffFile, string>();
+
 function renderFile(file: DiffFile): string {
+  const cached = renderedFiles.get(file);
+  if (cached !== undefined) return cached;
+  const rendered = renderFileUncached(file);
+  renderedFiles.set(file, rendered);
+  return rendered;
+}
+
+function renderFileUncached(file: DiffFile): string {
   const statusLabel =
     file.status === "renamed" ? `renamed from ${file.previousPath} to ${file.path}` : file.status;
 

--- a/apps/extension/src/lib/review/buildPrompt.ts
+++ b/apps/extension/src/lib/review/buildPrompt.ts
@@ -10,14 +10,6 @@ Follow these review-structuring conventions:
 Never invent code that isn't in the diff. Every fileId and hunkId you reference must come from the diff exactly as given.`;
 
 /**
- * Render a parsed diff into a compact, LLM-readable text form, with hunk ids
- * annotated so the model can reference them exactly in its structured output.
- */
-export function renderDiffForPrompt(diff: ParsedDiff): string {
-  return diff.files.map(renderFile).join("\n\n");
-}
-
-/**
  * Rendering is pure per file, and chunkDiffByFile measures every file before
  * buildUserPrompt renders the same files again — cache so a large diff is
  * only walked once.
@@ -99,7 +91,8 @@ export function buildUserPrompt(diff: ParsedDiff, prContext: PRContext): string 
       : "",
     "",
     "Diff:",
-    renderDiffForPrompt(diff),
+    // Hunk ids are annotated inline so the model can reference them exactly.
+    diff.files.map(renderFile).join("\n\n"),
   ]
     .filter(Boolean)
     .join("\n\n");

--- a/apps/extension/src/lib/review/reviewPlan.test.ts
+++ b/apps/extension/src/lib/review/reviewPlan.test.ts
@@ -1,12 +1,6 @@
 import { describe, expect, it } from "vitest";
-import {
-  isCompleteReviewUnit,
-  mergePlans,
-  prefixChunkUnitId,
-  validateAndCleanPlan,
-  validateAndCleanUnit,
-} from "./reviewPlan";
-import type { ParsedDiff, ReviewPlan, ReviewUnit } from "../types";
+import { isCompleteReviewUnit, prefixChunkUnitId, validateAndCleanUnit } from "./reviewPlan";
+import type { ParsedDiff, ReviewUnit } from "../types";
 
 function diffFixture(): ParsedDiff {
   return {
@@ -31,122 +25,75 @@ function diffFixture(): ParsedDiff {
   };
 }
 
-describe("validateAndCleanPlan", () => {
-  it("keeps a unit whose file/hunk refs all exist in the diff", () => {
-    const plan: ReviewPlan = {
-      units: [
-        {
-          id: "u1",
-          title: "Update foo",
-          context: "because",
-          files: [{ fileId: "src/foo.ts", hunkIds: ["src/foo.ts#0"], role: "core_logic" }],
-        },
-      ],
-    };
+describe("validateAndCleanUnit", () => {
+  function unitWith(files: ReviewUnit["files"]): ReviewUnit {
+    return { id: "u1", title: "Update foo", context: "because", files };
+  }
 
-    const cleaned = validateAndCleanPlan(plan, diffFixture());
-    expect(cleaned.units).toHaveLength(1);
-    expect(cleaned.units[0].files[0].hunkIds).toEqual(["src/foo.ts#0"]);
+  it("keeps a unit whose file/hunk refs all exist in the diff", () => {
+    const cleaned = validateAndCleanUnit(
+      unitWith([{ fileId: "src/foo.ts", hunkIds: ["src/foo.ts#0"], role: "core_logic" }]),
+      diffFixture(),
+    );
+
+    expect(cleaned?.files[0].hunkIds).toEqual(["src/foo.ts#0"]);
   });
 
   it("drops hallucinated hunk ids but keeps the file ref if the file is real", () => {
-    const plan: ReviewPlan = {
-      units: [
-        {
-          id: "u1",
-          title: "Update foo",
-          context: "because",
-          files: [
-            {
-              fileId: "src/foo.ts",
-              hunkIds: ["src/foo.ts#0", "src/foo.ts#99"],
-              role: "core_logic",
-            },
-          ],
-        },
-      ],
-    };
+    const cleaned = validateAndCleanUnit(
+      unitWith([
+        { fileId: "src/foo.ts", hunkIds: ["src/foo.ts#0", "src/foo.ts#99"], role: "core_logic" },
+      ]),
+      diffFixture(),
+    );
 
-    const cleaned = validateAndCleanPlan(plan, diffFixture());
-    expect(cleaned.units[0].files[0].hunkIds).toEqual(["src/foo.ts#0"]);
-  });
-
-  it("drops a file ref entirely when the file doesn't exist in the diff", () => {
-    const plan: ReviewPlan = {
-      units: [
-        {
-          id: "u1",
-          title: "Hallucinated file",
-          context: "because",
-          files: [{ fileId: "src/does-not-exist.ts", hunkIds: [], role: "core_logic" }],
-        },
-      ],
-    };
-
-    const cleaned = validateAndCleanPlan(plan, diffFixture());
-    expect(cleaned.units).toHaveLength(0);
-  });
-
-  it("drops the whole unit when every file ref is invalid", () => {
-    const plan: ReviewPlan = {
-      units: [
-        {
-          id: "u1",
-          title: "All hallucinated",
-          context: "because",
-          files: [{ fileId: "nope.ts", hunkIds: [], role: "core_logic" }],
-        },
-        {
-          id: "u2",
-          title: "Real",
-          context: "because",
-          files: [{ fileId: "src/foo.ts", hunkIds: [], role: "core_logic" }],
-        },
-      ],
-    };
-
-    const cleaned = validateAndCleanPlan(plan, diffFixture());
-    expect(cleaned.units.map((u) => u.id)).toEqual(["u2"]);
+    expect(cleaned?.files[0].hunkIds).toEqual(["src/foo.ts#0"]);
   });
 
   it("treats an empty hunkIds list as a whole-file reference and keeps it", () => {
-    const plan: ReviewPlan = {
-      units: [
-        {
-          id: "u1",
-          title: "Whole file",
-          context: "because",
-          files: [{ fileId: "src/foo.ts", hunkIds: [], role: "core_logic" }],
-        },
-      ],
-    };
+    const cleaned = validateAndCleanUnit(
+      unitWith([{ fileId: "src/foo.ts", hunkIds: [], role: "core_logic" }]),
+      diffFixture(),
+    );
 
-    const cleaned = validateAndCleanPlan(plan, diffFixture());
-    expect(cleaned.units).toHaveLength(1);
-    expect(cleaned.units[0].files[0].hunkIds).toEqual([]);
+    expect(cleaned?.files).toHaveLength(1);
+    expect(cleaned?.files[0].hunkIds).toEqual([]);
   });
-});
 
-describe("validateAndCleanUnit", () => {
-  it("returns a cleaned unit or null when nothing real remains", () => {
-    const good: ReviewUnit = {
-      id: "u1",
-      title: "Update foo",
-      context: "because",
-      files: [
-        { fileId: "src/foo.ts", hunkIds: ["src/foo.ts#0", "src/foo.ts#99"], role: "core_logic" },
-      ],
-    };
-    const cleaned = validateAndCleanUnit(good, diffFixture());
-    expect(cleaned?.files[0].hunkIds).toEqual(["src/foo.ts#0"]);
+  it("returns null when every file ref is hallucinated", () => {
+    const cleaned = validateAndCleanUnit(
+      unitWith([{ fileId: "src/does-not-exist.ts", hunkIds: [], role: "core_logic" }]),
+      diffFixture(),
+    );
 
-    const bad: ReviewUnit = {
-      id: "u2",
-      title: "Nope",
-      context: "",
-      files: [{ fileId: "missing.ts", hunkIds: [], role: "core_logic" }],
-    };
-    expect(validateAndCleanUnit(bad, diffFixture())).toBeNull();
+    expect(cleaned).toBeNull();
+  });
+
+  it("accepts a prebuilt known-files map as well as a diff", () => {
+    const diff = diffFixture();
+    const knownFiles = new Map(diff.files.map((f) => [f.path, f]));
+
+    const cleaned = validateAndCleanUnit(
+      unitWith([{ fileId: "src/foo.ts", hunkIds: [], role: "core_logic" }]),
+      knownFiles,
+    );
+
+    expect(cleaned?.id).toBe("u1");
+  });
+
+  it("falls back to core_logic for an unrecognized role", () => {
+    const cleaned = validateAndCleanUnit(
+      unitWith([
+        {
+          fileId: "src/foo.ts",
+          hunkIds: [],
+          role: "not_a_real_role" as ReviewUnit["files"][number]["role"],
+        },
+      ]),
+      diffFixture(),
+    );
+
+    expect(cleaned?.files[0].role).toBe("core_logic");
   });
 });
 
@@ -169,24 +116,5 @@ describe("prefixChunkUnitId", () => {
   it("namespaces unit ids by chunk index", () => {
     expect(prefixChunkUnitId(0, "u1")).toBe("c0-u1");
     expect(prefixChunkUnitId(2, "add-field")).toBe("c2-add-field");
-  });
-});
-
-describe("mergePlans", () => {
-  it("prefixes unit ids per chunk so units from different chunks never collide", () => {
-    const planA: ReviewPlan = {
-      units: [{ id: "u1", title: "A", context: "", files: [] }],
-    };
-    const planB: ReviewPlan = {
-      units: [{ id: "u1", title: "B", context: "", files: [] }],
-    };
-
-    const merged = mergePlans([planA, planB]);
-    expect(merged.units.map((u) => u.id)).toEqual(["c0-u1", "c1-u1"]);
-    expect(merged.units.map((u) => u.title)).toEqual(["A", "B"]);
-  });
-
-  it("returns an empty plan for no input plans", () => {
-    expect(mergePlans([])).toEqual({ units: [] });
   });
 });

--- a/apps/extension/src/lib/review/reviewPlan.test.ts
+++ b/apps/extension/src/lib/review/reviewPlan.test.ts
@@ -1,28 +1,26 @@
 import { describe, expect, it } from "vitest";
 import { isCompleteReviewUnit, prefixChunkUnitId, validateAndCleanUnit } from "./reviewPlan";
-import type { ParsedDiff, ReviewUnit } from "../types";
+import type { DiffFile, ReviewUnit } from "../types";
 
-function diffFixture(): ParsedDiff {
-  return {
-    files: [
+/** The known-files map `validateAndCleanUnit` validates against. */
+function diffFixture(): Map<string, DiffFile> {
+  const file: DiffFile = {
+    path: "src/foo.ts",
+    status: "modified",
+    isBinaryOrElided: false,
+    hunks: [
       {
-        path: "src/foo.ts",
-        status: "modified",
-        isBinaryOrElided: false,
-        hunks: [
-          {
-            id: "src/foo.ts#0",
-            header: "@@ -1,1 +1,1 @@",
-            oldStart: 1,
-            oldLines: 1,
-            newStart: 1,
-            newLines: 1,
-            lines: [],
-          },
-        ],
+        id: "src/foo.ts#0",
+        header: "@@ -1,1 +1,1 @@",
+        oldStart: 1,
+        oldLines: 1,
+        newStart: 1,
+        newLines: 1,
+        lines: [],
       },
     ],
   };
+  return new Map([[file.path, file]]);
 }
 
 describe("validateAndCleanUnit", () => {
@@ -67,18 +65,6 @@ describe("validateAndCleanUnit", () => {
     );
 
     expect(cleaned).toBeNull();
-  });
-
-  it("accepts a prebuilt known-files map as well as a diff", () => {
-    const diff = diffFixture();
-    const knownFiles = new Map(diff.files.map((f) => [f.path, f]));
-
-    const cleaned = validateAndCleanUnit(
-      unitWith([{ fileId: "src/foo.ts", hunkIds: [], role: "core_logic" }]),
-      knownFiles,
-    );
-
-    expect(cleaned?.id).toBe("u1");
   });
 
   it("falls back to core_logic for an unrecognized role", () => {

--- a/apps/extension/src/lib/review/reviewPlan.ts
+++ b/apps/extension/src/lib/review/reviewPlan.ts
@@ -1,12 +1,7 @@
-import type { FileRole, ParsedDiff, ReviewPlan, ReviewUnit, ReviewUnitFileRef } from "../types";
+import type { ParsedDiff, ReviewUnit, ReviewUnitFileRef } from "../types";
+import { DEFAULT_FILE_ROLE, FILE_ROLES } from "../types";
 
-const FILE_ROLES: ReadonlySet<string> = new Set([
-  "schema_or_model",
-  "core_logic",
-  "consumer_or_call_site",
-  "test",
-  "config_or_generated",
-]);
+const KNOWN_FILE_ROLES: ReadonlySet<string> = new Set(FILE_ROLES);
 
 /**
  * Namespace a unit id by chunk index so units from different `chunkDiffByFile`
@@ -17,28 +12,14 @@ export function prefixChunkUnitId(chunkIndex: number, unitId: string): string {
 }
 
 /**
- * The LLM plans structure and writes commentary, but the actual code shown
- * to the reviewer must always come from the real diff. This validates every
- * fileId/hunkId the model referenced against the diff it was given, dropping
- * (rather than trusting) anything that doesn't exist — a model that
- * hallucinates a file path should never surface as a broken or misleading
- * step in the UI.
- */
-export function validateAndCleanPlan(plan: ReviewPlan, diff: ParsedDiff): ReviewPlan {
-  const knownFiles = new Map(diff.files.map((f) => [f.path, f]));
-  const cleanedUnits: ReviewUnit[] = [];
-
-  for (const unit of plan.units) {
-    const cleaned = validateAndCleanUnit(unit, knownFiles);
-    if (cleaned) cleanedUnits.push(cleaned);
-  }
-
-  return { units: cleanedUnits };
-}
-
-/**
  * Validate a single review unit against the real diff. Returns null when
  * nothing real remains (all file refs hallucinated) so callers can drop it.
+ *
+ * The LLM plans structure and writes commentary, but the actual code shown to
+ * the reviewer must always come from the real diff. Every fileId/hunkId the
+ * model referenced is checked against the diff it was given, and anything that
+ * doesn't exist is dropped rather than trusted — a model that hallucinates a
+ * file path should never surface as a broken or misleading step in the UI.
  *
  * Mutates hunk id lists on a shallow copy of the unit's file refs only —
  * never mutates the caller's original unit.
@@ -69,7 +50,7 @@ export function validateAndCleanUnit(
     files.push({
       fileId: ref.fileId,
       hunkIds,
-      role: FILE_ROLES.has(ref.role) ? (ref.role as FileRole) : "core_logic",
+      role: KNOWN_FILE_ROLES.has(ref.role) ? ref.role : DEFAULT_FILE_ROLE,
     });
   }
 
@@ -104,22 +85,4 @@ export function isCompleteReviewUnit(value: unknown): value is ReviewUnit {
   }
 
   return true;
-}
-
-/**
- * Stitch together per-chunk plans into one plan, namespacing ids per chunk so
- * units from different chunks never collide. Used by tests and any non-stream
- * batch path; the live stream path prefixes via `prefixChunkUnitId` as units
- * arrive.
- */
-export function mergePlans(plans: ReviewPlan[]): ReviewPlan {
-  const units: ReviewUnit[] = [];
-
-  plans.forEach((plan, chunkIndex) => {
-    for (const unit of plan.units) {
-      units.push({ ...unit, id: prefixChunkUnitId(chunkIndex, unit.id) });
-    }
-  });
-
-  return { units };
 }

--- a/apps/extension/src/lib/review/reviewPlan.ts
+++ b/apps/extension/src/lib/review/reviewPlan.ts
@@ -1,4 +1,4 @@
-import type { ParsedDiff, ReviewUnit, ReviewUnitFileRef } from "../types";
+import type { DiffFile, ReviewUnit, ReviewUnitFileRef } from "../types";
 import { DEFAULT_FILE_ROLE, FILE_ROLES } from "../types";
 
 const KNOWN_FILE_ROLES: ReadonlySet<string> = new Set(FILE_ROLES);
@@ -26,13 +26,8 @@ export function prefixChunkUnitId(chunkIndex: number, unitId: string): string {
  */
 export function validateAndCleanUnit(
   unit: ReviewUnit,
-  diffOrKnownFiles: ParsedDiff | Map<string, ParsedDiff["files"][number]>,
+  knownFiles: Map<string, DiffFile>,
 ): ReviewUnit | null {
-  const knownFiles =
-    diffOrKnownFiles instanceof Map
-      ? diffOrKnownFiles
-      : new Map(diffOrKnownFiles.files.map((f) => [f.path, f]));
-
   const files: ReviewUnitFileRef[] = [];
 
   for (const ref of unit.files) {

--- a/apps/extension/src/lib/review/reviewSchema.test.ts
+++ b/apps/extension/src/lib/review/reviewSchema.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { REVIEW_PLAN_JSON_SCHEMA } from "./reviewSchema";
+import { validateAndCleanUnit } from "./reviewPlan";
+import { FILE_ROLES, type ParsedDiff, type ReviewUnit } from "../types";
+
+const roleSchema =
+  REVIEW_PLAN_JSON_SCHEMA.properties.units.items.properties.files.items.properties.role;
+
+function diffWith(path: string): ParsedDiff {
+  return {
+    files: [{ path, status: "modified", isBinaryOrElided: false, hunks: [] }],
+  };
+}
+
+describe("REVIEW_PLAN_JSON_SCHEMA", () => {
+  it("advertises exactly the roles declared in FILE_ROLES", () => {
+    expect([...roleSchema.enum]).toEqual([...FILE_ROLES]);
+  });
+
+  it("accepts every advertised role through runtime validation", () => {
+    // The model can only return roles the schema allows, so validation must not
+    // silently rewrite any of them — a mismatch here means a role was added to
+    // the schema but not to the validator's known set.
+    for (const role of FILE_ROLES) {
+      const unit: ReviewUnit = {
+        id: `u-${role}`,
+        title: "T",
+        context: "C",
+        files: [{ fileId: "src/foo.ts", hunkIds: [], role }],
+      };
+
+      const cleaned = validateAndCleanUnit(unit, diffWith("src/foo.ts"));
+      expect(cleaned?.files[0].role).toBe(role);
+    }
+  });
+});

--- a/apps/extension/src/lib/review/reviewSchema.test.ts
+++ b/apps/extension/src/lib/review/reviewSchema.test.ts
@@ -1,15 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { REVIEW_PLAN_JSON_SCHEMA } from "./reviewSchema";
 import { validateAndCleanUnit } from "./reviewPlan";
-import { FILE_ROLES, type ParsedDiff, type ReviewUnit } from "../types";
+import { FILE_ROLES, type DiffFile, type ReviewUnit } from "../types";
 
 const roleSchema =
   REVIEW_PLAN_JSON_SCHEMA.properties.units.items.properties.files.items.properties.role;
 
-function diffWith(path: string): ParsedDiff {
-  return {
-    files: [{ path, status: "modified", isBinaryOrElided: false, hunks: [] }],
-  };
+function diffWith(path: string): Map<string, DiffFile> {
+  return new Map([[path, { path, status: "modified", isBinaryOrElided: false, hunks: [] }]]);
 }
 
 describe("REVIEW_PLAN_JSON_SCHEMA", () => {

--- a/apps/extension/src/lib/review/reviewSchema.ts
+++ b/apps/extension/src/lib/review/reviewSchema.ts
@@ -1,3 +1,5 @@
+import { FILE_ROLES } from "../types";
+
 /**
  * JSON schema for the structured `ReviewPlan` output. Shared by every
  * provider so behavior is consistent regardless of which model produced it.
@@ -45,13 +47,7 @@ export const REVIEW_PLAN_JSON_SCHEMA = {
                 },
                 role: {
                   type: "string",
-                  enum: [
-                    "schema_or_model",
-                    "core_logic",
-                    "consumer_or_call_site",
-                    "test",
-                    "config_or_generated",
-                  ],
+                  enum: FILE_ROLES,
                 },
               },
               required: ["fileId", "hunkIds", "role"],

--- a/apps/extension/src/lib/review/streamPlanParser.ts
+++ b/apps/extension/src/lib/review/streamPlanParser.ts
@@ -49,11 +49,6 @@ export class StreamPlanParser {
     }
   }
 
-  /** Full buffered text (for debugging / final validation). */
-  getText(): string {
-    return this.buffer;
-  }
-
   private extractCompletedUnits(): ReviewUnit[] {
     if (this.unitsArrayStart < 0) {
       const start = findUnitsArrayStart(this.buffer);

--- a/apps/extension/src/lib/settings.test.ts
+++ b/apps/extension/src/lib/settings.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import { getProviderSettings, onProviderSettingsChanged, setProviderSettings } from "./settings";
-import { DEFAULT_MODELS } from "./types";
+import { defaultModelFor } from "./providers/catalog";
 
 describe("settings", () => {
   it("returns fallback settings when nothing is stored", async () => {
     const settings = await getProviderSettings();
     expect(settings).toEqual({
       provider: "anthropic",
-      model: DEFAULT_MODELS.anthropic,
+      model: defaultModelFor("anthropic"),
       apiKey: "",
     });
   });
@@ -23,7 +23,7 @@ describe("settings", () => {
       "guidedReview.providerSettings": { provider: "grok", apiKey: "x" },
     });
     const settings = await getProviderSettings();
-    expect(settings.model).toBe(DEFAULT_MODELS.grok);
+    expect(settings.model).toBe(defaultModelFor("grok"));
   });
 
   it("onProviderSettingsChanged fires with normalized settings on save", async () => {

--- a/apps/extension/src/lib/settings.ts
+++ b/apps/extension/src/lib/settings.ts
@@ -1,21 +1,29 @@
 import type { ProviderSettings } from "./types";
-import { DEFAULT_MODELS } from "./types";
-import { normalizeProviderSettings } from "./providers/catalog";
+import { defaultModelFor, normalizeProviderSettings } from "./providers/catalog";
+import { watchLocal } from "./storage";
 
 const STORAGE_KEY = "guidedReview.providerSettings";
 
 const FALLBACK_SETTINGS: ProviderSettings = {
   provider: "anthropic",
-  model: DEFAULT_MODELS.anthropic,
+  model: defaultModelFor("anthropic"),
   apiKey: "",
 };
+
+function parseSettings(raw: unknown): ProviderSettings {
+  if (!raw) return FALLBACK_SETTINGS;
+  return normalizeProviderSettings(raw as Partial<ProviderSettings>);
+}
+
+// Both accessors below deliberately skip the swallow-and-warn helpers in
+// `storage.ts`: a failed read must not look like "no API key configured", and
+// the options page reports a failed save to the user. Only the change listener
+// is shared.
 
 /** Read the user's configured provider settings from chrome.storage.local. */
 export async function getProviderSettings(): Promise<ProviderSettings> {
   const result = await chrome.storage.local.get(STORAGE_KEY);
-  const stored = result[STORAGE_KEY] as Partial<ProviderSettings> | undefined;
-  if (!stored) return FALLBACK_SETTINGS;
-  return normalizeProviderSettings(stored);
+  return parseSettings(result[STORAGE_KEY]);
 }
 
 export async function setProviderSettings(settings: ProviderSettings): Promise<void> {
@@ -29,17 +37,5 @@ export async function setProviderSettings(settings: ProviderSettings): Promise<v
 export function onProviderSettingsChanged(
   listener: (settings: ProviderSettings) => void,
 ): () => void {
-  const handler = (
-    changes: Record<string, chrome.storage.StorageChange>,
-    areaName: string,
-  ): void => {
-    if (areaName !== "local") return;
-    const change = changes[STORAGE_KEY];
-    if (!change) return;
-    const next = change.newValue as Partial<ProviderSettings> | undefined;
-    listener(next ? normalizeProviderSettings(next) : FALLBACK_SETTINGS);
-  };
-
-  chrome.storage.onChanged.addListener(handler);
-  return () => chrome.storage.onChanged.removeListener(handler);
+  return watchLocal(STORAGE_KEY, parseSettings, listener);
 }

--- a/apps/extension/src/lib/storage.ts
+++ b/apps/extension/src/lib/storage.ts
@@ -1,0 +1,53 @@
+/**
+ * Thin helpers over `chrome.storage.local` for the extension's single-key
+ * preferences. Each caller supplies a `parse` that turns the raw stored value
+ * (possibly `undefined` or stale) into a valid value of its own type.
+ */
+
+/**
+ * Read one key. Storage failures are logged and fall back to `parse(undefined)`
+ * — a preference that can't be read should never break the flow reading it.
+ * Callers that need a read failure to surface should call `chrome.storage.local`
+ * directly.
+ */
+export async function readLocal<T>(key: string, parse: (raw: unknown) => T): Promise<T> {
+  try {
+    const result = await chrome.storage.local.get(key);
+    return parse(result[key]);
+  } catch (error) {
+    console.warn(`Guided Review: failed to read ${key}`, error);
+    return parse(undefined);
+  }
+}
+
+/** Write one key. Failures are non-fatal and logged. */
+export async function writeLocal(key: string, value: unknown): Promise<void> {
+  try {
+    await chrome.storage.local.set({ [key]: value });
+  } catch (error) {
+    console.warn(`Guided Review: failed to persist ${key}`, error);
+  }
+}
+
+/**
+ * Watch one key for changes (e.g. the options page while a PR tab is open).
+ * Returns an unsubscribe function.
+ */
+export function watchLocal<T>(
+  key: string,
+  parse: (raw: unknown) => T,
+  listener: (value: T) => void,
+): () => void {
+  const handler = (
+    changes: Record<string, chrome.storage.StorageChange>,
+    areaName: string,
+  ): void => {
+    if (areaName !== "local") return;
+    const change = changes[key];
+    if (!change) return;
+    listener(parse(change.newValue));
+  };
+
+  chrome.storage.onChanged.addListener(handler);
+  return () => chrome.storage.onChanged.removeListener(handler);
+}

--- a/apps/extension/src/lib/types.ts
+++ b/apps/extension/src/lib/types.ts
@@ -107,11 +107,10 @@ export interface ReviewPlan {
 }
 
 // ---- Provider / settings -----------------------------------------------------
-// ProviderId and DEFAULT_MODELS live in the catalog so the options UI and
-// background clients share one registry of providers/models.
+// ProviderId lives in the catalog so the options UI and background clients
+// share one registry of providers/models.
 
 export type { ProviderId } from "./providers/catalog";
-export { DEFAULT_MODELS } from "./providers/catalog";
 import type { ProviderId } from "./providers/catalog";
 
 export interface ProviderSettings {

--- a/apps/extension/src/lib/types.ts
+++ b/apps/extension/src/lib/types.ts
@@ -56,8 +56,35 @@ export interface PRContext {
 
 // ---- Review plan (LLM structured output) ------------------------------------
 
-export type FileRole =
-  "schema_or_model" | "core_logic" | "consumer_or_call_site" | "test" | "config_or_generated";
+/**
+ * The roles a changed file can play in a review unit, in review order.
+ * Single source of truth: the `FileRole` union, the runtime validation set in
+ * `review/reviewPlan.ts`, and the JSON Schema enum in `review/reviewSchema.ts`
+ * are all derived from this array.
+ */
+export const FILE_ROLES = [
+  "schema_or_model",
+  "core_logic",
+  "consumer_or_call_site",
+  "test",
+  "config_or_generated",
+] as const;
+
+export type FileRole = (typeof FILE_ROLES)[number];
+
+/** Role assigned when the model omits one or returns something unrecognized. */
+export const DEFAULT_FILE_ROLE: FileRole = "core_logic";
+
+/**
+ * Shown when a review that requires a summary is submitted without one. The
+ * overlay checks this before calling the background worker so the user gets
+ * the error without a round-trip; `submitReview.ts` enforces it again because
+ * it is the actual boundary to GitHub.
+ */
+export const EMPTY_REVIEW_BODY_MESSAGE: Record<"COMMENT" | "REQUEST_CHANGES", string> = {
+  COMMENT: "Add a review comment before submitting.",
+  REQUEST_CHANGES: "Add a summary explaining the requested changes before submitting.",
+};
 
 export interface ReviewUnitFileRef {
   fileId: string;

--- a/apps/extension/src/lib/useCopyToClipboard.ts
+++ b/apps/extension/src/lib/useCopyToClipboard.ts
@@ -1,0 +1,57 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/** How long the "Copied" confirmation stays up before reverting. */
+const COPIED_RESET_MS = 2000;
+
+/**
+ * Copy text and flag it for a couple of seconds so a button can read "Copied".
+ * Shared by the options GitHub section and the overlay's Connect GitHub modal.
+ *
+ * A failed write (no permission, insecure context) leaves `copied` false so the
+ * label never claims a copy that did not happen — the user can still select the
+ * code by hand.
+ */
+export function useCopyToClipboard(resetAfterMs: number = COPIED_RESET_MS): {
+  copied: boolean;
+  copy: (text: string) => Promise<void>;
+  resetCopied: () => void;
+} {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  // Without this, the timer fires after the modal closes and flips state on an
+  // unmounted component.
+  useEffect(() => clearTimer, [clearTimer]);
+
+  const copy = useCallback(
+    async (text: string) => {
+      try {
+        await navigator.clipboard.writeText(text);
+        clearTimer();
+        setCopied(true);
+        timerRef.current = setTimeout(() => {
+          timerRef.current = null;
+          setCopied(false);
+        }, resetAfterMs);
+      } catch {
+        clearTimer();
+        setCopied(false);
+      }
+    },
+    [clearTimer, resetAfterMs],
+  );
+
+  const resetCopied = useCallback(() => {
+    clearTimer();
+    setCopied(false);
+  }, [clearTimer]);
+
+  return { copied, copy, resetCopied };
+}

--- a/apps/extension/src/options/GitHubAuthSection.test.tsx
+++ b/apps/extension/src/options/GitHubAuthSection.test.tsx
@@ -14,7 +14,10 @@ vi.mock("../lib/messaging", () => ({
   clearGitHubAuthSession: vi.fn(),
 }));
 
-vi.mock("../lib/github/oauthConfig", () => ({
+// Only the configured check is stubbed — the copy constants come from the real
+// module so a wording/name change is caught here rather than mocked away.
+vi.mock("../lib/github/oauthConfig", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/github/oauthConfig")>()),
   isGitHubOAuthConfigured: vi.fn(() => true),
 }));
 

--- a/apps/extension/src/options/GitHubAuthSection.tsx
+++ b/apps/extension/src/options/GitHubAuthSection.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import type { GitHubPublicAuthState } from "../lib/types";
-import { isGitHubOAuthConfigured } from "../lib/github/oauthConfig";
+import { GITHUB_CLIENT_ID_ENV_VAR, isGitHubOAuthConfigured } from "../lib/github/oauthConfig";
+import { useCopyToClipboard } from "../lib/useCopyToClipboard";
 import { openVerificationUri, useGitHubDeviceAuth } from "../lib/github/useGitHubDeviceAuth";
 import { clearGitHubAuthSession, getGitHubAuthStatus } from "../lib/messaging";
 import { confirm, ConfirmationHost } from "../content/overlay/components/confirmation";
@@ -20,7 +21,7 @@ export function GitHubAuthSection() {
   const [session, setSession] = useState<SessionState>({ kind: "loading" });
   const [disconnectBusy, setDisconnectBusy] = useState(false);
   const [disconnectError, setDisconnectError] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
+  const { copied, copy: copyUserCode, resetCopied } = useCopyToClipboard();
 
   const {
     flow,
@@ -61,7 +62,7 @@ export function GitHubAuthSection() {
 
   const onCancel = () => {
     cancel();
-    setCopied(false);
+    resetCopied();
   };
 
   const performDisconnect = async () => {
@@ -92,16 +93,6 @@ export function GitHubAuthSection() {
     });
   };
 
-  const onCopyCode = async (code: string) => {
-    try {
-      await navigator.clipboard.writeText(code);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 2000);
-    } catch {
-      setCopied(false);
-    }
-  };
-
   const busy = connectBusy || disconnectBusy;
   const showError = flow.kind === "error" ? flow.message : disconnectError;
 
@@ -117,7 +108,7 @@ export function GitHubAuthSection() {
         <p className="text-base text-opt-muted" role="status">
           GitHub connection isn’t configured in this build. Set{" "}
           <code className="rounded bg-opt-subtle px-1 py-0.5 text-sm text-opt-text">
-            VITE_GITHUB_CLIENT_ID
+            {GITHUB_CLIENT_ID_ENV_VAR}
           </code>{" "}
           and rebuild.
         </p>
@@ -157,7 +148,7 @@ export function GitHubAuthSection() {
             </code>
             <Button
               variant="secondary"
-              onClick={() => void onCopyCode(flow.userCode)}
+              onClick={() => void copyUserCode(flow.userCode)}
               data-testid="github-copy-code"
             >
               {copied ? "Copied" : "Copy Code"}

--- a/apps/extension/src/options/Options.test.tsx
+++ b/apps/extension/src/options/Options.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { Options } from "./Options";
-import { DEFAULT_MODELS } from "../lib/types";
+import { defaultModelFor } from "../lib/providers/catalog";
 
 async function chooseOption(
   user: ReturnType<typeof userEvent.setup>,
@@ -63,7 +63,7 @@ describe("Options", () => {
     const stored = await chrome.storage.local.get("guidedReview.providerSettings");
     expect(stored["guidedReview.providerSettings"]).toEqual({
       provider: "anthropic",
-      model: DEFAULT_MODELS.anthropic,
+      model: defaultModelFor("anthropic"),
       apiKey: "sk-new-key",
     });
   });

--- a/apps/web/components/ShortcutChord.tsx
+++ b/apps/web/components/ShortcutChord.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { Fragment, useSyncExternalStore } from "react";
-import { Kbd, KbdGroup } from "@guided-review/ui";
-import { isMacPlatform } from "../lib/platform";
+import { isMacPlatform, Kbd, KbdGroup } from "@guided-review/ui";
 
 function subscribe() {
   return () => {};

--- a/apps/web/components/icons.tsx
+++ b/apps/web/components/icons.tsx
@@ -14,65 +14,6 @@ function base(props: SVGProps<SVGSVGElement>) {
   };
 }
 
-export function LayersIcon(props: SVGProps<SVGSVGElement>) {
-  return (
-    <svg {...base(props)}>
-      <path d="M12 2 2 7l10 5 10-5-10-5Z" />
-      <path d="m2 17 10 5 10-5" />
-      <path d="m2 12 10 5 10-5" />
-    </svg>
-  );
-}
-
-export function DiffIcon(props: SVGProps<SVGSVGElement>) {
-  return (
-    <svg {...base(props)}>
-      <path d="M9 3v12" />
-      <path d="M9 15h6a3 3 0 0 0 3-3V9" />
-      <path d="m6 6 3-3 3 3" />
-      <path d="m15 12 3-3 3 3" />
-    </svg>
-  );
-}
-
-export function PlugIcon(props: SVGProps<SVGSVGElement>) {
-  return (
-    <svg {...base(props)}>
-      <path d="M12 22v-5" />
-      <path d="M9 8V2" />
-      <path d="M15 8V2" />
-      <path d="M18 8v3a6 6 0 0 1-12 0V8Z" />
-    </svg>
-  );
-}
-
-export function CheckShieldIcon(props: SVGProps<SVGSVGElement>) {
-  return (
-    <svg {...base(props)}>
-      <path d="M12 2 4 5v6c0 5 3.4 8.5 8 11 4.6-2.5 8-6 8-11V5l-8-3Z" />
-      <path d="m9 12 2 2 4-4" />
-    </svg>
-  );
-}
-
-export function KeyboardIcon(props: SVGProps<SVGSVGElement>) {
-  return (
-    <svg {...base(props)}>
-      <rect x="2" y="6" width="20" height="12" rx="2" />
-      <path d="M6 10h.01M10 10h.01M14 10h.01M18 10h.01M7 14h10" />
-    </svg>
-  );
-}
-
-export function SparkleIcon(props: SVGProps<SVGSVGElement>) {
-  return (
-    <svg {...base({ ...props, fill: "currentColor", stroke: "none" })}>
-      <path d="M12 2c.6 3.6 2.4 5.4 6 6-3.6.6-5.4 2.4-6 6-.6-3.6-2.4-5.4-6-6 3.6-.6 5.4-2.4 6-6Z" />
-      <path d="M19 15c.3 1.6 1.1 2.4 2.7 2.7-1.6.3-2.4 1.1-2.7 2.7-.3-1.6-1.1-2.4-2.7-2.7 1.6-.3 2.4-1.1 2.7-2.7Z" />
-    </svg>
-  );
-}
-
 export function GitHubIcon(props: SVGProps<SVGSVGElement>) {
   return (
     <svg {...base({ ...props, fill: "currentColor", stroke: "none" })}>

--- a/apps/web/content/help/configure-provider.mdx
+++ b/apps/web/content/help/configure-provider.mdx
@@ -57,11 +57,11 @@ If the test fails, step through [Troubleshooting → Provider and API key](/docs
 
 ## Where settings live
 
-| Setting                               | Storage                  | Used by                          |
-| ------------------------------------- | ------------------------ | -------------------------------- |
-| Provider, model, API key              | `chrome.storage.local`   | Background worker                |
-| Automatically open on Files changed   | `chrome.storage.local`   | Content script (auto-open)       |
-| Active review session                 | `chrome.storage.session` | Content overlay (session-scoped) |
+| Setting                             | Storage                  | Used by                          |
+| ----------------------------------- | ------------------------ | -------------------------------- |
+| Provider, model, API key            | `chrome.storage.local`   | Background worker                |
+| Automatically open on Files changed | `chrome.storage.local`   | Content script (auto-open)       |
+| Active review session               | `chrome.storage.session` | Content overlay (session-scoped) |
 
 Session resume behavior: [Your first review → Resume later](/docs/first-review#resume-later) and [Troubleshooting](/docs/troubleshooting#session-and-resume).
 

--- a/packages/ui/src/components/Input.tsx
+++ b/packages/ui/src/components/Input.tsx
@@ -10,32 +10,28 @@ export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   surface?: Surface;
 }
 
-export function inputClassName({
-  surface = "app",
-  className,
-}: {
-  surface?: Surface;
-  className?: string;
-} = {}): string {
-  return cn(
-    "w-full rounded-md border px-2.5 py-2 text-base",
-    "disabled:cursor-not-allowed disabled:opacity-60",
-    surface === "overlay"
-      ? cn(
-          "border-gr-border bg-gr-bg text-gr-text placeholder:text-gr-faint",
-          "focus:border-gr-accent focus:outline-none",
-        )
-      : cn(
-          "border-opt-border bg-opt-subtle text-opt-text placeholder:text-opt-muted",
-          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-opt-accent",
-        ),
-    className,
-  );
-}
-
 export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
   { surface = "app", className, ...props },
   ref,
 ) {
-  return <input ref={ref} className={inputClassName({ surface, className })} {...props} />;
+  return (
+    <input
+      ref={ref}
+      className={cn(
+        "w-full rounded-md border px-2.5 py-2 text-base",
+        "disabled:cursor-not-allowed disabled:opacity-60",
+        surface === "overlay"
+          ? cn(
+              "border-gr-border bg-gr-bg text-gr-text placeholder:text-gr-faint",
+              "focus:border-gr-accent focus:outline-none",
+            )
+          : cn(
+              "border-opt-border bg-opt-subtle text-opt-text placeholder:text-opt-muted",
+              "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-opt-accent",
+            ),
+        className,
+      )}
+      {...props}
+    />
+  );
 });

--- a/packages/ui/src/components/Textarea.tsx
+++ b/packages/ui/src/components/Textarea.tsx
@@ -10,32 +10,28 @@ export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElemen
   surface?: Surface;
 }
 
-export function textareaClassName({
-  surface = "app",
-  className,
-}: {
-  surface?: Surface;
-  className?: string;
-} = {}): string {
-  return cn(
-    "min-h-[88px] w-full resize-y rounded-md border px-3 py-2 font-sans text-base leading-relaxed",
-    "disabled:cursor-not-allowed disabled:opacity-60",
-    surface === "overlay"
-      ? cn(
-          "border-gr-border bg-gr-bg text-gr-text placeholder:text-gr-faint",
-          "focus:border-gr-accent focus:outline-none",
-        )
-      : cn(
-          "border-opt-border bg-opt-subtle text-opt-text placeholder:text-opt-muted",
-          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-opt-accent",
-        ),
-    className,
-  );
-}
-
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
   { surface = "app", className, ...props },
   ref,
 ) {
-  return <textarea ref={ref} className={textareaClassName({ surface, className })} {...props} />;
+  return (
+    <textarea
+      ref={ref}
+      className={cn(
+        "min-h-[88px] w-full resize-y rounded-md border px-3 py-2 font-sans text-base leading-relaxed",
+        "disabled:cursor-not-allowed disabled:opacity-60",
+        surface === "overlay"
+          ? cn(
+              "border-gr-border bg-gr-bg text-gr-text placeholder:text-gr-faint",
+              "focus:border-gr-accent focus:outline-none",
+            )
+          : cn(
+              "border-opt-border bg-opt-subtle text-opt-text placeholder:text-opt-muted",
+              "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-opt-accent",
+            ),
+        className,
+      )}
+      {...props}
+    />
+  );
 });

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,4 +1,5 @@
 export { cn } from "./cn";
+export { isMacPlatform } from "./platform";
 export type { Surface } from "./surface";
 
 export { Spinner } from "./components/Spinner";
@@ -10,10 +11,10 @@ export type { BrandMarkProps } from "./components/BrandMark";
 export { Button, buttonClassName } from "./components/Button";
 export type { ButtonProps, ButtonVariant, ButtonSize } from "./components/Button";
 
-export { Input, inputClassName } from "./components/Input";
+export { Input } from "./components/Input";
 export type { InputProps } from "./components/Input";
 
-export { Textarea, textareaClassName } from "./components/Textarea";
+export { Textarea } from "./components/Textarea";
 export type { TextareaProps } from "./components/Textarea";
 
 export { Label } from "./components/Label";

--- a/packages/ui/src/platform.test.ts
+++ b/packages/ui/src/platform.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isMacPlatform } from "./platform";
+
+function mockNavigator(partial: {
+  platform?: string;
+  userAgent?: string;
+  userAgentData?: { platform?: string };
+}) {
+  vi.stubGlobal("navigator", {
+    platform: partial.platform ?? "",
+    userAgent: partial.userAgent ?? "",
+    userAgentData: partial.userAgentData,
+  });
+}
+
+describe("isMacPlatform", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("detects macOS from navigator.platform", () => {
+    mockNavigator({ platform: "MacIntel" });
+    expect(isMacPlatform()).toBe(true);
+  });
+
+  it("detects macOS from userAgentData.platform", () => {
+    mockNavigator({ platform: "Win32", userAgentData: { platform: "macOS" } });
+    expect(isMacPlatform()).toBe(true);
+  });
+
+  it("detects macOS from userAgent fallback", () => {
+    mockNavigator({
+      platform: "",
+      userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+    });
+    expect(isMacPlatform()).toBe(true);
+  });
+
+  it("returns false for Windows", () => {
+    mockNavigator({ platform: "Win32", userAgent: "Windows NT 10.0" });
+    expect(isMacPlatform()).toBe(false);
+  });
+
+  it("returns false for Linux", () => {
+    mockNavigator({ platform: "Linux x86_64", userAgent: "X11; Linux x86_64" });
+    expect(isMacPlatform()).toBe(false);
+  });
+});

--- a/packages/ui/src/platform.ts
+++ b/packages/ui/src/platform.ts
@@ -1,8 +1,8 @@
 /**
  * OS detection for keyboard-shortcut labels (⌘ vs Ctrl).
- * Safe to call from client components only (reads navigator).
+ * Reads `navigator` only at call time, so it is safe in the extension's
+ * content script and in client components on the marketing site.
  */
-
 export function isMacPlatform(): boolean {
   if (typeof navigator === "undefined") return false;
 


### PR DESCRIPTION
## Summary
- Refactor the Anthropic/OpenAI-compatible provider adapters to share HTTP/SSE handling via `providers/http.ts`, cutting duplicated request/parsing logic
- Extract a shared `useCopyToClipboard` hook used by the options GitHub section and the overlay's Connect GitHub modal
- Extract shared `storage.ts` helpers over `chrome.storage.local` and rebase `autoOpenOnFilesTab.ts` on top of them
- Move `platform.ts` (Mac detection) from `apps/web/lib` into `packages/ui/src` so both apps share one implementation, with new tests
- Various smaller cleanups across overlay components, review plan/schema, and settings

## Test plan
- [x] `npm run typecheck` passes across all workspaces
- [x] `npm run test` passes (416 extension tests, 31 ui tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)