### PR TITLE
feat(web): SEO improvements for marketing site

### DIFF
--- a/apps/web/app/cookies/page.tsx
+++ b/apps/web/app/cookies/page.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from "next";
 import { LegalDocument } from "../../components/LegalDocument";
+import { openGraphSite } from "../../lib/site";
 
 export const metadata: Metadata = {
   title: "Cookies Policy",
   description: "How Guided Review uses cookies and similar technologies on the marketing website.",
   alternates: { canonical: "/cookies" },
+  openGraph: { ...openGraphSite, url: "/cookies" },
 };
 
 export default function CookiesPage() {

--- a/apps/web/app/docs/[slug]/page.tsx
+++ b/apps/web/app/docs/[slug]/page.tsx
@@ -3,14 +3,26 @@ import { notFound } from "next/navigation";
 import { helpPages } from "@/config/help-pages";
 import { helpNavigation } from "@/config/help-navigation";
 import { DocsPageWrapper } from "@/components/docs/DocsPageWrapper";
+import { JsonLd } from "@/components/JsonLd";
+import { openGraphSite, SITE_NAME, SITE_URL } from "@/lib/site";
 
 type Props = { params: Promise<{ slug: string }> };
 
-const SITE_URL = "https://guidedreview.dev";
+function getNavPage(slug: string) {
+  return helpNavigation.find((item) => item.type !== "heading" && item.slug === slug);
+}
 
 function getPageTitle(slug: string): string {
-  const navItem = helpNavigation.find((item) => item.type !== "heading" && item.slug === slug);
+  const navItem = getNavPage(slug);
   return navItem && navItem.type !== "heading" ? navItem.title : slug;
+}
+
+function getPageDescription(slug: string, pageTitle: string): string {
+  const navItem = getNavPage(slug);
+  if (navItem && navItem.type !== "heading" && navItem.description) {
+    return navItem.description;
+  }
+  return `${SITE_NAME} documentation: ${pageTitle}.`;
 }
 
 export async function generateStaticParams() {
@@ -22,12 +34,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!helpPages[slug]) return {};
 
   const pageTitle = getPageTitle(slug);
+  const description = getPageDescription(slug, pageTitle);
 
   return {
     title: pageTitle,
-    description: `Guided Review documentation: ${pageTitle}. Learn how to use this feature.`,
+    description,
     alternates: { canonical: `/docs/${slug}` },
-    openGraph: { type: "article", url: `/docs/${slug}` },
+    openGraph: { ...openGraphSite, type: "article", url: `/docs/${slug}` },
   };
 }
 
@@ -39,14 +52,26 @@ export default async function DocsSlugPage({ params }: Props) {
   const mod = await loader();
   const Content = mod.default;
   const pageTitle = getPageTitle(slug);
+  const description = getPageDescription(slug, pageTitle);
+  const pageUrl = `${SITE_URL}/docs/${slug}`;
 
   const techArticleSchema = {
     "@context": "https://schema.org",
     "@type": "TechArticle",
     headline: pageTitle,
-    description: `Guided Review documentation: ${pageTitle}.`,
-    url: `${SITE_URL}/docs/${slug}`,
-    isPartOf: { "@type": "WebSite", url: SITE_URL, name: "Guided Review" },
+    description,
+    url: pageUrl,
+    author: {
+      "@type": "Organization",
+      name: SITE_NAME,
+      url: SITE_URL,
+    },
+    publisher: {
+      "@type": "Organization",
+      name: SITE_NAME,
+      url: SITE_URL,
+    },
+    isPartOf: { "@type": "WebSite", url: SITE_URL, name: SITE_NAME },
   };
 
   const breadcrumbSchema = {
@@ -63,21 +88,15 @@ export default async function DocsSlugPage({ params }: Props) {
         "@type": "ListItem",
         position: 2,
         name: pageTitle,
-        item: `${SITE_URL}/docs/${slug}`,
+        item: pageUrl,
       },
     ],
   };
 
   return (
     <DocsPageWrapper slug={slug}>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(techArticleSchema) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
-      />
+      <JsonLd data={techArticleSchema} />
+      <JsonLd data={breadcrumbSchema} />
       <Content />
     </DocsPageWrapper>
   );

--- a/apps/web/app/docs/page.tsx
+++ b/apps/web/app/docs/page.tsx
@@ -1,18 +1,32 @@
 import type { Metadata } from "next";
 import Content from "@/content/help/index.mdx";
 import { DocsPageWrapper } from "@/components/docs/DocsPageWrapper";
