### PR TITLE
test(web): add Playwright e2e suite for marketing site

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -23,6 +23,7 @@ jobs:
     outputs:
       extension: ${{ steps.filter.outputs.extension }}
       ui: ${{ steps.filter.outputs.ui }}
+      web: ${{ steps.filter.outputs.web }}
       root: ${{ steps.filter.outputs.root }}
     steps:
       - uses: actions/checkout@v4
@@ -38,6 +39,12 @@ jobs:
               - 'tsconfig.base.json'
             ui:
               - 'packages/ui/**'
+            web:
+              - 'apps/web/**'
+              - 'packages/ui/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig.base.json'
             root:
               - 'eslint.config.js'
               - '.prettierrc'
@@ -119,4 +126,36 @@ jobs:
           path: |
             apps/extension/playwright-report/
             apps/extension/test-results/
+          retention-days: 7
+
+  e2e-web:
+    name: End-to-end tests (website)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.web == 'true' || github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npm run test:e2e:install -w @guided-review/web
+
+      - name: Run website e2e tests
+        run: npm run test:e2e -w @guided-review/web
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-web
+          path: |
+            apps/web/playwright-report/
+            apps/web/test-results/
           retention-days: 7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,10 +36,12 @@ Root scripts proxy into workspaces. `npm run build` builds **extension then web*
 - `npm run typecheck` — all workspaces with a typecheck script.
 - `npm test` — extension unit tests + `@guided-review/ui` unit tests.
 - `npm run test:e2e` — Playwright e2e against the built extension (builds first).
+- `npm run test:e2e:web` — Playwright e2e against the marketing site static export (builds first).
 - `npm run lint` / `format` / `format:check` — root ESLint + Prettier.
 
 Unit tests live next to source as `apps/extension/src/**/*.test.{ts,tsx}` and
-`packages/ui/src/**/*.test.{ts,tsx}`; e2e specs live under `apps/extension/e2e/`.
+`packages/ui/src/**/*.test.{ts,tsx}`; extension e2e specs live under `apps/extension/e2e/`;
+website e2e specs live under `apps/web/e2e/` (serves `apps/web/out`).
 
 **Always run `npm run build:extension` after extension code changes**, even if `npm run dev` is
 running. **`apps/extension/dist/`** is what's loaded as the unpacked extension, so a stale build

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ npm run build               # extension + web
 npm run build:extension     # → apps/extension/dist
 npm run build:web           # next build
 npm test                    # unit tests (extension + ui)
-npm run test:e2e            # Playwright e2e (builds extension first)
+npm run test:e2e            # Playwright e2e for the extension (builds first)
+npm run test:e2e:web        # Playwright e2e for the marketing site (builds first)
 npm run typecheck           # all workspaces
 npm run lint                # ESLint
 npm run format              # Prettier write

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -26,6 +26,21 @@ npm run start:web        # production preview
 
 Extension HMR uses port **5173**; this app uses **3000**.
 
+## E2E tests
+
+Playwright specs under `e2e/` exercise the **static export** (`out/`), not `next dev`.
+They check route smoke coverage, internal link/asset integrity (no external HTTP checks),
+Open Graph image bytes, SEO meta, and docs registry sync.
+
+```bash
+# from monorepo root
+npm run test:e2e:web                 # build + serve out/ + run specs
+npm run test:e2e:web:ui              # Playwright UI mode
+npm run test:e2e:install -w @guided-review/web   # install Chromium (CI/local once)
+```
+
+Specs use port **4173** for the static server so they do not clash with `dev:web`.
+
 ## Shared UI
 
 Uses `@guided-review/ui` via `transpilePackages` and Tailwind `@source` of `packages/ui` in `app/globals.css`.

