### PR TITLE
feat(extension): add first-install welcome screen

### DIFF
--- a/apps/extension/e2e/welcome.spec.ts
+++ b/apps/extension/e2e/welcome.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "./fixtures";
+
+test.describe("Welcome page", () => {
+  test("renders the first-install path and primary CTA", async ({ context, extensionId }) => {
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/src/welcome/index.html`);
+
+    await expect(page.getByRole("heading", { name: "Welcome" })).toBeVisible();
+    await expect(page.getByText(/Here's how to get started/i)).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Pin the extension" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Connect an AI provider" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Start a review on a PR" })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Connect AI provider/i })).toBeVisible();
+    await expect(page.getByRole("navigation", { name: "Product links" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Website" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Docs" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "GitHub" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Privacy" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Terms" })).toBeVisible();
+  });
+});

--- a/apps/extension/e2e/welcome.spec.ts
+++ b/apps/extension/e2e/welcome.spec.ts
@@ -14,7 +14,7 @@ test.describe("Welcome page", () => {
     await expect(page.getByRole("navigation", { name: "Product links" })).toBeVisible();
     await expect(page.getByRole("link", { name: "Website" })).toBeVisible();
     await expect(page.getByRole("link", { name: "Docs" })).toBeVisible();
-    await expect(page.getByRole("link", { name: "GitHub" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "GitHub", exact: true })).toBeVisible();
     await expect(page.getByRole("link", { name: "Privacy" })).toBeVisible();
     await expect(page.getByRole("link", { name: "Terms" })).toBeVisible();
   });

--- a/apps/extension/src/background/index.test.ts
+++ b/apps/extension/src/background/index.test.ts
@@ -11,6 +11,11 @@ async function loadHandleGitHubAuthGet() {
   return handleGitHubAuthGet;
 }
 
+async function loadHandleInstalled() {
+  const { handleInstalled, WELCOME_PAGE_PATH } = await import("./index");
+  return { handleInstalled, WELCOME_PAGE_PATH };
+}
+
 type MessageListener = (
   message: unknown,
   sender: unknown,
@@ -36,6 +41,28 @@ describe("OPEN_OPTIONS", () => {
 
     expect(chrome.runtime.openOptionsPage).toHaveBeenCalledTimes(1);
     expect(response).toEqual({ ok: true });
+  });
+});
+
+describe("handleInstalled", () => {
+  it("opens the welcome page on first install", async () => {
+    const { handleInstalled, WELCOME_PAGE_PATH } = await loadHandleInstalled();
+
+    handleInstalled({ reason: "install" });
+
+    expect(chrome.tabs.create).toHaveBeenCalledTimes(1);
+    expect(chrome.tabs.create).toHaveBeenCalledWith({
+      url: WELCOME_PAGE_PATH,
+    });
+    expect(chrome.runtime.getURL).toHaveBeenCalledWith(WELCOME_PAGE_PATH);
+  });
+
+  it("does not open a tab on update", async () => {
+    const { handleInstalled } = await loadHandleInstalled();
+
+    handleInstalled({ reason: "update" });
+
+    expect(chrome.tabs.create).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -41,6 +41,9 @@ import { ProviderError } from "./providers/types";
 
 const ANNOTATE_PORT_NAME = "annotate-review";
 
+/** Packaged welcome page path (stable across builds; matches Vite multi-page input). */
+export const WELCOME_PAGE_PATH = "src/welcome/index.html";
+
 // Toolbar icon opens the action popup (`src/popup/`), which starts a guided
 // review on PR pages or explains that the extension only works there.
 
@@ -50,6 +53,19 @@ const ANNOTATE_PORT_NAME = "annotate-review";
 chrome.storage.session
   .setAccessLevel({ accessLevel: "TRUSTED_AND_UNTRUSTED_CONTEXTS" })
   .catch((error) => console.error("Failed to set storage.session access level:", error));
+
+/**
+ * First-install only: open the welcome page. Never on update — no "What's New" tab.
+ * Load-unpacked also fires `install` (useful for local QA).
+ */
+export function handleInstalled(details: { reason: string }): void {
+  if (details.reason !== "install") return;
+  void chrome.tabs.create({
+    url: chrome.runtime.getURL(WELCOME_PAGE_PATH),
+  });
+}
+
+chrome.runtime.onInstalled.addListener(handleInstalled);
 
 chrome.runtime.onMessage.addListener((message: BackgroundRequest, _sender, sendResponse) => {
   if (message.type === "TEST_CONNECTION") {

--- a/apps/extension/src/test/chromeMock.ts
+++ b/apps/extension/src/test/chromeMock.ts
@@ -59,6 +59,7 @@ export function createChromeMock() {
   >();
 
   const onConnectListeners = new Set<(port: MockPort) => void>();
+  const onInstalledListeners = new Set<(details: { reason: string }) => void>();
 
   function createPort(name: string): MockPort {
     const onMessage = new Set<(message: unknown) => void>();
@@ -159,11 +160,21 @@ export function createChromeMock() {
         }),
         __listeners: onConnectListeners,
       },
+      onInstalled: {
+        addListener: vi.fn((listener: (details: { reason: string }) => void) => {
+          onInstalledListeners.add(listener);
+        }),
+        removeListener: vi.fn((listener: (details: { reason: string }) => void) => {
+          onInstalledListeners.delete(listener);
+        }),
+        __listeners: onInstalledListeners,
+      },
     },
     action: {
       onClicked: {
         addListener: vi.fn(),
       },
+      getUserSettings: vi.fn(async () => ({ isOnToolbar: false })),
     },
     tabs: {
       sendMessage: vi.fn(async (_tabId: number, _message: unknown) => undefined),

--- a/apps/extension/src/welcome/Welcome.test.tsx
+++ b/apps/extension/src/welcome/Welcome.test.tsx
@@ -24,7 +24,7 @@ describe("Welcome", () => {
       "href",
       "https://guidedreview.dev/docs",
     );
-    expect(screen.getByRole("link", { name: "GitHub" })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "GitHub", exact: true })).toHaveAttribute(
       "href",
       "https://github.com/nshntarora/guidedreview",
     );

--- a/apps/extension/src/welcome/Welcome.test.tsx
+++ b/apps/extension/src/welcome/Welcome.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { Welcome } from "./Welcome";
+
+describe("Welcome", () => {
+  it("shows the three setup steps and helpful links", async () => {
+    render(<Welcome />);
+
+    expect(screen.getByRole("heading", { name: "Welcome" })).toBeInTheDocument();
+    expect(screen.getByText(/Here's how to get started/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Extension installed/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Pin the extension" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Connect an AI provider" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Start a review on a PR" })).toBeInTheDocument();
+
+    const productLinks = screen.getByRole("navigation", { name: "Product links" });
+    expect(productLinks).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Website" })).toHaveAttribute(
+      "href",
+      "https://guidedreview.dev",
+    );
+    expect(screen.getByRole("link", { name: "Docs" })).toHaveAttribute(
+      "href",
+      "https://guidedreview.dev/docs",
+    );
+    expect(screen.getByRole("link", { name: "GitHub" })).toHaveAttribute(
+      "href",
+      "https://github.com/nshntarora/guidedreview",
+    );
+    expect(screen.getByRole("link", { name: "Privacy" })).toHaveAttribute(
+      "href",
+      "https://guidedreview.dev/privacy",
+    );
+    expect(screen.getByRole("link", { name: "Terms" })).toHaveAttribute(
+      "href",
+      "https://guidedreview.dev/terms",
+    );
+    expect(screen.getByRole("link", { name: /Open GitHub pull requests/i })).toHaveAttribute(
+      "href",
+      "https://github.com/pulls",
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/puzzle-piece menu/i)).toBeInTheDocument();
+    });
+  });
+
+  it("opens options when Connect AI provider is clicked", async () => {
+    const user = userEvent.setup();
+    render(<Welcome />);
+
+    await user.click(screen.getByRole("button", { name: /Connect AI provider/i }));
+
+    expect(chrome.runtime.openOptionsPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows pinned status when the extension is on the toolbar", async () => {
+    vi.mocked(chrome.action.getUserSettings).mockResolvedValueOnce({ isOnToolbar: true });
+
+    render(<Welcome />);
+
+    expect(await screen.findByText(/Pinned to the toolbar/i)).toBeInTheDocument();
+  });
+});

--- a/apps/extension/src/welcome/Welcome.tsx
+++ b/apps/extension/src/welcome/Welcome.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { Button, buttonClassName } from "@guided-review/ui";
+
+const SITE_URL = "https://guidedreview.dev";
+const DOCS_URL = `${SITE_URL}/docs`;
+const PRIVACY_URL = `${SITE_URL}/privacy`;
+const TERMS_URL = `${SITE_URL}/terms`;
+const GITHUB_REPO_URL = "https://github.com/nshntarora/guidedreview";
+const GITHUB_PULLS_URL = "https://github.com/pulls";
+
+const textLink =
+  "font-medium focus-visible:rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-opt-accent";
+
+const LINKS = [
+  { href: SITE_URL, label: "Website" },
+  { href: DOCS_URL, label: "Docs" },
+  { href: GITHUB_REPO_URL, label: "GitHub" },
+  { href: PRIVACY_URL, label: "Privacy" },
+  { href: TERMS_URL, label: "Terms" },
+] as const;
+
+type PinState = "loading" | "pinned" | "unpinned" | "unknown";
+
+async function readPinState(): Promise<PinState> {
+  try {
+    const settings = await chrome.action.getUserSettings();
+    return settings.isOnToolbar ? "pinned" : "unpinned";
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
+ * First-install welcome page. Short path to value: pin → connect provider → open a PR.
+ */
+export function Welcome() {
+  const [pinState, setPinState] = useState<PinState>("loading");
+  const logomarkUrl = chrome.runtime.getURL("logomark.svg");
+
+  useEffect(() => {
+    void readPinState().then(setPinState);
+  }, []);
+
+  const openSettings = () => {
+    chrome.runtime.openOptionsPage();
+  };
+
+  return (
+    <main id="main-content" className="mx-auto max-w-xl px-6 py-12 sm:py-16">
+      <header className="text-center">
+        <img
+          src={logomarkUrl}
+          alt=""
+          width={343}
+          height={172}
+          className="mx-auto block h-11 w-auto sm:h-12"
+          aria-hidden="true"
+        />
+        <h1 className="mt-8 m-0 font-brand text-3xl font-bold tracking-tight text-opt-text sm:text-4xl">
+          Welcome
+        </h1>
+        <p className="mt-3 m-0 text-base leading-relaxed text-opt-muted sm:text-lg">
+          Here&apos;s how to get started.
+        </p>
+      </header>
+
+      <ol className="mt-10 m-0 list-none space-y-0 divide-y divide-opt-border rounded-lg border border-opt-border bg-opt-subtle/50 p-0">
+        <Step n={1} title="Pin the extension" done={pinState === "pinned"}>
+          {pinState === "pinned" ? (
+            <p className="m-0 text-base leading-relaxed text-opt-muted">
+              Pinned to the toolbar — you&apos;re set.
+            </p>
+          ) : (
+            <p className="m-0 text-base leading-relaxed text-opt-muted">
+              Open the puzzle-piece menu and pin Guided Review so it stays visible. Unpinned
+              extensions are easy to forget.
+            </p>
+          )}
+        </Step>
+
+        <Step n={2} title="Connect an AI provider">
+          <p className="m-0 text-base leading-relaxed text-opt-muted">
+            Paste a key for Claude, OpenAI, or Grok. Keys stay in this browser — we don&apos;t have
+            servers in the middle.
+          </p>
+        </Step>
+
+        <Step n={3} title="Start a review on a PR">
+          <p className="m-0 text-base leading-relaxed text-opt-muted">
+            Open any GitHub pull request and click{" "}
+            <strong className="font-semibold text-opt-text">Start Guided Review</strong>. The
+            extension clusters related changes so you walk the PR in a sensible order.
+          </p>
+        </Step>
+      </ol>
+
+      <div className="mt-8 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-center">
+        <Button onClick={openSettings} data-testid="welcome-connect-provider">
+          Connect AI provider
+        </Button>
+        <a
+          href={GITHUB_PULLS_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={buttonClassName({ variant: "secondary" })}
+          data-testid="welcome-open-pulls"
+        >
+          Open GitHub pull requests
+        </a>
+      </div>
+
+      <p className="mt-10 m-0 text-center text-sm leading-relaxed text-opt-muted text-balance">
+        Your code never touches our infrastructure. Diffs go only to the provider you choose.
+      </p>
+
+      <nav
+        className="mt-5 flex flex-wrap items-center justify-center gap-x-3 gap-y-2 text-sm"
+        aria-label="Product links"
+      >
+        {LINKS.map((link, i) => (
+          <span key={link.href} className="inline-flex items-center gap-x-3">
+            {i > 0 ? (
+              <span className="text-opt-muted/50" aria-hidden="true">
+                ·
+              </span>
+            ) : null}
+            <a href={link.href} target="_blank" rel="noopener noreferrer" className={textLink}>
+              {link.label}
+            </a>
+          </span>
+        ))}
+      </nav>
+    </main>
+  );
+}
+
+function Step({
+  n,
+  title,
+  children,
+  done = false,
+}: {
+  n: number;
+  title: string;
+  children: ReactNode;
+  done?: boolean;
+}) {
+  return (
+    <li className="flex gap-4 px-5 py-5 text-left sm:px-6">
+      <span
+        className={
+          done
+            ? "flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-opt-ok/40 bg-opt-ok/15 font-mono text-sm font-semibold tabular-nums text-opt-ok"
+            : "flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-opt-border bg-opt-bg font-mono text-sm font-semibold tabular-nums text-opt-text"
+        }
+        aria-hidden="true"
+      >
+        {done ? "✓" : n}
+      </span>
+      <div className="min-w-0 pt-0.5">
+        <h2 className="m-0 font-brand text-base font-bold tracking-tight text-opt-text">{title}</h2>
+        <div className="mt-1.5">{children}</div>
+      </div>
+    </li>
+  );
+}

--- a/apps/extension/src/welcome/index.html
+++ b/apps/extension/src/welcome/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Guided Review — Welcome</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/apps/extension/src/welcome/main.tsx
+++ b/apps/extension/src/welcome/main.tsx
@@ -1,0 +1,14 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { Welcome } from "./Welcome";
+import "./styles.css";
+import "./welcome.scss";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Welcome page is missing its #root element.");
+
+createRoot(root).render(
+  <StrictMode>
+    <Welcome />
+  </StrictMode>,
+);

--- a/apps/extension/src/welcome/styles.css
+++ b/apps/extension/src/welcome/styles.css
@@ -1,0 +1,14 @@
+/* Tailwind must scan shared UI components (workspace package lives outside this app tree). */
+@source "../../../../packages/ui/src/**/*.{ts,tsx}";
+
+/* Brand mono — same family as options / marketing site headings. */
+@import "@fontsource/victor-mono/latin-400.css";
+@import "@fontsource/victor-mono/latin-700.css";
+
+@import "@guided-review/ui/theme.css";
+
+@theme {
+  --font-victor-mono: "Victor Mono";
+  --font-brand:
+    var(--font-victor-mono), ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+}

--- a/apps/extension/src/welcome/welcome.scss
+++ b/apps/extension/src/welcome/welcome.scss
@@ -1,0 +1,59 @@
+/*
+ * Welcome page base — matches options document chrome (dark opt surface + grain).
+ */
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+}
+
+body {
+  position: relative;
+  font-size: 0.875rem;
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  background: var(--color-opt-bg);
+  color: var(--color-opt-text);
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  opacity: 0.035;
+  mix-blend-mode: overlay;
+  pointer-events: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+
+#root {
+  position: relative;
+  z-index: 1;
+}
+
+:focus-visible {
+  outline: 2px solid var(--color-opt-accent, #caff57);
+  outline-offset: 2px;
+}
+
+::selection {
+  background: var(--opt-accent);
+  color: var(--opt-accent-on);
+}
+
+@layer base {
+  a:not(.inline-flex) {
+    color: var(--opt-accent, #caff57);
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+    transition: border-color 0.15s ease;
+  }
+
+  a:not(.inline-flex):hover {
+    border-bottom-color: currentColor;
+  }
+}

--- a/apps/extension/vite.config.ts
+++ b/apps/extension/vite.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
       input: {
         options: path.resolve(__dirname, "src/options/index.html"),
         popup: path.resolve(__dirname, "src/popup/index.html"),
+        welcome: path.resolve(__dirname, "src/welcome/index.html"),
       },
     },
   },


### PR DESCRIPTION
## Summary

- Open a first-install welcome page after the extension is installed, with a short setup path: pin → connect AI provider → start a review on a PR.
- Redesigned welcome UI: **Welcome** title, **Here’s how to get started** subheading, card-style steps, and the same product footer links as the About tab (Website · Docs · GitHub · Privacy · Terms).
- Unit and Playwright coverage for the welcome flow and primary CTAs.

## Test plan

- [ ] Load the unpacked extension from `apps/extension/dist` and confirm the welcome page opens on install
- [ ] Confirm pin step reflects toolbar pin state
- [ ] Click **Connect AI provider** and verify options page opens
- [ ] Click **Open GitHub pull requests** and product footer links
- [ ] `npm test --workspace=@guided-review/extension -- src/welcome/Welcome.test.tsx`
- [ ] `npm run test:e2e` (welcome e2e spec)