### PR TITLE
fix(web): improve marketing site mobile responsiveness

### DIFF
--- a/apps/web/app/docs/layout.tsx
+++ b/apps/web/app/docs/layout.tsx
@@ -8,7 +8,7 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
     <div className="flex min-h-[calc(100vh-8rem)] flex-col">
       <DocsMobileNav />
 
-      <div className="mx-auto w-full max-w-5xl flex-1 px-6">
+      <div className="mx-auto w-full max-w-5xl flex-1 px-4 sm:px-6">
         <div className="flex gap-8">
           <aside className="hidden w-56 shrink-0 lg:block">
             <div className="sticky top-20 h-[calc(100vh-5rem)] overflow-y-auto py-8 pr-4">

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -60,10 +60,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           Skip to content
         </a>
         <header className="sticky top-0 z-40 border-b border-gr-border bg-gr-chrome/95 backdrop-blur-sm">
-          <div className="mx-auto flex max-w-5xl items-center justify-between gap-4 px-6 py-3.5">
+          <div className="mx-auto flex max-w-5xl items-center justify-between gap-3 px-4 py-3.5 sm:gap-4 sm:px-6">
             <Link
               href="/"
-              className="rounded-sm border-b-0 no-underline hover:border-b-transparent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gr-accent"
+              className="shrink-0 rounded-sm border-b-0 no-underline hover:border-b-transparent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gr-accent"
               aria-label="Guided Review home"
             >
               <img
@@ -74,17 +74,20 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 height={49}
               />
             </Link>
-            <nav className="flex items-center gap-5 text-base" aria-label="Primary">
+            <nav
+              className="flex shrink-0 items-center gap-2 text-base sm:gap-3 md:gap-5"
+              aria-label="Primary"
+            >
               <Link
                 href="/#features"
-                className="hidden text-gr-text hover:text-gr-accent sm:inline"
+                className="hidden text-gr-text hover:text-gr-accent md:inline"
               >
                 Features
               </Link>
-              <Link href="/docs" className="hidden text-gr-text hover:text-gr-accent sm:inline">
+              <Link href="/docs" className="hidden text-gr-text hover:text-gr-accent md:inline">
                 Docs
               </Link>
-              <Link href="/#faqs" className="hidden text-gr-text hover:text-gr-accent sm:inline">
+              <Link href="/#faqs" className="hidden text-gr-text hover:text-gr-accent md:inline">
                 FAQ
               </Link>
               <StarOnGitHubButton size="sm" surface="overlay" compact />