--- a/apps/web/e2e/docs.spec.ts
+++ b/apps/web/e2e/docs.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from "@playwright/test";
+import { docsPath, helpPageSlugs, navPages } from "./helpers/routes";
+import { assertStatusOk } from "./helpers/http";
+
+test.describe("docs registry", () => {
+  test("helpPages and helpNavigation stay in sync", () => {
+    const nav = navPages();
+    const navSlugs = new Set(nav.map((p) => p.slug));
+    const pageSlugs = new Set(helpPageSlugs());
+
+    // Intro is slug "" in nav; not a helpPages key
+    const navContentSlugs = new Set([...navSlugs].filter((s) => s !== ""));
+
+    const missingFromPages = [...navContentSlugs].filter((s) => !pageSlugs.has(s));
+    const missingFromNav = [...pageSlugs].filter((s) => !navContentSlugs.has(s));
+
+    expect(
+      missingFromPages,
+      `nav entries without helpPages: ${missingFromPages.join(", ")}`,
+    ).toEqual([]);
+    expect(missingFromNav, `helpPages missing from nav: ${missingFromNav.join(", ")}`).toEqual([]);
+
+    // Intro must exist in nav
+    expect(navSlugs.has("")).toBe(true);
+  });
+
+  test("every docs nav entry is reachable", async ({ request }) => {
+    for (const page of navPages()) {
+      const path = docsPath(page.slug);
+      await assertStatusOk(request, path, `docs ${page.title} (${path})`);
+    }
+  });
+
+  test("every helpPages slug is reachable", async ({ request }) => {
+    for (const slug of helpPageSlugs()) {
+      await assertStatusOk(request, docsPath(slug), `helpPages ${slug}`);
+    }
+  });
+
+  test("docs index and a slug page link to other docs pages", async ({ page }) => {
+    await page.goto("/docs", { waitUntil: "domcontentloaded" });
+    const indexCount = await page.locator('a[href^="/docs"]').count();
+    expect(indexCount, "docs index should link to other docs").toBeGreaterThan(3);
+
+    await page.goto("/docs/install", { waitUntil: "domcontentloaded" });
+    const installCount = await page.locator('a[href^="/docs"]').count();
+    expect(installCount, "docs slug page should link to other docs").toBeGreaterThan(3);
+  });
+});

--- a/apps/web/e2e/helpers/crawl.ts
+++ b/apps/web/e2e/helpers/crawl.ts
@@ -1,0 +1,103 @@
+import type { Page } from "@playwright/test";
+
+export type CollectedAnchor = {
+  href: string;
+  target: string | null;
+  rel: string | null;
+};
+
+export type PageCrawl = {
+  pageUrl: string;
+  anchors: CollectedAnchor[];
+  assets: string[];
+  meta: Record<string, string>;
+  jsonLd: string[];
+  title: string;
+  lang: string | null;
+  hasMain: boolean;
+  h1Count: number;
+  skipLinkHref: string | null;
+};
+
+/**
+ * Collect links, same-document assets, and SEO bits from a loaded page.
+ * Attribute values only — no network.
+ */
+export async function collectFromPage(page: Page): Promise<PageCrawl> {
+  return page.evaluate(() => {
+    const anchors = [...document.querySelectorAll("a[href]")].map((el) => {
+      const a = el as HTMLAnchorElement;
+      return {
+        href: a.getAttribute("href") ?? "",
+        target: a.getAttribute("target"),
+        rel: a.getAttribute("rel"),
+      };
+    });
+
+    const assets = new Set<string>();
+    for (const el of document.querySelectorAll(
+      "img[src], script[src], video[src], source[src], audio[src]",
+    )) {
+      const value = el.getAttribute("src");
+      if (value) assets.add(value);
+    }
+    for (const el of document.querySelectorAll("video[poster]")) {
+      const value = el.getAttribute("poster");
+      if (value) assets.add(value);
+    }
+    for (const el of document.querySelectorAll("link[href]")) {
+      const rel = (el.getAttribute("rel") ?? "").toLowerCase();
+      if (
+        rel.includes("icon") ||
+        rel === "stylesheet" ||
+        rel === "preload" ||
+        rel === "modulepreload"
+      ) {
+        const href = el.getAttribute("href");
+        if (href) assets.add(href);
+      }
+    }
+
+    const meta: Record<string, string> = {};
+    for (const el of document.querySelectorAll("meta[name], meta[property]")) {
+      const key = el.getAttribute("property") ?? el.getAttribute("name");
+      const content = el.getAttribute("content");
+      if (key && content != null) meta[key] = content;
+    }
+    const canonical = document.querySelector("link[rel='canonical']")?.getAttribute("href");
+    if (canonical) meta["link:canonical"] = canonical;
+
+    const jsonLd = [...document.querySelectorAll('script[type="application/ld+json"]')].map(
+      (el) => el.textContent ?? "",
+    );
+
+    const skip = document.querySelector('a[href="#main"]');
+
+    return {
+      pageUrl: location.href,
+      anchors,
+      assets: [...assets],
+      meta,
+      jsonLd,
+      title: document.title,
+      lang: document.documentElement.getAttribute("lang"),
+      hasMain: !!document.getElementById("main"),
+      h1Count: document.querySelectorAll("h1").length,
+      skipLinkHref: skip?.getAttribute("href") ?? null,
+    };
+  });
+}
+
+/** Whether an element with the given id exists in the current document. */
+export async function elementIdExists(page: Page, id: string): Promise<boolean> {
+  if (!id) return false;
+  return page.evaluate((elementId) => {
+    if (document.getElementById(elementId)) return true;
+    // CSS.escape for ids that need it; fallback query
+    try {
+      return !!document.querySelector(`#${CSS.escape(elementId)}`);
+    } catch {
+      return false;
+    }
+  }, id);
+}