+import { JsonLd } from "@/components/JsonLd";
+import { openGraphSite, SITE_NAME, SITE_URL } from "@/lib/site";
+
+const DOCS_DESCRIPTION =
+  "Learn how to install Guided Review, configure your AI provider, and walk through GitHub pull requests with structured review plans.";
 
 export const metadata: Metadata = {
   title: "Documentation",
-  description:
-    "Learn how to install Guided Review, configure your AI provider, and walk through GitHub pull requests with structured review plans.",
+  description: DOCS_DESCRIPTION,
   alternates: { canonical: "/docs" },
-  openGraph: { type: "website", url: "/docs" },
+  openGraph: { ...openGraphSite, type: "website", url: "/docs" },
+};
+
+const docsIndexSchema = {
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  name: `Documentation · ${SITE_NAME}`,
+  description: DOCS_DESCRIPTION,
+  url: `${SITE_URL}/docs`,
+  isPartOf: { "@type": "WebSite", url: SITE_URL, name: SITE_NAME },
 };
 
 export default function DocsPage() {
   return (
     <DocsPageWrapper slug="">
+      <JsonLd data={docsIndexSchema} />
       <Content />
     </DocsPageWrapper>
   );

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -4,8 +4,11 @@ import logoSvg from "@guided-review/ui/assets/logo.svg";
 import Link from "next/link";
 import { InstallButton, StarOnGitHubButton } from "../components/CtaButtons";
 import { Footer } from "../components/Footer";
+import { JsonLd } from "../components/JsonLd";
 import { LineGutter } from "../components/LineGutter";
 import { SiteShortcuts } from "../components/SiteShortcuts";
+import { GITHUB_REPO_URL } from "../lib/links";
+import { DEFAULT_DESCRIPTION, openGraphSite, SITE_NAME, SITE_URL } from "../lib/site";
 import "./globals.css";
 
 const victorMono = Victor_Mono({
@@ -24,34 +27,44 @@ const newsreader = Newsreader({
 const logoSrc = typeof logoSvg === "string" ? logoSvg : (logoSvg as { src: string }).src;
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://guidedreview.dev"),
+  metadataBase: new URL(SITE_URL),
   title: {
-    default: "Guided Review",
-    template: "%s · Guided Review",
+    default: SITE_NAME,
+    template: `%s · ${SITE_NAME}`,
   },
-  description:
-    "A better way for humans to review AI generated code. Clustered changes, summaries, keyboard-first — free, open source, bring your own LLM key.",
+  description: DEFAULT_DESCRIPTION,
+  robots: {
+    index: true,
+    follow: true,
+  },
   icons: {
     icon: "/favicon.ico",
   },
+  // Do not hardcode openGraph/twitter title or description here — page-level
+  // title and description cascade into share previews when these are omitted.
   openGraph: {
-    title: "Guided Review",
-    description:
-      "A better way for humans to review AI generated code. Clustered changes, summaries, keyboard-first — free, open source, bring your own LLM key.",
+    ...openGraphSite,
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Guided Review",
-    description:
-      "A better way for humans to review AI generated code. Clustered changes, summaries, keyboard-first — free, open source, bring your own LLM key.",
   },
+};
+
+const organizationSchema = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: SITE_NAME,
+  url: SITE_URL,
+  logo: `${SITE_URL}/favicon.ico`,
+  sameAs: [GITHUB_REPO_URL, "https://x.com/nshntarora"],
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={`${victorMono.variable} ${newsreader.variable}`}>
       <body className="min-h-screen antialiased">
+        <JsonLd data={organizationSchema} />
         <LineGutter />
         <a
           href="#main"

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -5,19 +5,58 @@ import { FeatureGrid } from "../components/FeatureGrid";
 import { TrustBand } from "../components/TrustBand";
 import { Faqs } from "../components/Faqs";
 import { InstallCta } from "../components/InstallCta";
+import { JsonLd } from "../components/JsonLd";
 import { getGitHubStarCount } from "../lib/github";
+import { CHROME_WEB_STORE_URL } from "../lib/links";
+import { HOME_DESCRIPTION, openGraphSite, SITE_NAME, SITE_URL } from "../lib/site";
 
 export const metadata: Metadata = {
   title: "Guided Review — a better way to review AI generated code",
-  description:
-    "A Chrome extension that clusters a GitHub pull request into review units with summaries, so you can actually read the code an agent wrote. Free, open source, bring your own LLM key.",
+  description: HOME_DESCRIPTION,
+  alternates: { canonical: "/" },
+  openGraph: {
+    ...openGraphSite,
+    type: "website",
+    url: "/",
+  },
 };
+
+const homeSchema = [
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: SITE_NAME,
+    url: SITE_URL,
+    description: HOME_DESCRIPTION,
+    publisher: {
+      "@type": "Organization",
+      name: SITE_NAME,
+      url: SITE_URL,
+    },
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: SITE_NAME,
+    applicationCategory: "DeveloperApplication",
+    operatingSystem: "Chrome",
+    description: HOME_DESCRIPTION,
+    url: SITE_URL,
+    downloadUrl: CHROME_WEB_STORE_URL,
+    offers: {
+      "@type": "Offer",
+      price: "0",
+      priceCurrency: "USD",
+    },
+  },
+];
 
 export default async function HomePage() {
   const starCount = await getGitHubStarCount();
 
   return (
     <>
+      <JsonLd data={homeSchema} />
       <Hero />
       <Why />
       <FeatureGrid />

--- a/apps/web/app/privacy/page.tsx
+++ b/apps/web/app/privacy/page.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from "next";
 import { LegalContactBlock, LegalDocument } from "../../components/LegalDocument";
+import { openGraphSite } from "../../lib/site";
 
 export const metadata: Metadata = {
   title: "Privacy Policy",
   description:
     "How Guided Review collects, uses, and protects personal data across the website and Chrome extension.",
   alternates: { canonical: "/privacy" },
+  openGraph: { ...openGraphSite, url: "/privacy" },
 };
 
 export default function PrivacyPage() {

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/site";
+
+export const dynamic = "force-static";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  };
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,0 +1,51 @@
+import type { MetadataRoute } from "next";
+import { helpPages } from "@/config/help-pages";
+import { SITE_URL } from "@/lib/site";
+
+export const dynamic = "force-static";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date();
+
+  const staticEntries: MetadataRoute.Sitemap = [
+    {
+      url: SITE_URL,
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: `${SITE_URL}/docs`,
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 0.9,
+    },
+    {
+      url: `${SITE_URL}/privacy`,
+      lastModified: now,
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+    {
+      url: `${SITE_URL}/terms`,
+      lastModified: now,
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+    {
+      url: `${SITE_URL}/cookies`,
+      lastModified: now,
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+  ];
+
+  const docEntries: MetadataRoute.Sitemap = Object.keys(helpPages).map((slug) => ({
+    url: `${SITE_URL}/docs/${slug}`,
+    lastModified: now,
+    changeFrequency: "monthly" as const,
+    priority: 0.7,
+  }));
+
+  return [...staticEntries, ...docEntries];
+}

--- a/apps/web/app/terms/page.tsx
+++ b/apps/web/app/terms/page.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from "next";
 import { LegalContactBlock, LegalDocument } from "../../components/LegalDocument";
+import { openGraphSite } from "../../lib/site";
 
 export const metadata: Metadata = {
   title: "Terms of Service",
   description: "Terms governing use of the Guided Review Chrome extension and website.",
   alternates: { canonical: "/terms" },
+  openGraph: { ...openGraphSite, url: "/terms" },
 };
 
 export default function TermsPage() {

--- a/apps/web/components/JsonLd.tsx
+++ b/apps/web/components/JsonLd.tsx
@@ -1,0 +1,6 @@
+/** Renders a schema.org JSON-LD script. Data is author-controlled, not user input. */
+export function JsonLd({ data }: { data: Record<string, unknown> | Record<string, unknown>[] }) {
+  return (
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }} />
+  );
+}

--- a/apps/web/config/help-navigation.ts
+++ b/apps/web/config/help-navigation.ts
@@ -1,22 +1,83 @@
 export type HelpNavItem =
-  { type: "heading"; title: string } | { type?: undefined; slug: string; title: string };
+  | { type: "heading"; title: string }
+  | { type?: undefined; slug: string; title: string; description?: string };
 
 export const helpNavigation: HelpNavItem[] = [
   { type: "heading", title: "Getting Started" },
-  { slug: "", title: "Introduction" },
-  { slug: "install", title: "Install the extension" },
-  { slug: "first-review", title: "Your first review" },
+  {
+    slug: "",
+    title: "Introduction",
+    description:
+      "What Guided Review is, how it turns a GitHub PR into an ordered walkthrough, and where to start in the docs.",
+  },
+  {
+    slug: "install",
+    title: "Install the extension",
+    description:
+      "Install Guided Review from the Chrome Web Store or load an unpacked build for development.",
+  },
+  {
+    slug: "first-review",
+    title: "Your first review",
+    description:
+      "Open a GitHub PR, start Guided Review, walk review units, and leave comments from the overlay.",
+  },
   { type: "heading", title: "Setup" },
-  { slug: "configure-provider", title: "Configure AI provider" },
-  { slug: "connect-github", title: "Connect GitHub" },
+  {
+    slug: "configure-provider",
+    title: "Configure AI provider",
+    description:
+      "Add your Anthropic, OpenAI, or Grok API key, pick a model, and test the connection in options.",
+  },
+  {
+    slug: "connect-github",
+    title: "Connect GitHub",
+    description:
+      "Optionally connect GitHub with device flow so you can submit reviews and line comments from the overlay.",
+  },
   { type: "heading", title: "Product" },
-  { slug: "how-it-works", title: "How a review plan works" },
-  { slug: "leave-comments", title: "Leave line comments" },
-  { slug: "submit-review", title: "Submit a review" },
-  { slug: "keyboard-shortcuts", title: "Keyboard shortcuts" },
+  {
+    slug: "how-it-works",
+    title: "How a review plan works",
+    description:
+      "How Guided Review parses a PR diff, chunks large changes, and builds validated review units.",
+  },
+  {
+    slug: "leave-comments",
+    title: "Leave line comments",
+    description:
+      "Draft multi-line GitHub comments from the overlay while you walk the review plan.",
+  },
+  {
+    slug: "submit-review",
+    title: "Submit a review",
+    description:
+      "Post drafted comments and Comment, Approve, or Request Changes without leaving the overlay.",
+  },
+  {
+    slug: "keyboard-shortcuts",
+    title: "Keyboard shortcuts",
+    description:
+      "Keyboard-first shortcuts for overlay navigation, diff view, comments, and submitting a review.",
+  },
   { type: "heading", title: "Help" },
-  { slug: "troubleshooting", title: "Troubleshooting" },
-  { slug: "faq", title: "FAQ" },
+  {
+    slug: "troubleshooting",
+    title: "Troubleshooting",
+    description:
+      "Fixes for a missing Start Guided Review button, provider errors, plan failures, and GitHub auth issues.",
+  },
+  {
+    slug: "faq",
+    title: "FAQ",
+    description:
+      "Answers about how Guided Review works, privacy, pricing, AI providers, and whether AI approves PRs.",
+  },
   { type: "heading", title: "Trust" },
-  { slug: "privacy-and-data", title: "Privacy & data" },
+  {
+    slug: "privacy-and-data",
+    title: "Privacy & data",
+    description:
+      "What the extension sends to GitHub and your AI provider, what stays local, and website analytics.",
+  },
 ];

--- a/apps/web/lib/site.ts
+++ b/apps/web/lib/site.ts
@@ -1,0 +1,21 @@
+/**
+ * Canonical production origin for the marketing site.
+ * Single source for metadataBase, robots, sitemap, and JSON-LD — do not hardcode elsewhere.
+ */
+export const SITE_URL = "https://guidedreview.dev";
+
+export const SITE_NAME = "Guided Review";
+
+/** Default document description (root layout + pages that do not override). */
+export const DEFAULT_DESCRIPTION =
+  "A better way for humans to review AI generated code. Clustered changes, summaries, keyboard-first — free, open source, bring your own LLM key.";
+
+/** Homepage-specific description (≤160 chars for SERP snippets). */
+export const HOME_DESCRIPTION =
+  "Chrome extension that clusters GitHub PR diffs into review units with summaries. Free, open source, bring your own LLM key.";
+
+/** Shared Open Graph fields — page-level `openGraph` can replace the root object, so re-spread these. */
+export const openGraphSite = {
+  siteName: SITE_NAME,
+  locale: "en_US",
+} as const;


### PR DESCRIPTION
## Summary

Improves search and social discovery for the Guided Review marketing site (`apps/web`).

- Add static `robots.txt` and `sitemap.xml` (all 16 public URLs) via Next Metadata routes, compatible with Cloudflare static export
- Centralize production origin and shared OG fields in `lib/site.ts`
- Fix Open Graph / Twitter cascade so page titles and descriptions unfurl correctly (legal pages no longer show root marketing copy)
- Homepage: self-referencing canonical, `og:url`, tighter meta description, WebSite + SoftwareApplication JSON-LD
- Docs: real per-page meta descriptions, TechArticle author/publisher, CollectionPage on `/docs`
- Root Organization JSON-LD (`sameAs` GitHub + X); explicit `index, follow` robots

## Test plan

- [ ] `npm run typecheck -w @guided-review/web`
- [ ] `npm run build:web`
- [ ] Confirm `apps/web/out/robots.txt` allows `/` and points at the sitemap
- [ ] Confirm `apps/web/out/sitemap.xml` lists home, docs, legal, and all doc slugs
- [ ] Spot-check head tags on `/`, `/docs`, `/docs/install`, `/privacy` (canonical, og:title/description/url/site_name)
- [ ] Confirm `/opengraph-image` still returns a PNG