--- a/apps/web/components/CtaButtons.tsx
+++ b/apps/web/components/CtaButtons.tsx
@@ -12,6 +12,7 @@ type CtaButtonProps = {
 
 export function InstallButton({ size = "lg", surface = "app", compact = false }: CtaButtonProps) {
   const { key, href, label } = SITE_SHORTCUTS.install;
+  const displayLabel = compact ? "Install" : label;
   return (
     <a
       href={href}
@@ -19,9 +20,9 @@ export function InstallButton({ size = "lg", surface = "app", compact = false }:
       target="_blank"
       rel="noopener noreferrer"
       aria-keyshortcuts={ariaKeyShortcuts(key)}
-      aria-label={`${label} (⌘/Ctrl+${key.toUpperCase()})`}
+      aria-label={displayLabel}
     >
-      {compact ? "Install" : label}
+      {displayLabel}
       <ShortcutChord keyLabel={key} />
     </a>
   );
@@ -40,7 +41,7 @@ export function StarOnGitHubButton({
       target="_blank"
       rel="noopener noreferrer"
       aria-keyshortcuts={ariaKeyShortcuts(key)}
-      aria-label={`${label} (⌘/Ctrl+${key.toUpperCase()})`}
+      aria-label={label}
     >
       <GitHubIcon className="h-4 w-4" />
       {compact ? <span className="hidden sm:inline">Star</span> : label}

--- a/apps/web/components/Faqs.tsx
+++ b/apps/web/components/Faqs.tsx
@@ -112,7 +112,7 @@ function faqJsonLd(items: Faq[]) {
 
 export function Faqs() {
   return (
-    <section id="faqs" className="relative px-6 py-20 sm:py-28">
+    <section id="faqs" className="relative px-4 py-16 sm:px-6 sm:py-28">
       {/* Static, locally-authored JSON (not user input) — safe to inject directly. */}
       <script
         type="application/ld+json"
@@ -132,7 +132,7 @@ export function Faqs() {
             {faqs.map((faq) => (
               <li key={faq.question}>
                 <details className="group [&_summary::-webkit-details-marker]:hidden">
-                  <summary className="flex cursor-pointer list-none items-center justify-between gap-4 p-6 text-lg font-semibold tracking-tight transition-colors hover:text-opt-accent sm:p-8 sm:text-xl">
+                  <summary className="flex cursor-pointer list-none items-center justify-between gap-3 p-4 text-base font-semibold tracking-tight transition-colors hover:text-opt-accent sm:gap-4 sm:p-6 sm:text-lg md:p-8 md:text-xl">
                     {faq.question}
                     <svg
                       aria-hidden="true"
@@ -147,7 +147,7 @@ export function Faqs() {
                       <path d="m6 9 6 6 6-6" />
                     </svg>
                   </summary>
-                  <div className="space-y-3 px-6 pb-6 text-base leading-relaxed text-opt-muted sm:px-8 sm:pb-8 sm:text-lg">
+                  <div className="space-y-3 px-4 pb-4 text-base leading-relaxed text-opt-muted sm:px-6 sm:pb-6 sm:text-lg md:px-8 md:pb-8">
                     {faq.answer.map((paragraph, index) => (
                       <p key={index} className="m-0">
                         {paragraph}

--- a/apps/web/components/FeatureGrid.tsx
+++ b/apps/web/components/FeatureGrid.tsx
@@ -60,7 +60,7 @@ export function FeatureGrid() {
   const last = rest.pop();
 
   return (
-    <section id="features" className="relative px-6 py-20 sm:py-28">
+    <section id="features" className="relative px-4 py-16 sm:px-6 sm:py-28">
       <div className="mx-auto max-w-5xl">
         <h2 className="m-0 text-center text-3xl font-bold tracking-tight sm:text-4xl font-brand">
           Features

--- a/apps/web/components/Footer.tsx
+++ b/apps/web/components/Footer.tsx
@@ -4,10 +4,10 @@ import { GITHUB_REPO_URL } from "../lib/links";
 export function Footer() {
   return (
     <footer className="mt-16 border-t border-gr-border bg-gr-bg">
-      <div className="mx-auto max-w-5xl px-6 py-12">
-        <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-gr-muted">
+      <div className="mx-auto max-w-5xl px-4 py-12 sm:px-6">
+        <div className="flex flex-col items-start gap-4 text-sm text-gr-muted sm:flex-row sm:items-center sm:justify-between sm:gap-3">
           <p className="m-0">© {new Date().getFullYear()} Guided Review</p>
-          <div className="flex gap-4">
+          <div className="flex flex-wrap gap-x-4 gap-y-2">
             <a href={GITHUB_REPO_URL} target="_blank" rel="noopener noreferrer">
               GitHub
             </a>

--- a/apps/web/components/Hero.tsx
+++ b/apps/web/components/Hero.tsx
@@ -9,10 +9,10 @@ function riseDelay(seconds: number): CSSProperties {
 
 export function Hero() {
   return (
-    <section className="relative overflow-hidden px-6 pb-20 pt-16 text-center sm:pb-28 sm:pt-24">
+    <section className="relative overflow-hidden px-4 pb-16 pt-12 text-center sm:px-6 sm:pb-28 sm:pt-24">
       <div className="mx-auto max-w-5xl">
         <h1
-          className="gr-rise-in mx-auto max-w-3xl text-4xl leading-[1.35] font-bold tracking-tight text-balance sm:text-6xl sm:leading-[1.3] font-brand"
+          className="gr-rise-in mx-auto max-w-3xl text-3xl leading-[1.35] font-bold tracking-tight text-balance sm:text-5xl sm:leading-[1.3] md:text-6xl font-brand"
           style={riseDelay(0.1)}
         >
           A better way for humans to{" "}

--- a/apps/web/components/InstallCta.tsx
+++ b/apps/web/components/InstallCta.tsx
@@ -6,7 +6,7 @@ const iconSrc = typeof iconSvg === "string" ? iconSvg : (iconSvg as { src: strin
 
 export function InstallCta() {
   return (
-    <section id="install" className="mx-auto my-16 max-w-5xl px-6">
+    <section id="install" className="mx-auto my-12 max-w-5xl px-4 sm:my-16 sm:px-6">
       <WindowFrame label="install.sh">
         <div className="mx-auto max-w-2xl text-center">
           <img

--- a/apps/web/components/LegalDocument.tsx
+++ b/apps/web/components/LegalDocument.tsx
@@ -13,7 +13,7 @@ type LegalDocumentProps = {
  */
 export function LegalDocument({ title, meta, children }: LegalDocumentProps) {
   return (
-    <article className="mx-auto max-w-5xl px-6 py-16">
+    <article className="mx-auto max-w-5xl px-4 py-12 sm:px-6 sm:py-16">
       <div className="mx-auto max-w-3xl">
         <h1 className="m-0 text-3xl font-bold tracking-tight">{title}</h1>
         <p className="mt-2 text-sm text-opt-muted">{meta}</p>

--- a/apps/web/components/ShortcutChord.tsx
+++ b/apps/web/components/ShortcutChord.tsx
@@ -20,7 +20,7 @@ export function ShortcutChord({ keyLabel }: { keyLabel: string }) {
   const keys = [isMac ? "⌘" : "Ctrl", keyLabel.toUpperCase()];
 
   return (
-    <KbdGroup aria-hidden="true">
+    <KbdGroup aria-hidden="true" className="max-sm:hidden">
       {keys.map((key, i) => (
         <Fragment key={`${key}-${i}`}>
           {i > 0 ? (

--- a/apps/web/components/TrustBand.tsx
+++ b/apps/web/components/TrustBand.tsx
@@ -14,7 +14,7 @@ function formatStarCount(count: number): string {
 
 export function TrustBand({ starCount }: TrustBandProps) {
   return (
-    <section className="relative px-6 py-20 sm:py-28">
+    <section className="relative px-4 py-16 sm:px-6 sm:py-28">
       <div className="mx-auto max-w-5xl text-center">
         <h2 className="m-0 text-2xl font-bold tracking-tight sm:text-3xl font-brand">
           Your code never touches our infrastructure

--- a/apps/web/components/Why.tsx
+++ b/apps/web/components/Why.tsx
@@ -2,7 +2,7 @@ import { WindowFrame } from "./WindowFrame";
 
 export function Why() {
   return (
-    <section id="why" className="relative px-6 py-20 sm:py-28">
+    <section id="why" className="relative px-4 py-16 sm:px-6 sm:py-28">
       <div className="mx-auto max-w-5xl">
         <h2 className="m-0 text-center text-2xl font-bold tracking-tight text-opt-accent font-brand sm:text-3xl">
           Why?

--- a/apps/web/components/WindowFrame.tsx
+++ b/apps/web/components/WindowFrame.tsx
@@ -28,7 +28,7 @@ export function WindowFrame({ label, children, className, bodyClassName }: Windo
         <span className="h-2.5 w-2.5 rounded-full bg-gr-add-text/70" aria-hidden="true" />
         <span className="ml-2.5 truncate font-mono text-xs text-opt-muted">{label}</span>
       </div>
-      <div className={cn("p-6 sm:p-8", bodyClassName)}>{children}</div>
+      <div className={cn("p-4 sm:p-6 md:p-8", bodyClassName)}>{children}</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Tighten horizontal padding and section spacing on small screens across landing, docs, and legal pages
- Scale hero/FAQ typography and header nav gaps through `sm`/`md` breakpoints so content fits narrow viewports
- Hide keyboard shortcut chords and secondary nav links on small screens; keep logo/nav from shrinking/overflowing
- Stack footer content vertically on mobile

## Test plan
- [ ] Open the marketing site at ~375px width and confirm header, hero, features, FAQ, install CTA, and footer layout cleanly without horizontal scroll
- [ ] Check tablet (~768px) and desktop breakpoints for no regressions
- [ ] Spot-check `/docs`, privacy/terms/cookies pages for padding and wrapping
- [ ] Confirm Install / Star CTAs still work; shortcut chords appear at `sm+`