--- a/apps/web/e2e/helpers/http.ts
+++ b/apps/web/e2e/helpers/http.ts
@@ -1,0 +1,115 @@
+import type { APIRequestContext } from "@playwright/test";
+import { PRODUCTION_ORIGIN } from "./routes";
+
+const SKIP_SCHEMES = /^(mailto:|tel:|javascript:|data:)/i;
+
+/** True if href should never be HTTP-fetched. */
+export function isSkippableScheme(href: string): boolean {
+  return SKIP_SCHEMES.test(href.trim());
+}
+
+/**
+ * Resolve an href against a page URL, rewriting the production origin to the
+ * local base so absolute site URLs are checked against the build under test.
+ */
+export function resolveHref(
+  href: string,
+  pageUrl: string,
+  baseURL: string,
+): { kind: "skip" } | { kind: "external"; url: URL } | { kind: "internal"; url: URL } {
+  const trimmed = href.trim();
+  if (!trimmed || isSkippableScheme(trimmed)) {
+    return { kind: "skip" };
+  }
+
+  let url: URL;
+  try {
+    url = new URL(trimmed, pageUrl);
+  } catch {
+    return { kind: "skip" };
+  }
+
+  // Map production absolute URLs onto the local static server.
+  if (url.origin === PRODUCTION_ORIGIN || url.hostname === "guidedreview.dev") {
+    const local = new URL(baseURL);
+    url.protocol = local.protocol;
+    url.host = local.host;
+  }
+
+  const base = new URL(baseURL);
+  if (url.origin !== base.origin) {
+    return { kind: "external", url };
+  }
+
+  return { kind: "internal", url };
+}
+
+/** Path + search only (stable key for dedupe of internal resources). */
+export function resourceKey(url: URL): string {
+  return `${url.pathname}${url.search}`;
+}
+
+/** Path without trailing slash (except root), for route comparisons. */
+export function normalizePathname(pathname: string): string {
+  if (pathname.length > 1 && pathname.endsWith("/")) {
+    return pathname.slice(0, -1);
+  }
+  return pathname || "/";
+}
+
+export async function assertStatusOk(
+  request: APIRequestContext,
+  url: string,
+  label?: string,
+): Promise<void> {
+  const response = await request.get(url, { maxRedirects: 5 });
+  const status = response.status();
+  if (status >= 400) {
+    throw new Error(
+      `${label ?? "GET"} ${url} returned ${status}${response.statusText() ? ` ${response.statusText()}` : ""}`,
+    );
+  }
+}
+
+export async function fetchOk(
+  request: APIRequestContext,
+  url: string,
+): Promise<{ status: number; body: Buffer }> {
+  const response = await request.get(url, { maxRedirects: 5 });
+  const status = response.status();
+  const body = Buffer.from(await response.body());
+  return { status, body };
+}
+
+/** PNG signature. */
+export function isPng(buffer: Buffer): boolean {
+  return (
+    buffer.length >= 8 &&
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47 &&
+    buffer[4] === 0x0d &&
+    buffer[5] === 0x0a &&
+    buffer[6] === 0x1a &&
+    buffer[7] === 0x0a
+  );
+}
+
+/**
+ * Read width/height from PNG IHDR (first chunk after 8-byte signature).
+ * Throws if the buffer is not a minimal valid PNG.
+ */
+export function pngSize(buffer: Buffer): { width: number; height: number } {
+  if (!isPng(buffer) || buffer.length < 24) {
+    throw new Error("Not a PNG (missing signature or IHDR)");
+  }
+  // Bytes 8–11: chunk length; 12–15: "IHDR"; 16–23: width/height
+  const type = buffer.subarray(12, 16).toString("ascii");
+  if (type !== "IHDR") {
+    throw new Error(`Expected IHDR chunk, got ${JSON.stringify(type)}`);
+  }
+  const width = buffer.readUInt32BE(16);
+  const height = buffer.readUInt32BE(20);
+  return { width, height };
+}

