### PR TITLE
feat(options): redesign options shell and About page

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,14 +47,25 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
-      # Push to main: diff the tip commit against its parent so merge/squash
-      # deploys still see the right paths. PR: diff against the default branch.
+      # paths-filter cannot fetch relative refs like HEAD~1 (invalid refspec).
+      # Resolve push base to a real parent SHA after checkout; PRs use default branch.
+      - name: Resolve change-detection base
+        if: github.event_name == 'workflow_run'
+        id: paths_base
+        run: |
+          if [ "${{ github.event.workflow_run.event }}" = "push" ]; then
+            # Tip vs parent so merge/squash deploys still see the right paths.
+            echo "base=$(git rev-parse HEAD~1)" >> "$GITHUB_OUTPUT"
+          else
+            echo "base=${{ github.event.repository.default_branch }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: dorny/paths-filter@v4
         id: filter
         if: github.event_name == 'workflow_run'
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
-          base: ${{ github.event.workflow_run.event == 'push' && 'HEAD~1' || github.event.repository.default_branch }}
+          base: ${{ steps.paths_base.outputs.base }}
           filters: |
             web:
               - 'apps/web/**'

--- a/apps/extension/e2e/options.spec.ts
+++ b/apps/extension/e2e/options.spec.ts
@@ -59,12 +59,12 @@ test.describe("Options page", () => {
     const page = await context.newPage();
     await page.goto(`chrome-extension://${extensionId}/src/options/index.html`);
 
-    await page.getByRole("link", { name: /about guided review/i }).click();
-    await expect(page.getByRole("heading", { name: "What It Does" })).toBeVisible();
+    await page.getByRole("link", { name: "About" }).click();
+    await expect(page.getByRole("heading", { name: "How it works" })).toBeVisible();
     await expect(page).toHaveURL(/#about$/);
     await expect(page).toHaveTitle(/About/);
 
-    await page.getByRole("link", { name: /settings/i }).click();
+    await page.getByRole("link", { name: "Settings" }).click();
     await expect(page.getByRole("combobox", { name: "Provider" })).toBeVisible();
     await expect(page).toHaveURL(/#settings$/);
   });

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -22,6 +22,7 @@
     "gen-icons": "python3 scripts/gen-icons.py"
   },
   "dependencies": {
+    "@fontsource/victor-mono": "^5.3.0",
     "@guided-review/ui": "*",
     "dompurify": "^3.4.12",
     "highlight.js": "^11.11.1",

--- a/apps/extension/src/components/GitHubLogo.tsx
+++ b/apps/extension/src/components/GitHubLogo.tsx
@@ -1,0 +1,28 @@
+/** Official GitHub mark (Octocat) — filled via currentColor. */
+export function GitHubLogo({
+  className,
+  size = 40,
+  "data-testid": testId,
+}: {
+  className?: string;
+  size?: number;
+  "data-testid"?: string;
+}) {
+  return (
+    <svg
+      className={className}
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      data-testid={testId}
+    >
+      <path
+        fillRule="evenodd"
+        d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"
+      />
+    </svg>
+  );
+}

--- a/apps/extension/src/content/overlay/components/ConnectGitHubModal.tsx
+++ b/apps/extension/src/content/overlay/components/ConnectGitHubModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId, useRef, type MutableRefObject } from "react";
+import { GitHubLogo } from "../../../components/GitHubLogo";
 import { GITHUB_CLIENT_ID_ENV_VAR, isGitHubOAuthConfigured } from "../../../lib/github/oauthConfig";
 import { useCopyToClipboard } from "../../../lib/useCopyToClipboard";
 import { openVerificationUri, useGitHubDeviceAuth } from "../../../lib/github/useGitHubDeviceAuth";
@@ -16,27 +17,6 @@ export interface ConnectGitHubModalProps {
    * the overlay capture keydown can fire Enter without relying on element React handlers.
    */
   connectActionRef?: MutableRefObject<(() => void) | null>;
-}
-
-/** Official GitHub mark (Octocat) — filled via currentColor. */
-function GitHubLogo({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      width="40"
-      height="40"
-      viewBox="0 0 16 16"
-      fill="currentColor"
-      xmlns="http://www.w3.org/2000/svg"
-      aria-hidden="true"
-      data-testid="connect-github-logo"
-    >
-      <path
-        fillRule="evenodd"
-        d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"
-      />
-    </svg>
-  );
 }
 
 /**
@@ -137,7 +117,7 @@ export function ConnectGitHubModal({
           className="flex h-16 w-16 items-center justify-center rounded-full bg-gr-accent-subtle text-gr-accent"
           aria-hidden="true"
         >
-          <GitHubLogo />
+          <GitHubLogo data-testid="connect-github-logo" />
         </div>
 
         <h2 id={titleId} className="m-0 w-full text-center text-lg font-semibold text-gr-text">

--- a/apps/extension/src/options/About.test.tsx
+++ b/apps/extension/src/options/About.test.tsx
@@ -4,22 +4,58 @@ import { About } from "./About";
 import { OptionsShell } from "./OptionsShell";
 
 describe("About", () => {
-  it("explains what the extension does and how a review works", () => {
+  it("shows a minimal product overview with logomark, how it works, and privacy", () => {
     render(
       <OptionsShell route="about">
         <About />
       </OptionsShell>,
     );
 
-    expect(screen.getByRole("heading", { name: "About" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Guided Review" })).toBeInTheDocument();
     expect(screen.getByText(/v0\.1\.0/)).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "What It Does" })).toBeInTheDocument();
-    expect(screen.getByText(/turns a PR diff into an ordered review plan/i)).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "How a Review Works" })).toBeInTheDocument();
+    expect(screen.getByText(/makes reading code better/i)).toBeInTheDocument();
+    expect(screen.getByText(/Free · Open source · Bring your own LLM key/)).toBeInTheDocument();
+
+    expect(screen.getByRole("heading", { name: "How it works" })).toBeInTheDocument();
+    expect(screen.getByText(/Start Guided Review/i)).toBeInTheDocument();
+    expect(screen.getByText(/clusters related changes/i)).toBeInTheDocument();
+
     expect(screen.getByRole("heading", { name: "Privacy" })).toBeInTheDocument();
-    expect(screen.getByText(/no Guided Review backend/i)).toBeInTheDocument();
-    const privacyPolicy = screen.getByRole("link", { name: /privacy policy/i });
-    expect(privacyPolicy).toHaveAttribute("href", "https://guidedreview.dev/privacy");
+    expect(screen.getByText(/never touches our infrastructure/i)).toBeInTheDocument();
+  });
+
+  it("links out to website, docs, github, privacy, and terms", () => {
+    render(
+      <OptionsShell route="about">
+        <About />
+      </OptionsShell>,
+    );
+
+    const productLinks = screen.getByRole("navigation", { name: "Product links" });
+
+    expect(screen.getByRole("link", { name: "Website" })).toHaveAttribute(
+      "href",
+      "https://guidedreview.dev",
+    );
+    // Docs appears in the shell nav and the product links footer.
+    expect(
+      screen
+        .getAllByRole("link", { name: "Docs" })
+        .every((el) => el.getAttribute("href") === "https://guidedreview.dev/docs"),
+    ).toBe(true);
+    expect(screen.getByRole("link", { name: "GitHub" })).toHaveAttribute(
+      "href",
+      "https://github.com/nshntarora/guidedreview",
+    );
+    expect(screen.getByRole("link", { name: "Privacy" })).toHaveAttribute(
+      "href",
+      "https://guidedreview.dev/privacy",
+    );
+    expect(screen.getByRole("link", { name: "Terms" })).toHaveAttribute(
+      "href",
+      "https://guidedreview.dev/terms",
+    );
+    expect(productLinks).toBeInTheDocument();
   });
 
   it("links back to settings via the shell nav", () => {

--- a/apps/extension/src/options/About.test.tsx
+++ b/apps/extension/src/options/About.test.tsx
@@ -1,24 +1,35 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { About } from "./About";
+import { OptionsShell } from "./OptionsShell";
 
 describe("About", () => {
   it("explains what the extension does and how a review works", () => {
-    render(<About />);
+    render(
+      <OptionsShell route="about">
+        <About />
+      </OptionsShell>,
+    );
 
-    expect(screen.getByRole("heading", { name: "Guided Review" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "About" })).toBeInTheDocument();
     expect(screen.getByText(/v0\.1\.0/)).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "What It Does" })).toBeInTheDocument();
     expect(screen.getByText(/turns a PR diff into an ordered review plan/i)).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "How a Review Works" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Privacy" })).toBeInTheDocument();
     expect(screen.getByText(/no Guided Review backend/i)).toBeInTheDocument();
+    const privacyPolicy = screen.getByRole("link", { name: /privacy policy/i });
+    expect(privacyPolicy).toHaveAttribute("href", "https://guidedreview.dev/privacy");
   });
 
-  it("links back to settings via hash", () => {
-    render(<About />);
+  it("links back to settings via the shell nav", () => {
+    render(
+      <OptionsShell route="about">
+        <About />
+      </OptionsShell>,
+    );
 
-    const link = screen.getByRole("link", { name: /settings/i });
+    const link = screen.getByRole("link", { name: "Settings" });
     expect(link).toHaveAttribute("href", "#settings");
   });
 });

--- a/apps/extension/src/options/About.tsx
+++ b/apps/extension/src/options/About.tsx
@@ -1,77 +1,90 @@
-import { BrandHeader } from "./BrandHeader";
+import { SettingsCard } from "./SettingsCard";
 
-const sectionTitle = "mb-2 mt-0 text-base font-semibold text-opt-text";
-const bodyText = "m-0 text-base leading-relaxed text-opt-muted";
+const DOCS_URL = "https://guidedreview.dev/docs";
+const PRIVACY_POLICY_URL = "https://guidedreview.dev/privacy";
+const sectionBody = "m-0 text-base leading-relaxed text-opt-muted";
+const textLink =
+  "font-medium focus-visible:rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-opt-accent";
 
 /**
  * Explains what Guided Review does, how a review works, and where data goes.
- * Linked from the Settings (options) page via `#about`.
+ * Linked from Settings via the options shell nav (`#about`).
  */
 export function About() {
   const version = chrome.runtime.getManifest().version;
 
   return (
-    <main id="main-content" className="mx-auto max-w-[480px] px-6 py-8">
-      <BrandHeader />
-      <p className="mb-6 text-base text-opt-muted">
-        AI-structured review plans for GitHub pull requests
-        {version ? (
-          <>
-            {" "}
-            · <span className="tabular-nums">v{version}</span>
-          </>
-        ) : null}
-      </p>
-
-      <section className="mb-6">
-        <h2 className={sectionTitle}>What It Does</h2>
-        <p className={bodyText}>
-          Guided Review turns a PR diff into an ordered review plan. You step through logical units
-          — schema and data model first, then core logic, call-sites, then tests — with short
-          context and risk notes per step.
+    <main id="main-content">
+      <header className="mb-8">
+        <div className="flex flex-wrap items-baseline gap-2">
+          <h1 className="m-0 font-brand text-2xl font-bold tracking-tight text-opt-text">About</h1>
+          {version ? (
+            <span className="rounded-full border border-opt-border bg-opt-subtle/60 px-2.5 py-px font-mono text-xs text-opt-muted tabular-nums">
+              v{version}
+            </span>
+          ) : null}
+        </div>
+        <p className="mt-2 m-0 text-base leading-relaxed text-opt-muted text-balance">
+          AI-structured review plans for GitHub pull requests
         </p>
-      </section>
+      </header>
 
-      <section className="mb-6">
-        <h2 className={sectionTitle}>How a Review Works</h2>
-        <ol className="m-0 list-decimal space-y-2 pl-5 text-base leading-relaxed text-opt-muted">
-          <li>Open a pull request on GitHub.</li>
-          <li>
-            Click <strong className="font-semibold text-opt-text">Start Guided Review</strong> on
-            the PR page (or use the extension icon while a PR tab is active).
-          </li>
-          <li>
-            The extension fetches the PR diff and sends it to the AI provider you configured, which
-            builds a structured review plan.
-          </li>
-          <li>
-            Step through the plan in the overlay: description first, then each review unit with the
-            real diff hunks resolved from the PR — the model plans structure and commentary only; it
-            does not invent the code you see.
-          </li>
-        </ol>
-      </section>
+      <div className="flex flex-col gap-4">
+        <SettingsCard title="What It Does" titleId="about-what">
+          <p className={sectionBody}>
+            Guided Review turns a PR diff into an ordered review plan. You step through logical
+            units — schema and data model first, then core logic, call-sites, then tests — with
+            short context and risk notes per step.
+          </p>
+        </SettingsCard>
 
-      <section className="mb-6">
-        <h2 className={sectionTitle}>Privacy</h2>
-        <p className={bodyText}>
-          Your API key is stored only in this browser via{" "}
-          <code className="rounded bg-opt-subtle px-1 py-0.5 text-sm text-opt-text">
-            chrome.storage.local
-          </code>
-          . Diffs and prompts go only to the provider you choose (Anthropic, OpenAI, or xAI). There
-          is no Guided Review backend in the middle.
-        </p>
-      </section>
+        <SettingsCard title="How a Review Works" titleId="about-how">
+          <ol className="m-0 list-decimal space-y-2 pl-5 text-base leading-relaxed text-opt-muted">
+            <li>Open a pull request on GitHub.</li>
+            <li>
+              Click <strong className="font-semibold text-opt-text">Start Guided Review</strong> on
+              the PR page (or use the extension icon while a PR tab is active).
+            </li>
+            <li>
+              The extension fetches the PR diff and sends it to the AI provider you configured,
+              which builds a structured review plan.
+            </li>
+            <li>
+              Step through the plan in the overlay: description first, then each review unit with
+              the real diff hunks resolved from the PR — the model plans structure and commentary
+              only; it does not invent the code you see.
+            </li>
+          </ol>
+        </SettingsCard>
 
-      <nav className="mt-8 border-t border-opt-border pt-6" aria-label="Settings">
-        <a
-          href="#settings"
-          className="text-base font-semibold text-opt-muted no-underline hover:text-opt-text hover:underline focus-visible:rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-opt-accent"
-        >
-          ← Settings
+        <SettingsCard title="Privacy" titleId="about-privacy">
+          <p className={sectionBody}>
+            Your API key is stored only in this browser via{" "}
+            <code className="rounded bg-opt-bg/80 px-1 py-0.5 font-mono text-sm text-opt-text">
+              chrome.storage.local
+            </code>
+            . Diffs and prompts go only to the provider you choose (Anthropic, OpenAI, or xAI).
+            There is no Guided Review backend in the middle.
+          </p>
+          <p className={`${sectionBody} mt-3`}>
+            <a
+              href={PRIVACY_POLICY_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={textLink}
+            >
+              Privacy policy
+            </a>
+          </p>
+        </SettingsCard>
+      </div>
+
+      <p className="mt-6 m-0 text-sm text-opt-muted">
+        <a href={DOCS_URL} target="_blank" rel="noopener noreferrer" className={textLink}>
+          Full docs
         </a>
-      </nav>
+        <span className="text-opt-muted"> · guidedreview.dev</span>
+      </p>
     </main>
   );
 }

--- a/apps/extension/src/options/About.tsx
+++ b/apps/extension/src/options/About.tsx
@@ -1,90 +1,112 @@
-import { SettingsCard } from "./SettingsCard";
+const SITE_URL = "https://guidedreview.dev";
+const DOCS_URL = `${SITE_URL}/docs`;
+const PRIVACY_POLICY_URL = `${SITE_URL}/privacy`;
+const TERMS_URL = `${SITE_URL}/terms`;
+const GITHUB_REPO_URL = "https://github.com/nshntarora/guidedreview";
 
-const DOCS_URL = "https://guidedreview.dev/docs";
-const PRIVACY_POLICY_URL = "https://guidedreview.dev/privacy";
-const sectionBody = "m-0 text-base leading-relaxed text-opt-muted";
 const textLink =
   "font-medium focus-visible:rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-opt-accent";
 
+const LINKS = [
+  { href: SITE_URL, label: "Website" },
+  { href: DOCS_URL, label: "Docs" },
+  { href: GITHUB_REPO_URL, label: "GitHub" },
+  { href: PRIVACY_POLICY_URL, label: "Privacy" },
+  { href: TERMS_URL, label: "Terms" },
+] as const;
+
 /**
- * Explains what Guided Review does, how a review works, and where data goes.
- * Linked from Settings via the options shell nav (`#about`).
+ * Minimal product overview — logomark, what it is, how a review works, privacy,
+ * and outbound links. Linked from Settings via the options shell nav (`#about`).
  */
 export function About() {
   const version = chrome.runtime.getManifest().version;
+  const logomarkUrl = chrome.runtime.getURL("logomark.svg");
 
   return (
-    <main id="main-content">
-      <header className="mb-8">
-        <div className="flex flex-wrap items-baseline gap-2">
-          <h1 className="m-0 font-brand text-2xl font-bold tracking-tight text-opt-text">About</h1>
-          {version ? (
-            <span className="rounded-full border border-opt-border bg-opt-subtle/60 px-2.5 py-px font-mono text-xs text-opt-muted tabular-nums">
-              v{version}
-            </span>
-          ) : null}
-        </div>
-        <p className="mt-2 m-0 text-base leading-relaxed text-opt-muted text-balance">
-          AI-structured review plans for GitHub pull requests
+    <main id="main-content" className="mx-auto max-w-xl">
+      <header className="text-center">
+        <img
+          src={logomarkUrl}
+          alt=""
+          width={343}
+          height={172}
+          className="mx-auto block h-12 w-auto sm:h-14"
+          aria-hidden="true"
+        />
+        <h1 className="mt-5 m-0 font-brand text-2xl font-bold tracking-tight text-opt-text sm:text-3xl">
+          Guided Review
+        </h1>
+        {version ? (
+          <p className="mt-2 m-0 font-mono text-xs text-opt-muted tabular-nums">v{version}</p>
+        ) : null}
+        <p className="mt-5 m-0 text-base leading-relaxed text-opt-muted text-balance sm:text-lg">
+          A Chrome extension that makes reading code better — clustered changes, short summaries,
+          and a keyboard-first review overlay for GitHub pull requests.
+        </p>
+        <p className="mt-3 m-0 font-mono text-xs text-opt-muted">
+          Free · Open source · Bring your own LLM key
         </p>
       </header>
 
-      <div className="flex flex-col gap-4">
-        <SettingsCard title="What It Does" titleId="about-what">
-          <p className={sectionBody}>
-            Guided Review turns a PR diff into an ordered review plan. You step through logical
-            units — schema and data model first, then core logic, call-sites, then tests — with
-            short context and risk notes per step.
-          </p>
-        </SettingsCard>
+      <section className="mt-12 text-left" aria-labelledby="about-how">
+        <h2
+          id="about-how"
+          className="m-0 font-brand text-lg font-bold tracking-tight text-opt-text"
+        >
+          How it works
+        </h2>
+        <ol className="mt-4 m-0 list-decimal space-y-3 pl-5 text-base leading-relaxed text-opt-muted">
+          <li>Open a pull request on GitHub.</li>
+          <li>
+            Click <strong className="font-semibold text-opt-text">Start Guided Review</strong> on
+            the PR page.
+          </li>
+          <li>
+            The extension fetches the diff and sends it to the AI provider you configured, which
+            clusters related changes into an ordered review plan.
+          </li>
+          <li>
+            Step through the plan in the overlay — real diff hunks, short context, you still judge
+            the code.
+          </li>
+        </ol>
+      </section>
 
-        <SettingsCard title="How a Review Works" titleId="about-how">
-          <ol className="m-0 list-decimal space-y-2 pl-5 text-base leading-relaxed text-opt-muted">
-            <li>Open a pull request on GitHub.</li>
-            <li>
-              Click <strong className="font-semibold text-opt-text">Start Guided Review</strong> on
-              the PR page (or use the extension icon while a PR tab is active).
-            </li>
-            <li>
-              The extension fetches the PR diff and sends it to the AI provider you configured,
-              which builds a structured review plan.
-            </li>
-            <li>
-              Step through the plan in the overlay: description first, then each review unit with
-              the real diff hunks resolved from the PR — the model plans structure and commentary
-              only; it does not invent the code you see.
-            </li>
-          </ol>
-        </SettingsCard>
+      <section className="mt-12 text-left" aria-labelledby="about-privacy">
+        <h2
+          id="about-privacy"
+          className="m-0 font-brand text-lg font-bold tracking-tight text-opt-text"
+        >
+          Privacy
+        </h2>
+        <p className="mt-4 m-0 text-base leading-relaxed text-opt-muted">
+          Your code never touches our infrastructure — we don&apos;t have any. Diffs and prompts go
+          only to the provider you choose. Your API key stays in this browser via{" "}
+          <code className="rounded bg-opt-subtle px-1 py-0.5 font-mono text-sm text-opt-text">
+            chrome.storage.local
+          </code>
+          .
+        </p>
+      </section>
 
-        <SettingsCard title="Privacy" titleId="about-privacy">
-          <p className={sectionBody}>
-            Your API key is stored only in this browser via{" "}
-            <code className="rounded bg-opt-bg/80 px-1 py-0.5 font-mono text-sm text-opt-text">
-              chrome.storage.local
-            </code>
-            . Diffs and prompts go only to the provider you choose (Anthropic, OpenAI, or xAI).
-            There is no Guided Review backend in the middle.
-          </p>
-          <p className={`${sectionBody} mt-3`}>
-            <a
-              href={PRIVACY_POLICY_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={textLink}
-            >
-              Privacy policy
+      <nav
+        className="mt-14 flex flex-wrap items-center justify-center gap-x-3 gap-y-2 text-sm"
+        aria-label="Product links"
+      >
+        {LINKS.map((link, i) => (
+          <span key={link.href} className="inline-flex items-center gap-x-3">
+            {i > 0 ? (
+              <span className="text-opt-muted/50" aria-hidden="true">
+                ·
+              </span>
+            ) : null}
+            <a href={link.href} target="_blank" rel="noopener noreferrer" className={textLink}>
+              {link.label}
             </a>
-          </p>
-        </SettingsCard>
-      </div>
-
-      <p className="mt-6 m-0 text-sm text-opt-muted">
-        <a href={DOCS_URL} target="_blank" rel="noopener noreferrer" className={textLink}>
-          Full docs
-        </a>
-        <span className="text-opt-muted"> · guidedreview.dev</span>
-      </p>
+          </span>
+        ))}
+      </nav>
     </main>
   );
 }

--- a/apps/extension/src/options/App.test.tsx
+++ b/apps/extension/src/options/App.test.tsx
@@ -14,6 +14,10 @@ describe("App", () => {
 
     expect(await screen.findByRole("combobox", { name: /provider/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "About" })).toHaveAttribute("href", "#about");
+    expect(screen.getByRole("link", { name: "Docs" })).toHaveAttribute(
+      "href",
+      "https://guidedreview.dev/docs",
+    );
     expect(document.title).toBe("Guided Review — Settings");
   });
 
@@ -21,7 +25,7 @@ describe("App", () => {
     window.location.hash = "#about";
     render(<App />);
 
-    expect(await screen.findByRole("heading", { name: "What It Does" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "How it works" })).toBeInTheDocument();
     expect(screen.queryByRole("combobox", { name: /provider/i })).not.toBeInTheDocument();
     expect(document.title).toBe("Guided Review — About");
   });
@@ -33,7 +37,7 @@ describe("App", () => {
     await screen.findByRole("combobox", { name: /provider/i });
     await user.click(screen.getByRole("link", { name: "About" }));
 
-    expect(await screen.findByRole("heading", { name: "What It Does" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "How it works" })).toBeInTheDocument();
     await waitFor(() => expect(window.location.hash).toBe("#about"));
 
     await user.click(screen.getByRole("link", { name: "Settings" }));

--- a/apps/extension/src/options/App.test.tsx
+++ b/apps/extension/src/options/App.test.tsx
@@ -13,10 +13,7 @@ describe("App", () => {
     render(<App />);
 
     expect(await screen.findByRole("combobox", { name: /provider/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /about guided review/i })).toHaveAttribute(
-      "href",
-      "#about",
-    );
+    expect(screen.getByRole("link", { name: "About" })).toHaveAttribute("href", "#about");
     expect(document.title).toBe("Guided Review — Settings");
   });
 
@@ -34,12 +31,12 @@ describe("App", () => {
     render(<App />);
 
     await screen.findByRole("combobox", { name: /provider/i });
-    await user.click(screen.getByRole("link", { name: /about guided review/i }));
+    await user.click(screen.getByRole("link", { name: "About" }));
 
     expect(await screen.findByRole("heading", { name: "What It Does" })).toBeInTheDocument();
     await waitFor(() => expect(window.location.hash).toBe("#about"));
 
-    await user.click(screen.getByRole("link", { name: /settings/i }));
+    await user.click(screen.getByRole("link", { name: "Settings" }));
     expect(await screen.findByRole("combobox", { name: /provider/i })).toBeInTheDocument();
     await waitFor(() => expect(window.location.hash).toBe("#settings"));
   });

--- a/apps/extension/src/options/App.tsx
+++ b/apps/extension/src/options/App.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from "react";
 import { About } from "./About";
 import { Options } from "./Options";
+import { OptionsShell } from "./OptionsShell";
+import type { OptionsRoute } from "./routes";
 
-export type OptionsRoute = "settings" | "about";
+export type { OptionsRoute };
 
 function parseHash(hash: string): OptionsRoute {
   const path = hash.replace(/^#\/?/, "").toLowerCase();
@@ -39,5 +41,5 @@ export function App() {
     document.title = TITLES[route];
   }, [route]);
 
-  return route === "about" ? <About /> : <Options />;
+  return <OptionsShell route={route}>{route === "about" ? <About /> : <Options />}</OptionsShell>;
 }

--- a/apps/extension/src/options/BrandHeader.tsx
+++ b/apps/extension/src/options/BrandHeader.tsx
@@ -1,6 +1,0 @@
-import { BrandMark } from "@guided-review/ui";
-
-/** Shared branding block used by Settings and About. Chrome-resolved icon URL. */
-export function BrandHeader({ title }: { title?: string }) {
-  return <BrandMark title={title} iconSrc={chrome.runtime.getURL("icon.png")} />;
-}

--- a/apps/extension/src/options/GitHubAuthSection.test.tsx
+++ b/apps/extension/src/options/GitHubAuthSection.test.tsx
@@ -52,6 +52,7 @@ describe("GitHubAuthSection", () => {
   it("shows Connect when disconnected", async () => {
     render(<GitHubAuthSection />);
     expect(await screen.findByRole("button", { name: /connect github/i })).toBeInTheDocument();
+    expect(screen.getByTestId("github-auth-logo")).toBeInTheDocument();
   });
 
   it("shows the connected account when auth is stored", async () => {

--- a/apps/extension/src/options/GitHubAuthSection.tsx
+++ b/apps/extension/src/options/GitHubAuthSection.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from "react";
 import type { GitHubPublicAuthState } from "../lib/types";
+import { GitHubLogo } from "../components/GitHubLogo";
 import { GITHUB_CLIENT_ID_ENV_VAR, isGitHubOAuthConfigured } from "../lib/github/oauthConfig";
 import { useCopyToClipboard } from "../lib/useCopyToClipboard";
 import { openVerificationUri, useGitHubDeviceAuth } from "../lib/github/useGitHubDeviceAuth";
 import { clearGitHubAuthSession, getGitHubAuthStatus } from "../lib/messaging";
 import { confirm, ConfirmationHost } from "../content/overlay/components/confirmation";
 import { Button, Spinner, cn } from "@guided-review/ui";
+import { SettingsCard } from "./SettingsCard";
 
 type SessionState =
   | { kind: "loading" }
@@ -97,17 +99,24 @@ export function GitHubAuthSection() {
   const showError = flow.kind === "error" ? flow.message : disconnectError;
 
   return (
-    <section className="mb-8 border-b border-opt-border pb-8" data-testid="github-auth-section">
-      <h2 className="mb-1.5 text-base font-semibold text-opt-text">GitHub Account</h2>
-      <p className="mb-4 text-base text-opt-muted">
-        Connect GitHub so Guided Review can submit reviews on your behalf. Uses device sign-in — no
-        password is stored. Token stays in this browser only.
-      </p>
-
+    <SettingsCard
+      title="GitHub Account"
+      titleId="github-heading"
+      icon={
+        <span
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gr-accent-subtle text-opt-accent"
+          aria-hidden="true"
+        >
+          <GitHubLogo size={18} data-testid="github-auth-logo" />
+        </span>
+      }
+      description="Connect GitHub so Guided Review can submit reviews on your behalf. Uses device sign-in — no password is stored. Token stays in this browser only."
+      data-testid="github-auth-section"
+    >
       {!configured && (
-        <p className="text-base text-opt-muted" role="status">
+        <p className="m-0 text-base text-opt-muted" role="status">
           GitHub connection isn’t configured in this build. Set{" "}
-          <code className="rounded bg-opt-subtle px-1 py-0.5 text-sm text-opt-text">
+          <code className="rounded bg-opt-bg/80 px-1 py-0.5 font-mono text-sm text-opt-text">
             {GITHUB_CLIENT_ID_ENV_VAR}
           </code>{" "}
           and rebuild.
@@ -115,7 +124,7 @@ export function GitHubAuthSection() {
       )}
 
       {configured && session.kind === "loading" && flow.kind === "idle" && !showError && (
-        <p className="flex items-center gap-2 text-base text-opt-muted" role="status">
+        <p className="m-0 flex items-center gap-2 text-base text-opt-muted" role="status">
           <Spinner surface="app" size={14} label="Loading GitHub connection" />
           Loading…
         </p>
@@ -141,7 +150,7 @@ export function GitHubAuthSection() {
         <div className="space-y-3" data-testid="github-auth-awaiting">
           <div className="flex flex-wrap items-center gap-2">
             <code
-              className="rounded-md border border-opt-border bg-opt-subtle px-3 py-2 font-mono text-lg tracking-widest text-opt-text"
+              className="rounded-md border border-opt-border bg-opt-bg/60 px-3 py-2 font-mono text-lg tracking-widest text-opt-text"
               data-testid="github-user-code"
             >
               {flow.userCode}
@@ -177,7 +186,7 @@ export function GitHubAuthSection() {
 
       {configured && session.kind === "connected" && flow.kind === "idle" && !showError && (
         <div
-          className="flex flex-wrap items-center justify-between gap-3"
+          className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-opt-border bg-opt-bg/60 p-3"
           data-testid="github-auth-connected"
         >
           <div className="flex min-w-0 items-center gap-3">
@@ -231,6 +240,6 @@ export function GitHubAuthSection() {
       )}
 
       <ConfirmationHost />
-    </section>
+    </SettingsCard>
   );
 }

--- a/apps/extension/src/options/Options.test.tsx
+++ b/apps/extension/src/options/Options.test.tsx
@@ -166,14 +166,16 @@ describe("Options", () => {
     expect(within(listbox).getByRole("option", { name: /Claude Haiku 4\.5/i })).toBeInTheDocument();
   });
 
-  it("links to the about page via the shell nav when rendered in App", async () => {
-    // About nav lives in OptionsShell (App); Options alone is the settings body.
+  it("links to about and docs via the shell nav when rendered in App", async () => {
+    // About/Docs nav lives in OptionsShell (App); Options alone is the settings body.
     const { App } = await import("./App");
     render(<App />);
 
     await screen.findByRole("combobox", { name: /provider/i });
-    const about = screen.getByRole("link", { name: "About" });
-    expect(about).toHaveAttribute("href", "#about");
+    expect(screen.getByRole("link", { name: "About" })).toHaveAttribute("href", "#about");
+    const docs = screen.getByRole("link", { name: "Docs" });
+    expect(docs).toHaveAttribute("href", "https://guidedreview.dev/docs");
+    expect(docs).toHaveAttribute("target", "_blank");
   });
 
   it("defaults the Files changed auto-open switch to off", async () => {

--- a/apps/extension/src/options/Options.test.tsx
+++ b/apps/extension/src/options/Options.test.tsx
@@ -166,21 +166,23 @@ describe("Options", () => {
     expect(within(listbox).getByRole("option", { name: /Claude Haiku 4\.5/i })).toBeInTheDocument();
   });
 
-  it("links to the about page", async () => {
-    render(<Options />);
+  it("links to the about page via the shell nav when rendered in App", async () => {
+    // About nav lives in OptionsShell (App); Options alone is the settings body.
+    const { App } = await import("./App");
+    render(<App />);
 
     await screen.findByRole("combobox", { name: /provider/i });
-    const about = screen.getByRole("link", { name: /about guided review/i });
+    const about = screen.getByRole("link", { name: "About" });
     expect(about).toHaveAttribute("href", "#about");
   });
 
-  it("defaults the Files changed auto-open checkbox to off", async () => {
+  it("defaults the Files changed auto-open switch to off", async () => {
     render(<Options />);
 
-    const checkbox = await screen.findByRole("checkbox", {
-      name: /automatically open when i go to files changed tab in a pr/i,
+    const toggle = await screen.findByRole("switch", {
+      name: /automatically open on files changed/i,
     });
-    expect(checkbox).not.toBeChecked();
+    expect(toggle).toHaveAttribute("aria-checked", "false");
   });
 
   it("hydrates and persists the Files changed auto-open preference", async () => {
@@ -189,13 +191,13 @@ describe("Options", () => {
 
     render(<Options />);
 
-    const checkbox = await screen.findByRole("checkbox", {
-      name: /automatically open when i go to files changed tab in a pr/i,
+    const toggle = await screen.findByRole("switch", {
+      name: /automatically open on files changed/i,
     });
-    expect(checkbox).toBeChecked();
+    expect(toggle).toHaveAttribute("aria-checked", "true");
 
-    await user.click(checkbox);
-    expect(checkbox).not.toBeChecked();
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-checked", "false");
 
     await waitFor(async () => {
       const stored = await chrome.storage.local.get("guidedReview.autoOpenOnFilesTab");

--- a/apps/extension/src/options/Options.tsx
+++ b/apps/extension/src/options/Options.tsx
@@ -10,9 +10,13 @@ import { getAutoOpenOnFilesTab, setAutoOpenOnFilesTab } from "../lib/autoOpenOnF
 import { getProviderSettings, setProviderSettings } from "../lib/settings";
 import { testConnection } from "../lib/messaging";
 import { ProviderIcon } from "./components/ProviderIcon";
-import { BrandHeader } from "./BrandHeader";
 import { GitHubAuthSection } from "./GitHubAuthSection";
-import { Button, Input, Label, Select, Spinner, cn, type SelectOption } from "@guided-review/ui";
+import { SettingsCard } from "./SettingsCard";
+import { StatusCallout } from "./StatusCallout";
+import { Toggle } from "./Toggle";
+import { Button, Input, Label, Select, Spinner, type SelectOption } from "@guided-review/ui";
+
+const CONFIGURE_PROVIDER_DOCS_URL = "https://guidedreview.dev/docs/configure-provider";
 
 type ActionStatus =
   | { kind: "idle" }
@@ -128,120 +132,141 @@ export function Options() {
         : null;
 
   return (
-    <main id="main-content" className="mx-auto max-w-[480px] px-6 py-8">
-      <BrandHeader />
-      <p className="mb-6 text-base text-opt-muted">
-        Connect GitHub and choose an AI provider. Keys and tokens stay in this browser only.
-      </p>
-
-      <GitHubAuthSection />
-
-      <h2 className="mb-4 text-base font-semibold text-opt-text">AI Provider</h2>
-
-      <div className="mb-4">
-        <Label id="provider-label" htmlFor="provider">
-          Provider
-        </Label>
-        <Select
-          id="provider"
-          aria-labelledby="provider-label"
-          value={settings.provider}
-          options={providerOptions}
-          onChange={onProviderChange}
-          disabled={busy}
-        />
-      </div>
-
-      <div className="mb-4">
-        <Label id="model-label" htmlFor="model">
-          Model
-        </Label>
-        <Select
-          id="model"
-          aria-labelledby="model-label"
-          value={settings.model}
-          options={modelOptions}
-          onChange={onModelChange}
-          disabled={busy}
-        />
-      </div>
-
-      <div className="mb-4">
-        <Label htmlFor="apiKey">API Key</Label>
-        <Input
-          id="apiKey"
-          type="password"
-          autoComplete="off"
-          placeholder={providerDef.keyPlaceholder}
-          value={settings.apiKey}
-          onChange={(e) => onApiKeyChange(e.target.value)}
-          disabled={busy}
-          aria-describedby="apiKey-hint"
-        />
-        <p id="apiKey-hint" className="mt-1 text-sm text-opt-muted">
-          Stored locally on this device via chrome.storage.local — never synced.
+    <main id="main-content">
+      <header className="mb-8">
+        <h1 className="m-0 font-brand text-2xl font-bold tracking-tight text-opt-text">Settings</h1>
+        <p className="mt-2 m-0 text-base leading-relaxed text-opt-muted text-balance">
+          Connect GitHub and choose an AI provider. Keys and tokens stay in this browser only.
         </p>
-      </div>
+      </header>
 
-      <div className="mt-6 flex flex-wrap items-center gap-2.5">
-        <Button onClick={onSave} disabled={busy}>
-          {saveStatus.kind === "working" && <Spinner surface="app" size={14} label="Saving" />}
-          {saveStatus.kind === "working" ? "Saving…" : "Save"}
-        </Button>
-        <Button variant="secondary" onClick={onTestConnection} disabled={!settings.apiKey || busy}>
-          {connection.kind === "working" && (
-            <Spinner surface="app" size={14} label="Testing connection" />
-          )}
-          {connection.kind === "working" ? "Testing…" : "Test Connection"}
-        </Button>
-        {statusMessage && (
-          <span
-            role="status"
-            aria-live="polite"
-            className={cn(
-              "text-base",
-              statusMessage.kind === "ok" && "text-opt-ok",
-              statusMessage.kind === "error" && "text-opt-error",
-            )}
-          >
-            {statusMessage.kind === "error"
-              ? `Error: ${statusMessage.message}`
-              : statusMessage.message}
-          </span>
-        )}
-      </div>
+      <div className="flex flex-col gap-4">
+        <GitHubAuthSection />
 
-      <h2 className="mb-4 mt-8 text-base font-semibold text-opt-text">Review</h2>
-      <div className="mb-2">
-        <label className="flex cursor-pointer items-start gap-3">
-          <input
-            id="autoOpenOnFilesTab"
-            type="checkbox"
-            className="mt-1 size-4 shrink-0 rounded border-opt-border accent-opt-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-opt-accent"
-            checked={autoOpenOnFilesTab}
-            onChange={(e) => void onAutoOpenChange(e.target.checked)}
-            aria-describedby="autoOpenOnFilesTab-hint"
-          />
-          <span className="min-w-0">
-            <span className="block text-base font-semibold text-opt-text">
-              Automatically open when I go to Files changed tab in a PR
-            </span>
-            <span id="autoOpenOnFilesTab-hint" className="mt-1 block text-sm text-opt-muted">
-              When enabled, Guided Review opens (or resumes) automatically on a PR’s Files changed /
-              Changes tab. You can still start it from the button anytime.
-            </span>
-          </span>
-        </label>
-      </div>
-
-      <nav className="mt-8 border-t border-opt-border pt-6" aria-label="About">
-        <a
-          href="#about"
-          className="text-base font-semibold text-opt-muted no-underline hover:text-opt-text hover:underline focus-visible:rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-opt-accent"
+        <SettingsCard
+          title="AI Provider"
+          titleId="ai-provider-heading"
+          description={
+            <>
+              Bring your own key for Claude, OpenAI, or Grok.{" "}
+              <a
+                href={CONFIGURE_PROVIDER_DOCS_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium focus-visible:rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-opt-accent"
+              >
+                Setup docs
+              </a>
+            </>
+          }
         >
-          About Guided Review
-        </a>
-      </nav>
+          <div className="space-y-4">
+            <div>
+              <Label id="provider-label" htmlFor="provider">
+                Provider
+              </Label>
+              <Select
+                id="provider"
+                aria-labelledby="provider-label"
+                value={settings.provider}
+                options={providerOptions}
+                onChange={onProviderChange}
+                disabled={busy}
+              />
+            </div>
+
+            <div>
+              <Label id="model-label" htmlFor="model">
+                Model
+              </Label>
+              <Select
+                id="model"
+                aria-labelledby="model-label"
+                value={settings.model}
+                options={modelOptions}
+                onChange={onModelChange}
+                disabled={busy}
+              />
+            </div>
+
+            <div>
+              <Label htmlFor="apiKey">API Key</Label>
+              <Input
+                id="apiKey"
+                type="password"
+                autoComplete="off"
+                placeholder={providerDef.keyPlaceholder}
+                value={settings.apiKey}
+                onChange={(e) => onApiKeyChange(e.target.value)}
+                disabled={busy}
+                aria-describedby="apiKey-hint"
+              />
+              <p id="apiKey-hint" className="mt-1.5 m-0 text-sm text-opt-muted">
+                Stored locally on this device via{" "}
+                <code className="rounded bg-opt-bg/80 px-1 py-0.5 font-mono text-sm text-opt-text">
+                  chrome.storage.local
+                </code>{" "}
+                — never synced.
+              </p>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2.5 pt-1">
+              <Button onClick={onSave} disabled={busy}>
+                {saveStatus.kind === "working" && (
+                  <Spinner surface="app" size={14} label="Saving" />
+                )}
+                {saveStatus.kind === "working" ? "Saving…" : "Save"}
+              </Button>
+              <Button
+                variant="secondary"
+                onClick={onTestConnection}
+                disabled={!settings.apiKey || busy}
+              >
+                {connection.kind === "working" && (
+                  <Spinner surface="app" size={14} label="Testing connection" />
+                )}
+                {connection.kind === "working" ? "Testing…" : "Test Connection"}
+              </Button>
+            </div>
+
+            {statusMessage && (
+              <StatusCallout kind={statusMessage.kind} message={statusMessage.message} />
+            )}
+          </div>
+        </SettingsCard>
+
+        <SettingsCard
+          title="Review"
+          titleId="review-heading"
+          description="How Guided Review behaves when you open a pull request."
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0 flex-1">
+              <p
+                id="autoOpenOnFilesTab-label"
+                className="m-0 font-brand text-base font-bold tracking-tight text-opt-text"
+              >
+                Automatically open on Files changed
+              </p>
+              <p id="autoOpenOnFilesTab-hint" className="mt-1 m-0 text-sm text-opt-muted">
+                When enabled, Guided Review opens (or resumes) automatically on a PR’s Files changed
+                / Changes tab. You can still start it from the button anytime.
+              </p>
+            </div>
+            <Toggle
+              id="autoOpenOnFilesTab"
+              checked={autoOpenOnFilesTab}
+              onChange={(enabled) => void onAutoOpenChange(enabled)}
+              aria-labelledby="autoOpenOnFilesTab-label"
+              aria-describedby="autoOpenOnFilesTab-hint"
+            />
+          </div>
+        </SettingsCard>
+      </div>
+
+      <p className="mt-6 m-0 text-sm leading-relaxed text-opt-muted">
+        Keys and tokens stay in this browser. Diffs go only to GitHub and the provider you choose.
+      </p>
     </main>
   );
 }

--- a/apps/extension/src/options/OptionsShell.tsx
+++ b/apps/extension/src/options/OptionsShell.tsx
@@ -2,6 +2,11 @@ import type { ReactNode } from "react";
 import { cn } from "@guided-review/ui";
 import type { OptionsRoute } from "./routes";
 
+const DOCS_URL = "https://guidedreview.dev/docs";
+
+const NAV_ITEM_CLASS =
+  "rounded-md border-b-0 px-3 py-1.5 text-base font-medium no-underline transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-opt-accent";
+
 const NAV: { route: OptionsRoute; href: string; label: string }[] = [
   { route: "settings", href: "#settings", label: "Settings" },
   { route: "about", href: "#about", label: "About" },
@@ -13,7 +18,7 @@ export interface OptionsShellProps {
 }
 
 /**
- * Shared chrome for the options page: sticky brand header + Settings/About nav.
+ * Shared chrome for the options page: sticky brand header + Settings/About/Docs nav.
  * Matches marketing/overlay page chrome without importing those apps.
  */
 export function OptionsShell({ route, children }: OptionsShellProps) {
@@ -47,8 +52,7 @@ export function OptionsShell({ route, children }: OptionsShellProps) {
                   href={item.href}
                   aria-current={active ? "page" : undefined}
                   className={cn(
-                    "rounded-md border-b-0 px-3 py-1.5 text-base font-medium no-underline transition-colors",
-                    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-opt-accent",
+                    NAV_ITEM_CLASS,
                     active
                       ? "bg-opt-subtle text-opt-text"
                       : "text-opt-muted hover:bg-opt-subtle/60 hover:text-opt-text",
@@ -58,6 +62,17 @@ export function OptionsShell({ route, children }: OptionsShellProps) {
                 </a>
               );
             })}
+            <a
+              href={DOCS_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={cn(
+                NAV_ITEM_CLASS,
+                "text-opt-muted hover:bg-opt-subtle/60 hover:text-opt-text",
+              )}
+            >
+              Docs
+            </a>
           </nav>
         </div>
       </header>

--- a/apps/extension/src/options/OptionsShell.tsx
+++ b/apps/extension/src/options/OptionsShell.tsx
@@ -1,0 +1,68 @@
+import type { ReactNode } from "react";
+import { cn } from "@guided-review/ui";
+import type { OptionsRoute } from "./routes";
+
+const NAV: { route: OptionsRoute; href: string; label: string }[] = [
+  { route: "settings", href: "#settings", label: "Settings" },
+  { route: "about", href: "#about", label: "About" },
+];
+
+export interface OptionsShellProps {
+  route: OptionsRoute;
+  children: ReactNode;
+}
+
+/**
+ * Shared chrome for the options page: sticky brand header + Settings/About nav.
+ * Matches marketing/overlay page chrome without importing those apps.
+ */
+export function OptionsShell({ route, children }: OptionsShellProps) {
+  const logoUrl = chrome.runtime.getURL("logo.svg");
+
+  return (
+    <div className="relative min-h-screen">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-opt-accent focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-opt-accent-on"
+      >
+        Skip to content
+      </a>
+
+      <header className="sticky top-0 z-40 border-b border-gr-border bg-gr-chrome/95 backdrop-blur-sm">
+        <div className="mx-auto flex max-w-3xl items-center justify-between gap-3 px-5 py-3.5 sm:px-6">
+          <img
+            src={logoUrl}
+            alt="Guided Review"
+            width={350}
+            height={49}
+            className="block h-6 w-auto shrink-0 sm:h-7"
+          />
+
+          <nav className="flex shrink-0 items-center gap-1" aria-label="Options">
+            {NAV.map((item) => {
+              const active = route === item.route;
+              return (
+                <a
+                  key={item.route}
+                  href={item.href}
+                  aria-current={active ? "page" : undefined}
+                  className={cn(
+                    "rounded-md border-b-0 px-3 py-1.5 text-base font-medium no-underline transition-colors",
+                    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-opt-accent",
+                    active
+                      ? "bg-opt-subtle text-opt-text"
+                      : "text-opt-muted hover:bg-opt-subtle/60 hover:text-opt-text",
+                  )}
+                >
+                  {item.label}
+                </a>
+              );
+            })}
+          </nav>
+        </div>
+      </header>
+
+      <div className="mx-auto max-w-3xl px-5 py-8 sm:px-6">{children}</div>
+    </div>
+  );
+}

--- a/apps/extension/src/options/SettingsCard.tsx
+++ b/apps/extension/src/options/SettingsCard.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from "react";
+import { cn } from "@guided-review/ui";
+
+export interface SettingsCardProps {
+  title: string;
+  description?: ReactNode;
+  children: ReactNode;
+  className?: string;
+  /** Optional decorative icon shown before the title. */
+  icon?: ReactNode;
+  /** Optional id for the title heading (aria-labelledby). */
+  titleId?: string;
+  "data-testid"?: string;
+}
+
+/**
+ * Bordered section panel for the options page — landing-card language
+ * without WindowFrame traffic lights.
+ */
+export function SettingsCard({
+  title,
+  description,
+  children,
+  className,
+  icon,
+  titleId,
+  "data-testid": dataTestId,
+}: SettingsCardProps) {
+  return (
+    <section
+      className={cn(
+        "rounded-lg border border-opt-border bg-opt-subtle/50 px-4 py-4 sm:px-5 sm:py-5",
+        className,
+      )}
+      aria-labelledby={titleId}
+      data-testid={dataTestId}
+    >
+      <header className="mb-4">
+        <div className="flex items-center gap-2.5">
+          {icon}
+          <h2
+            id={titleId}
+            className="m-0 font-brand text-lg font-bold tracking-tight text-opt-text"
+          >
+            {title}
+          </h2>
+        </div>
+        {description ? (
+          <div className="mt-1.5 text-sm leading-relaxed text-opt-muted">{description}</div>
+        ) : null}
+      </header>
+      {children}
+    </section>
+  );
+}

--- a/apps/extension/src/options/StatusCallout.tsx
+++ b/apps/extension/src/options/StatusCallout.tsx
@@ -1,0 +1,28 @@
+import { cn } from "@guided-review/ui";
+
+export interface StatusCalloutProps {
+  kind: "ok" | "error";
+  message: string;
+  className?: string;
+}
+
+/** Compact save / connection status strip for the options form. */
+export function StatusCallout({ kind, message, className }: StatusCalloutProps) {
+  const text = kind === "error" ? `Error: ${message}` : message;
+
+  return (
+    <p
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "m-0 rounded-md border px-3 py-2 text-base",
+        kind === "ok" && "border-opt-border bg-opt-bg/60 text-opt-ok",
+        kind === "error" &&
+          "border-[color-mix(in_srgb,var(--opt-error)_35%,var(--opt-border))] bg-[color-mix(in_srgb,var(--opt-error)_10%,var(--opt-subtle))] text-opt-error",
+        className,
+      )}
+    >
+      {text}
+    </p>
+  );
+}

--- a/apps/extension/src/options/Toggle.tsx
+++ b/apps/extension/src/options/Toggle.tsx
@@ -1,0 +1,53 @@
+import { cn } from "@guided-review/ui";
+
+export interface ToggleProps {
+  id: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  disabled?: boolean;
+  "aria-labelledby"?: string;
+  "aria-describedby"?: string;
+  className?: string;
+}
+
+/**
+ * Accessible on/off switch for options preferences (WAI-ARIA switch pattern).
+ * Options-local; promote to packages/ui if overlay needs the same control.
+ */
+export function Toggle({
+  id,
+  checked,
+  onChange,
+  disabled = false,
+  "aria-labelledby": ariaLabelledBy,
+  "aria-describedby": ariaDescribedBy,
+  className,
+}: ToggleProps) {
+  return (
+    <button
+      id={id}
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-labelledby={ariaLabelledBy}
+      aria-describedby={ariaDescribedBy}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      className={cn(
+        "relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border transition-colors",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-opt-accent",
+        "disabled:cursor-not-allowed disabled:opacity-60",
+        checked ? "border-opt-accent bg-opt-accent" : "border-opt-border bg-opt-subtle",
+        className,
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "pointer-events-none absolute top-0.5 left-0.5 size-4 rounded-full shadow-sm transition-transform",
+          checked ? "translate-x-5 bg-opt-accent-on" : "translate-x-0 bg-opt-muted",
+        )}
+      />
+    </button>
+  );
+}

--- a/apps/extension/src/options/options.scss
+++ b/apps/extension/src/options/options.scss
@@ -1,10 +1,16 @@
 /*
- * Options page base — only what Tailwind utilities on components can't cover
- * (document-level body defaults). Theme tokens come from theme.css.
+ * Options page base — document-level defaults + marketing-site visual parity.
+ * Theme tokens come from theme.css; brand font from styles.css (@fontsource).
  */
 
+html,
 body {
   margin: 0;
+  min-height: 100%;
+}
+
+body {
+  position: relative;
   font-size: 0.875rem;
   font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
@@ -14,7 +20,44 @@ body {
   color: var(--color-opt-text);
 }
 
+/* Faint grain for texture — same technique as the marketing site. */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  opacity: 0.035;
+  mix-blend-mode: overlay;
+  pointer-events: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+
+#root {
+  position: relative;
+  z-index: 1;
+}
+
 :focus-visible {
   outline: 2px solid var(--color-opt-accent, #caff57);
   outline-offset: 2px;
+}
+
+::selection {
+  background: var(--opt-accent);
+  color: var(--opt-accent-on);
+}
+
+/* Text links: accent + bottom border on hover (matches marketing globals).
+   Button-styled anchors use `inline-flex` and keep their own chrome. */
+@layer base {
+  a:not(.inline-flex) {
+    color: var(--opt-accent, #caff57);
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+    transition: border-color 0.15s ease;
+  }
+
+  a:not(.inline-flex):hover {
+    border-bottom-color: currentColor;
+  }
 }

--- a/apps/extension/src/options/routes.ts
+++ b/apps/extension/src/options/routes.ts
@@ -1,0 +1,2 @@
+/** Hash routes for the options page (`#settings` / `#about`). */
+export type OptionsRoute = "settings" | "about";

--- a/apps/extension/src/options/styles.css
+++ b/apps/extension/src/options/styles.css
@@ -1,3 +1,16 @@
 /* Tailwind must scan shared UI components (workspace package lives outside this app tree). */
 @source "../../../../packages/ui/src/**/*.{ts,tsx}";
+
+/* Brand mono — same family as marketing site headings (Victor Mono via next/font there).
+   Self-hosted for the extension so CSP stays on 'self' (no remote fonts). */
+@import "@fontsource/victor-mono/latin-400.css";
+@import "@fontsource/victor-mono/latin-700.css";
+
 @import "@guided-review/ui/theme.css";
+
+/* Marketing-aligned type tokens (scoped to options; not in shared theme). */
+@theme {
+  --font-victor-mono: "Victor Mono";
+  --font-brand:
+    var(--font-victor-mono), ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@fontsource/victor-mono": "^5.3.0",
         "@guided-review/ui": "*",
         "dompurify": "^3.4.12",
         "highlight.js": "^11.11.1",
@@ -1449,6 +1450,15 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fontsource/victor-mono": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/victor-mono/-/victor-mono-5.3.0.tgz",
+      "integrity": "sha512-4U33jWYiEKLDHYuQGONZWJRCg9HD5XCLtPIzJfIxxstFgn9S1YYcaOoPTPc4cPMyjH5woTRFk8NMfax5AmfsMw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@guided-review/extension": {


### PR DESCRIPTION
## Summary
- Redesign the extension options page with a shared shell (sticky brand header, Settings / About / Docs nav), settings cards, accessible toggles, and status callouts for a cleaner, marketing-aligned layout.
- Replace the card-heavy About page with a minimal landing-style overview: centered logomark, short product description, how-it-works steps, privacy statement, and outbound links (website, docs, GitHub, privacy, terms).
- Add a Docs nav item that opens https://guidedreview.dev/docs in a new tab.

## Test plan
- [ ] Load the unpacked extension from `apps/extension/dist` and open the options page
- [ ] Confirm Settings shows the redesigned shell, cards, GitHub auth, provider form, and toggles
- [ ] Navigate Settings ↔ About via the nav; confirm hash routes (`#settings` / `#about`) and document titles
- [ ] On About, confirm logomark, description, how it works, privacy copy, and product links
- [ ] Click Docs in the navbar and confirm it opens guidedreview.dev/docs
- [ ] `npm test` (or options-focused vitest) passes for About / App / Options