--- a/apps/web/e2e/helpers/routes.ts
+++ b/apps/web/e2e/helpers/routes.ts
@@ -1,0 +1,50 @@
+import { helpNavigation } from "../../config/help-navigation";
+import { helpPages } from "../../config/help-pages";
+
+/** Static marketing + legal routes (always present). */
+export const STATIC_ROUTES = ["/", "/docs", "/privacy", "/terms", "/cookies"] as const;
+
+/** Production origin used in metadataBase / absolute site links. */
+export const PRODUCTION_ORIGIN = "https://guidedreview.dev";
+
+/** Public assets that must ship even if not currently linked from UI. */
+export const PUBLIC_ASSETS = [
+  "/favicon.ico",
+  "/product-preview/thumbnail.png",
+  "/product-preview/demo.webm",
+  "/mitchell-hashimoto-tweet.png",
+  "/opengraph-image",
+] as const;
+
+export type NavPage = { slug: string; title: string };
+
+/** Non-heading entries from docs sidebar config. */
+export function navPages(): NavPage[] {
+  return helpNavigation
+    .filter((item): item is { slug: string; title: string } => item.type !== "heading")
+    .map((item) => ({ slug: item.slug, title: item.title }));
+}
+
+/** Path for a docs nav slug (`""` → `/docs`). */
+export function docsPath(slug: string): string {
+  return slug === "" ? "/docs" : `/docs/${slug}`;
+}
+
+/** All docs routes from help navigation. */
+export function docRoutesFromNav(): string[] {
+  return navPages().map((p) => docsPath(p.slug));
+}
+
+/** Docs slug keys registered in helpPages (excludes intro `/docs`). */
+export function helpPageSlugs(): string[] {
+  return Object.keys(helpPages);
+}
+
+/** Union of static + docs routes (deduped, stable order). */
+export function allRoutes(): string[] {
+  const set = new Set<string>([...STATIC_ROUTES, ...docRoutesFromNav()]);
+  for (const slug of helpPageSlugs()) {
+    set.add(docsPath(slug));
+  }
+  return [...set];
+}

--- a/apps/web/e2e/links.spec.ts
+++ b/apps/web/e2e/links.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from "@playwright/test";
+import { collectFromPage, elementIdExists } from "./helpers/crawl";
+import { allRoutes } from "./helpers/routes";
+import { assertStatusOk, normalizePathname, resolveHref, resourceKey } from "./helpers/http";
+
+test.describe("internal links and assets", () => {
+  test("crawl all pages: internal URLs return <400; hash targets exist", async ({
+    page,
+    request,
+    baseURL,
+  }) => {
+    expect(baseURL).toBeTruthy();
+    const base = baseURL!;
+
+    const checkedResources = new Set<string>();
+    const checkedAnchors = new Set<string>(); // path#hash
+    const failures: string[] = [];
+    const blankTargetIssues: string[] = [];
+
+    for (const route of allRoutes()) {
+      await page.goto(route, { waitUntil: "domcontentloaded" });
+      const crawl = await collectFromPage(page);
+
+      for (const asset of crawl.assets) {
+        const resolved = resolveHref(asset, crawl.pageUrl, base);
+        if (resolved.kind !== "internal") continue;
+        const key = resourceKey(resolved.url);
+        if (checkedResources.has(key)) continue;
+        checkedResources.add(key);
+        try {
+          await assertStatusOk(request, resolved.url.toString(), `asset ${key}`);
+        } catch (err) {
+          failures.push(String(err));
+        }
+      }
+
+      for (const anchor of crawl.anchors) {
+        const href = anchor.href;
+        if (!href.trim()) {
+          failures.push(`Empty href on ${route}`);
+          continue;
+        }
+        if (href.trim() === "#") {
+          failures.push(`Bare "#" href on ${route}`);
+          continue;
+        }
+
+        // Markup-only: external blank targets need noopener (no HTTP check).
+        if (anchor.target === "_blank") {
+          const rel = (anchor.rel ?? "").toLowerCase();
+          if (!rel.includes("noopener")) {
+            blankTargetIssues.push(`${route} → ${href} (target=_blank missing rel=noopener)`);
+          }
+        }
+
+        const resolved = resolveHref(href, crawl.pageUrl, base);
+        if (resolved.kind === "skip" || resolved.kind === "external") continue;
+
+        const url = resolved.url;
+        const pathKey = resourceKey(url);
+        const hash = url.hash.startsWith("#") ? url.hash.slice(1) : url.hash;
+
+        if (!checkedResources.has(pathKey)) {
+          checkedResources.add(pathKey);
+          try {
+            // Strip hash for the HTTP request
+            const requestUrl = new URL(url.toString());
+            requestUrl.hash = "";
+            await assertStatusOk(request, requestUrl.toString(), `link ${pathKey}`);
+          } catch (err) {
+            failures.push(String(err));
+          }
+        }
+
+        if (hash) {
+          const destPath = normalizePathname(url.pathname);
+          const anchorKey = `${destPath}#${hash}`;
+          if (checkedAnchors.has(anchorKey)) continue;
+          checkedAnchors.add(anchorKey);
+
+          const currentPath = normalizePathname(new URL(crawl.pageUrl).pathname);
+          if (destPath !== currentPath) {
+            await page.goto(destPath, { waitUntil: "domcontentloaded" });
+          }
+          const exists = await elementIdExists(page, decodeURIComponent(hash));
+          if (!exists) {
+            failures.push(`Missing hash target ${anchorKey} (linked from ${route})`);
+          }
+          // Restore crawl page if we navigated away mid-loop for hash checks
+          if (destPath !== currentPath) {
+            await page.goto(route, { waitUntil: "domcontentloaded" });
+          }
+        }
+      }
+    }
+
+    expect(failures, failures.join("\n")).toEqual([]);
+    expect(blankTargetIssues, blankTargetIssues.join("\n")).toEqual([]);
+  });
+});

--- a/apps/web/e2e/seo.spec.ts
+++ b/apps/web/e2e/seo.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from "@playwright/test";
+import { collectFromPage } from "./helpers/crawl";
+import { fetchOk, isPng, pngSize, resolveHref } from "./helpers/http";
+
+async function metaOn(page: import("@playwright/test").Page, path: string) {
+  await page.goto(path, { waitUntil: "domcontentloaded" });
+  return collectFromPage(page);
+}
+
+test.describe("SEO and Open Graph", () => {
+  test("home has title, description, OG, and Twitter tags", async ({ page }) => {
+    const crawl = await metaOn(page, "/");
+    expect(crawl.title.length).toBeGreaterThan(10);
+    expect(crawl.title).toMatch(/Guided Review/i);
+
+    const desc = crawl.meta["description"];
+    expect(desc, "meta description").toBeTruthy();
+    expect(desc!.length).toBeGreaterThanOrEqual(50);
+    expect(desc!.length).toBeLessThanOrEqual(320);
+
+    expect(crawl.meta["og:title"]).toBeTruthy();
+    expect(crawl.meta["og:description"]).toBeTruthy();
+    expect(crawl.meta["og:type"]).toBe("website");
+    expect(crawl.meta["og:image"]).toMatch(/opengraph-image/);
+    expect(crawl.meta["og:image:width"]).toBe("1200");
+    expect(crawl.meta["og:image:height"]).toBe("630");
+    expect(crawl.meta["og:image:type"]).toBe("image/png");
+    expect(crawl.meta["og:image:alt"]?.length ?? 0).toBeGreaterThan(0);
+
+    expect(crawl.meta["twitter:card"]).toBe("summary_large_image");
+    expect(crawl.meta["twitter:title"]).toBeTruthy();
+    expect(crawl.meta["twitter:description"]).toBeTruthy();
+    expect(crawl.meta["twitter:image"]).toMatch(/opengraph-image/);
+  });
+
+  test("opengraph-image is a 1200×630 PNG (meta URL + bare path)", async ({
+    page,
+    request,
+    baseURL,
+  }) => {
+    const crawl = await metaOn(page, "/");
+    const ogImage = crawl.meta["og:image"];
+    expect(ogImage).toBeTruthy();
+
+    const resolved = resolveHref(ogImage!, crawl.pageUrl, baseURL!);
+    expect(resolved.kind).toBe("internal");
+    if (resolved.kind !== "internal") return;
+
+    const fromMeta = await fetchOk(request, resolved.url.toString());
+    expect(fromMeta.status, "og:image URL status").toBeLessThan(400);
+    expect(isPng(fromMeta.body), "og:image is PNG").toBe(true);
+    expect(pngSize(fromMeta.body)).toEqual({ width: 1200, height: 630 });
+
+    const bare = await fetchOk(request, "/opengraph-image");
+    expect(bare.status).toBeLessThan(400);
+    expect(isPng(bare.body)).toBe(true);
+    expect(pngSize(bare.body)).toEqual({ width: 1200, height: 630 });
+  });
+
+  test("docs and legal pages have description and canonical", async ({ page, baseURL }) => {
+    const samples = [
+      { path: "/docs", expectedCanonical: "/docs" },
+      { path: "/docs/install", expectedCanonical: "/docs/install" },
+      { path: "/privacy", expectedCanonical: "/privacy" },
+      { path: "/terms", expectedCanonical: "/terms" },
+      { path: "/cookies", expectedCanonical: "/cookies" },
+    ];
+
+    for (const { path, expectedCanonical } of samples) {
+      const crawl = await metaOn(page, path);
+      expect(crawl.title, `${path} title`).toMatch(/Guided Review/i);
+      expect(crawl.meta["description"], `${path} description`).toBeTruthy();
+
+      const canonical = crawl.meta["link:canonical"];
+      expect(canonical, `${path} canonical`).toBeTruthy();
+      const resolved = resolveHref(canonical!, crawl.pageUrl, baseURL!);
+      expect(resolved.kind, `${path} canonical internal`).toBe("internal");
+      if (resolved.kind === "internal") {
+        expect(resolved.url.pathname.replace(/\/$/, "") || "/").toBe(expectedCanonical);
+      }
+    }
+  });
+
+  test("home FAQPage JSON-LD is valid", async ({ page }) => {
+    const crawl = await metaOn(page, "/");
+    expect(crawl.jsonLd.length).toBeGreaterThan(0);
+
+    const parsed = crawl.jsonLd.map((raw) => JSON.parse(raw) as Record<string, unknown>);
+    const faq = parsed.find((doc) => doc["@type"] === "FAQPage");
+    expect(faq, "FAQPage schema").toBeTruthy();
+    const entities = faq!["mainEntity"];
+    expect(Array.isArray(entities)).toBe(true);
+    expect((entities as unknown[]).length).toBeGreaterThan(0);
+  });
+
+  test("docs slug has TechArticle and BreadcrumbList JSON-LD", async ({ page }) => {
+    const crawl = await metaOn(page, "/docs/install");
+    const parsed = crawl.jsonLd.map((raw) => JSON.parse(raw) as Record<string, unknown>);
+    const types = parsed.map((doc) => doc["@type"]);
+    expect(types).toContain("TechArticle");
+    expect(types).toContain("BreadcrumbList");
+
+    const crumbs = parsed.find((doc) => doc["@type"] === "BreadcrumbList");
+    const items = crumbs!["itemListElement"] as Array<{ name?: string }>;
+    expect(items.length).toBeGreaterThanOrEqual(2);
+    expect(items.some((i) => /docs/i.test(i.name ?? ""))).toBe(true);
+  });
+
+  test("favicon is reachable", async ({ page, request, baseURL }) => {
+    const crawl = await metaOn(page, "/");
+    // Prefer icon link from head; fall back to /favicon.ico
+    const iconHref =
+      crawl.assets.find((a) => a.includes("favicon") || a.endsWith(".ico")) ?? "/favicon.ico";
+    const resolved = resolveHref(iconHref, crawl.pageUrl, baseURL!);
+    expect(resolved.kind).toBe("internal");
+    if (resolved.kind === "internal") {
+      const res = await fetchOk(request, resolved.url.toString());
+      expect(res.status).toBeLessThan(400);
+      expect(res.body.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from "@playwright/test";
+import { collectFromPage } from "./helpers/crawl";
+import { allRoutes, PUBLIC_ASSETS } from "./helpers/routes";
+import { assertStatusOk } from "./helpers/http";
+
+test.describe("smoke: all routes respond", () => {
+  for (const route of allRoutes()) {
+    test(`${route} returns 200 and has basic structure`, async ({ page, request }) => {
+      const response = await page.goto(route, { waitUntil: "domcontentloaded" });
+      expect(response, `navigation to ${route}`).not.toBeNull();
+      expect(response!.status(), `${route} status`).toBeLessThan(400);
+
+      const crawl = await collectFromPage(page);
+      expect(crawl.lang, `${route} html lang`).toBe("en");
+      expect(crawl.hasMain, `${route} #main`).toBe(true);
+      expect(crawl.h1Count, `${route} h1 count`).toBeGreaterThanOrEqual(1);
+      expect(crawl.title, `${route} title`).toMatch(/Guided Review/i);
+      expect(crawl.skipLinkHref, `${route} skip link`).toBe("#main");
+
+      // Also verify via request API (no client redirect quirks)
+      await assertStatusOk(request, route, `GET ${route}`);
+    });
+  }
+});
+
+test.describe("smoke: public assets", () => {
+  for (const asset of PUBLIC_ASSETS) {
+    test(`${asset} is available`, async ({ request }) => {
+      await assertStatusOk(request, asset, `GET ${asset}`);
+    });
+  }
+});
+
+test("unknown path is not a soft-200 of the homepage", async ({ request }) => {
+  const path = "/this-page-does-not-exist-e2e-test";
+  const response = await request.get(path);
+  const status = response.status();
+  // serve returns 404; Cloudflare may serve 404.html with 404 status.
+  // Never accept a successful HTML document that looks like the homepage.
+  if (status < 400) {
+    const body = await response.text();
+    expect(body, "404 soft-200 must not be homepage").not.toMatch(
+      /A better way for humans to review AI generated code/i,
+    );
+    // Prefer failing if the server pretends the page exists with 200
+    expect(status, `unexpected success for ${path}`).toBeGreaterThanOrEqual(400);
+  } else {
+    expect(status).toBeGreaterThanOrEqual(400);
+  }
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,6 +8,10 @@
     "build": "next build",
     "start": "next start --port 3000",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "pretest:e2e": "npm run build",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:install": "playwright install --with-deps chromium",
     "deploy": "npm run build && wrangler pages deploy out --project-name=guidedreview",
     "preview:cf": "npm run build && wrangler pages deploy out --project-name=guidedreview --branch=preview"
   },
@@ -21,11 +25,13 @@
     "react-dom": "^19.2.8"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.0",
     "@tailwindcss/postcss": "^4.3.3",
     "@types/mdx": "^2.0.13",
     "@types/node": "^26.1.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "serve": "^14.2.6",
     "tailwindcss": "^4.3.3",
     "typescript": "^6.0.3",
     "wrangler": "^4.114.0"

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = 4173;
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+
+/**
+ * Website e2e against the static export in `out/` (mirrors Cloudflare Pages).
+ * Run `npm run build` first (`pretest:e2e` does this automatically).
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL: BASE_URL,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: `npx serve out -l ${PORT} --no-clipboard`,
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,14 +99,64 @@
         "react-dom": "^19.2.8"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.0",
         "@tailwindcss/postcss": "^4.3.3",
         "@types/mdx": "^2.0.13",
         "@types/node": "^26.1.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
+        "serve": "^14.2.6",
         "tailwindcss": "^4.3.3",
         "typescript": "^6.0.3",
         "wrangler": "^4.114.0"
+      }
+    },
+    "apps/web/node_modules/@playwright/test": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "apps/web/node_modules/playwright": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "apps/web/node_modules/playwright-core": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3960,6 +4010,13 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@zeit/schemas": {
+      "version": "2.36.0",
+      "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.36.0.tgz",
+      "integrity": "sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -4011,13 +4068,57 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
+    "node_modules/ansi-align/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-align/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-align/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4035,6 +4136,34 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/arch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -4140,6 +4269,29 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/boxen": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.0.0.tgz",
+      "integrity": "sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.1",
+        "camelcase": "^7.0.0",
+        "chalk": "^5.0.1",
+        "cli-boxes": "^3.0.0",
+        "string-width": "^5.1.2",
+        "type-fest": "^2.13.0",
+        "widest-line": "^4.0.1",
+        "wrap-ansi": "^8.0.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
@@ -4187,6 +4339,29 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
+      "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001806",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
@@ -4225,6 +4400,68 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/character-entities": {
@@ -4283,11 +4520,42 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clipboardy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-3.0.0.tgz",
+      "integrity": "sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arch": "^2.2.0",
+        "execa": "^5.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -4308,6 +4576,26 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -4316,6 +4604,72 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/convert-source-map": {
@@ -4462,6 +4816,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -4577,12 +4941,26 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.394",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.394.tgz",
       "integrity": "sha512-Wmt2Gm0o8JWBuGgmc4XZ0u9s1RaCRqhxP47phplmfg04+qypTUurpeJGP45A7Fhv7jdrrVH44PLlR9qXo37cVQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.24.3",
@@ -5007,6 +5385,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -5043,6 +5445,23 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -5150,6 +5569,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/glob-parent": {
@@ -5312,6 +5744,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/husky": {
       "version": "9.1.7",
       "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
@@ -5365,6 +5807,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
@@ -5405,6 +5854,22 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5413,6 +5878,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -5450,12 +5925,51 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-port-reachable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-port-reachable/-/is-port-reachable-4.0.0.tgz",
+      "integrity": "sha512-9UoipoxYmSk6Xy7QFgRv2HDyaysmgSG75TFQs6S+3pDM7ZhKTF/bskZV+0UlABHzKjNVhPjYCLfeZUEg1wXxig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -6237,6 +6751,13 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/micromark": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
@@ -6833,6 +7354,49 @@
       ],
       "license": "MIT"
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "~1.33.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types/node_modules/mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -7398,6 +7962,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -7428,6 +8002,16 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/next": {
       "version": "16.2.11",
@@ -7512,6 +8096,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -7537,6 +8134,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -7649,6 +8272,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)"
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -7815,6 +8445,32 @@
         "node": ">=6"
       }
     },
+    "node_modules/range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
@@ -7937,6 +8593,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/registry-auth-token": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/registry-url": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha512-ZbgR5aZEdf4UKZVBPYIgaglBmSF2Hi94s2PcIHhRGFjKYu+chjJdYfHn4rt3hB6eCKLJ8giVIIfgMa1ehDfZKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rehype-recma": {
@@ -8071,6 +8751,27 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/sass": {
       "version": "1.101.3",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.101.3.tgz",
@@ -8120,6 +8821,120 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/serve": {
+      "version": "14.2.6",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.6.tgz",
+      "integrity": "sha512-QEjUSA+sD4Rotm1znR8s50YqA3kYpRGPmtd5GlFxbaL9n/FdUNbqMhxClqdditSk0LlZyA/dhud6XNRTOC9x2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@zeit/schemas": "2.36.0",
+        "ajv": "8.18.0",
+        "arg": "5.0.2",
+        "boxen": "7.0.0",
+        "chalk": "5.0.1",
+        "chalk-template": "0.4.0",
+        "clipboardy": "3.0.0",
+        "compression": "1.8.1",
+        "is-port-reachable": "4.0.0",
+        "serve-handler": "6.1.7",
+        "update-check": "1.5.4"
+      },
+      "bin": {
+        "serve": "build/main.js"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/serve-handler": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.7.tgz",
+      "integrity": "sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.0.0",
+        "content-disposition": "0.5.2",
+        "mime-types": "2.1.18",
+        "minimatch": "3.1.5",
+        "path-is-inside": "1.0.2",
+        "path-to-regexp": "3.3.0",
+        "range-parser": "1.2.0"
+      }
+    },
+    "node_modules/serve-handler/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/serve-handler/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/serve-handler/node_modules/bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/serve-handler/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/serve-handler/node_modules/path-to-regexp": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/serve/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/serve/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -8209,6 +9024,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -8261,6 +9083,24 @@
         "node": ">=0.6.19"
       }
     },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -8275,6 +9115,45 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -8286,6 +9165,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/style-to-js": {
@@ -8512,6 +9401,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -8718,6 +9620,17 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/update-check": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/update-check/-/update-check-1.5.4.tgz",
+      "integrity": "sha512-5YHsflzHP4t1G+8WGPlvKbJEbAJGCgw+Em+dGR1KmBUbr1J36SJBqlHLjR7oob7sco5hWHGQVcr9B2poIVDDTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "registry-auth-token": "3.3.2",
+        "registry-url": "3.1.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -8726,6 +9639,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vfile": {
@@ -9027,6 +9950,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/widest-line": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
+      "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -9107,6 +10046,37 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "test:e2e": "npm run test:e2e -w @guided-review/extension",
     "test:e2e:ui": "npm run test:e2e:ui -w @guided-review/extension",
     "test:e2e:install": "npm run test:e2e:install -w @guided-review/extension",
+    "test:e2e:web": "npm run test:e2e -w @guided-review/web",
+    "test:e2e:web:ui": "npm run test:e2e:ui -w @guided-review/web",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",


### PR DESCRIPTION
## Summary
- Adds a Playwright e2e suite for the marketing site static export (`apps/web/out`), covering route smoke checks, internal link/asset integrity, SEO meta, OG image bytes, and docs registry sync.
- Wires root scripts (`test:e2e:web`, `test:e2e:web:ui`) and a path-filtered CI job in `lint-and-test.yml` that runs website e2e when web/ui or root lockfile changes (always on push).
- Documents the new commands in root README, AGENTS.md, and `apps/web/README.md`.

## Test plan
- [ ] `npm run test:e2e:web` builds the static export, serves `out/` on port 4173, and all specs pass
- [ ] CI `e2e-web` job runs on this PR and is green
- [ ] Confirm path filter skips website e2e when only extension files change (on PRs)
- [ ] Confirm docs/smoke/links/seo specs still pass after a docs content tweak