### PR TITLE
refactor(ui): unify theme tokens, drop opt-*/gr-* dual palettes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,12 +125,12 @@ registering it there — everything downstream (schema, chunking, validation) is
 Source-only package (no emit/`build` script). Apps import `@guided-review/ui` and transpile via Vite /
 Next `transpilePackages`.
 
-- Tokens: `@guided-review/ui/theme.css`
+- Tokens: `@guided-review/ui/theme.css` — single dark palette (`background`, `surface`,
+  `surface-raised`, `surface-muted`, `foreground`, `muted`, `faint`, `border`, `primary*`,
+  `success`/`danger`, `diff-*`, `syntax-*`). Same tokens for marketing, options, welcome, and
+  overlay (Tailwind utilities + `var(--color-*)` in SCSS).
 - Components: `cn`, `Spinner`, `Kbd`, `BrandMark`, `Button` / `buttonClassName`, `Input`, `Textarea`,
   `Label`, `Select` (chrome-free; brand mark takes `iconSrc`)
-- Surfaces: form controls accept `surface?: "app" | "overlay"` — `app` uses dark `opt-*` tokens
-  (options + marketing), `overlay` uses dark `gr-*` tokens (review overlay). Defaults: form controls
-  → `app`; `Spinner` → `overlay`.
 - Assets: `@guided-review/ui/assets/*` (canonical brand). Extension syncs into `public/` via
   `apps/extension/scripts/sync-ui-assets.mjs` on `predev`/`prebuild`.
 

--- a/apps/extension/src/content/index.tsx
+++ b/apps/extension/src/content/index.tsx
@@ -14,7 +14,7 @@ import { useReviewStore, restoreSession, buildSessionKey } from "./overlay/store
 const BUTTON_ID = "guided-review-start-btn";
 const BUTTON_STYLE_ID = "guided-review-start-btn-styles";
 const HOST_ID = "guided-review-overlay-host";
-/** Brand accent hover — keep in sync with `--color-gr-accent-hover` in theme.css. */
+/** Brand accent hover — keep in sync with `--color-primary-hover` in theme.css. */
 const ACCENT_HOVER = "#b6e64e";
 
 let currentPR: PRIdentity | null = null;

--- a/apps/extension/src/content/overlay/Overlay.tsx
+++ b/apps/extension/src/content/overlay/Overlay.tsx
@@ -222,7 +222,7 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
       aria-modal="true"
       aria-labelledby={titleId}
       tabIndex={-1}
-      className="fixed inset-0 z-[2147483000] flex flex-col bg-gr-bg font-sans text-base text-gr-text antialiased outline-none [color-scheme:dark] [text-rendering:optimizeLegibility]"
+      className="fixed inset-0 z-[2147483000] flex flex-col bg-surface font-sans text-base text-foreground antialiased outline-none [color-scheme:dark] [text-rendering:optimizeLegibility]"
       data-testid="guided-review-overlay"
     >
       <div
@@ -249,7 +249,7 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
       <div className="flex min-h-0 flex-1">
         <main
           id="main-content"
-          className="min-w-0 flex-[1_1_68%] overflow-y-auto border-r border-gr-border bg-gr-bg px-8 py-6"
+          className="min-w-0 flex-[1_1_68%] overflow-y-auto border-r border-border bg-surface px-8 py-6"
           ref={codeColRef}
           data-testid="code-col"
           tabIndex={-1}
@@ -267,7 +267,7 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
         </main>
 
         <aside
-          className="flex max-w-[420px] min-w-[300px] flex-[1_1_32%] flex-col overflow-hidden bg-gr-chrome py-6"
+          className="flex max-w-[420px] min-w-[300px] flex-[1_1_32%] flex-col overflow-hidden bg-background py-6"
           aria-label="Review context and plan"
         >
           <div

--- a/apps/extension/src/content/overlay/components/CloseButton.tsx
+++ b/apps/extension/src/content/overlay/components/CloseButton.tsx
@@ -11,7 +11,7 @@ export function CloseButton({
   return (
     <button
       type="button"
-      className="inline-flex cursor-pointer items-center justify-center rounded-md border border-gr-border bg-gr-bg p-1.5 text-gr-muted hover:bg-gr-subtle hover:text-gr-text disabled:cursor-not-allowed disabled:opacity-50"
+      className="inline-flex cursor-pointer items-center justify-center rounded-md border border-border bg-surface p-1.5 text-muted hover:bg-surface-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
       onClick={onClick}
       disabled={disabled}
       aria-label="Close"

--- a/apps/extension/src/content/overlay/components/CommentComposer.tsx
+++ b/apps/extension/src/content/overlay/components/CommentComposer.tsx
@@ -47,17 +47,16 @@ export function CommentComposer({
 
   return (
     <div
-      className="border border-gr-border bg-gr-chrome px-3 py-3"
+      className="border border-border bg-background px-3 py-3"
       data-testid="comment-composer"
       role="form"
       aria-label="Draft review comment"
     >
-      <div className="mb-2 font-mono text-sm text-gr-muted">
+      <div className="mb-2 font-mono text-sm text-muted">
         {formatLineRangeLabel(filePath, startLine, endLine)}
       </div>
       <Textarea
         ref={textareaRef}
-        surface="overlay"
         placeholder="Line comment (markdown supported)…"
         value={body}
         onChange={(e) => setBody(e.target.value)}
@@ -66,12 +65,11 @@ export function CommentComposer({
         data-testid="comment-composer-input"
       />
       <div className="mt-2 flex flex-wrap items-center justify-end gap-2">
-        <Button surface="overlay" variant="secondary" size="sm" onClick={onCancel}>
+        <Button variant="secondary" size="sm" onClick={onCancel}>
           Cancel
           <Kbd>Esc</Kbd>
         </Button>
         <Button
-          surface="overlay"
           size="sm"
           disabled={!canSave}
           onClick={() => {

--- a/apps/extension/src/content/overlay/components/ConnectGitHubModal.tsx
+++ b/apps/extension/src/content/overlay/components/ConnectGitHubModal.tsx
@@ -108,29 +108,26 @@ export function ConnectGitHubModal({
         "data-flow": flow.kind,
       }}
     >
-      <div className="flex items-center justify-end border-b border-gr-border px-4 py-3">
+      <div className="flex items-center justify-end border-b border-border px-4 py-3">
         <CloseButton onClick={onCancel} testId="connect-github-close" />
       </div>
 
       <div className="flex flex-col items-center gap-4 px-6 py-6 text-center">
         <div
-          className="flex h-16 w-16 items-center justify-center rounded-full bg-gr-accent-subtle text-gr-accent"
+          className="flex h-16 w-16 items-center justify-center rounded-full bg-primary-muted text-primary"
           aria-hidden="true"
         >
           <GitHubLogo data-testid="connect-github-logo" />
         </div>
 
-        <h2 id={titleId} className="m-0 w-full text-center text-lg font-semibold text-gr-text">
+        <h2 id={titleId} className="m-0 w-full text-center text-lg font-semibold text-foreground">
           Connect GitHub
         </h2>
 
         {!configured ? (
-          <p
-            className="m-0 w-full text-center text-base leading-relaxed text-gr-muted"
-            role="status"
-          >
+          <p className="m-0 w-full text-center text-base leading-relaxed text-muted" role="status">
             GitHub connection isn’t configured in this build. Set{" "}
-            <code className="rounded bg-gr-bg px-1 py-0.5 text-sm text-gr-text">
+            <code className="rounded bg-surface px-1 py-0.5 text-sm text-foreground">
               {GITHUB_CLIENT_ID_ENV_VAR}
             </code>{" "}
             and rebuild.
@@ -147,13 +144,12 @@ export function ConnectGitHubModal({
           <div className="w-full space-y-3 text-left" data-testid="connect-github-awaiting">
             <div className="flex flex-wrap items-center justify-center gap-2 my-4">
               <code
-                className="rounded-md border border-gr-border bg-gr-bg px-3 py-2 font-mono text-lg tracking-widest text-gr-text"
+                className="rounded-md border border-border bg-surface px-3 py-2 font-mono text-lg tracking-widest text-foreground"
                 data-testid="connect-github-user-code"
               >
                 {flow.userCode}
               </code>
               <Button
-                surface="overlay"
                 variant="secondary"
                 size="sm"
                 onClick={() => void copyUserCode(flow.userCode)}
@@ -163,13 +159,13 @@ export function ConnectGitHubModal({
               </Button>
             </div>
             <p
-              className="m-0 text-center text-base leading-relaxed text-gr-muted"
+              className="m-0 text-center text-base leading-relaxed text-muted"
               data-testid="connect-github-copy-hint"
             >
               Copy this code, then paste it on the GitHub tab.
             </p>
             <span
-              className="flex items-center justify-center gap-2 text-base text-gr-muted"
+              className="flex items-center justify-center gap-2 text-base text-muted"
               role="status"
             >
               <Spinner label="Waiting for GitHub authorization" size={16} />
@@ -178,7 +174,7 @@ export function ConnectGitHubModal({
           </div>
         ) : (
           <p
-            className="m-0 w-full text-center text-base leading-relaxed text-gr-muted"
+            className="m-0 w-full text-center text-base leading-relaxed text-muted"
             data-testid="connect-github-prompt"
           >
             Connect GitHub to submit this review. Uses device sign-in; the token stays in this
@@ -187,9 +183,8 @@ export function ConnectGitHubModal({
         )}
       </div>
 
-      <div className="flex items-center justify-end gap-2 border-t border-gr-border px-4 py-3">
+      <div className="flex items-center justify-end gap-2 border-t border-border px-4 py-3">
         <Button
-          surface="overlay"
           variant="secondary"
           size="sm"
           onClick={onCancel}
@@ -200,7 +195,6 @@ export function ConnectGitHubModal({
         </Button>
         {configured && flow.kind === "error" ? (
           <Button
-            surface="overlay"
             size="sm"
             onClick={() => void startConnect()}
             disabled={busy}
@@ -220,7 +214,6 @@ export function ConnectGitHubModal({
           </Button>
         ) : configured && flow.kind === "awaiting" ? (
           <Button
-            surface="overlay"
             size="sm"
             onClick={() => void openVerificationUri(flow.verificationUri)}
             data-testid="connect-github-enter-code"
@@ -231,7 +224,6 @@ export function ConnectGitHubModal({
         ) : configured ? (
           <Button
             ref={connectButtonRef}
-            surface="overlay"
             size="sm"
             onClick={() => void startConnect()}
             disabled={busy}

--- a/apps/extension/src/content/overlay/components/ConnectProviderPrompt.tsx
+++ b/apps/extension/src/content/overlay/components/ConnectProviderPrompt.tsx
@@ -5,12 +5,12 @@ import { openOptionsPage } from "../../../lib/messaging";
 const CONFIGURE_PROVIDER_DOCS_URL = "https://guidedreview.dev/docs/configure-provider";
 
 /** Raised panel — one step above the context-pane background. */
-const SURFACE = "fill-[var(--color-gr-subtle)] stroke-[var(--color-gr-border)]";
+const SURFACE = "fill-[var(--color-surface-muted)] stroke-[var(--color-border)]";
 /** Recessed area (code pane, placeholder bars) sitting inside a surface. */
-const INSET = "fill-[var(--color-gr-bg)] stroke-[var(--color-gr-border)]";
+const INSET = "fill-[var(--color-surface)] stroke-[var(--color-border)]";
 /** The single accent moment: the context column waiting to be filled. */
 const ACCENT_WASH =
-  "fill-[color-mix(in_srgb,var(--color-gr-accent)_10%,transparent)] stroke-[var(--color-gr-accent)]";
+  "fill-[color-mix(in_srgb,var(--color-primary)_10%,transparent)] stroke-[var(--color-primary)]";
 
 /**
  * Review window with its AI context column empty and unconnected — same
@@ -29,15 +29,15 @@ function DisconnectedProviderArt() {
     >
       {/* Window chrome */}
       <rect x="8" y="10" width="224" height="120" rx="10" className={SURFACE} strokeWidth="1.25" />
-      <circle cx="22" cy="24" r="2.5" className="fill-[var(--color-gr-border)]" />
-      <circle cx="31" cy="24" r="2.5" className="fill-[var(--color-gr-border)]" />
-      <circle cx="40" cy="24" r="2.5" className="fill-[var(--color-gr-border)]" />
+      <circle cx="22" cy="24" r="2.5" className="fill-[var(--color-border)]" />
+      <circle cx="31" cy="24" r="2.5" className="fill-[var(--color-border)]" />
+      <circle cx="40" cy="24" r="2.5" className="fill-[var(--color-border)]" />
       <line
         x1="8"
         y1="38"
         x2="232"
         y2="38"
-        className="stroke-[var(--color-gr-border)]"
+        className="stroke-[var(--color-border)]"
         strokeWidth="1.25"
       />
 
@@ -51,20 +51,20 @@ function DisconnectedProviderArt() {
           width={[76, 58, 84, 46, 66][i]}
           height="5"
           rx="2.5"
-          className="fill-[var(--color-gr-border-muted)]"
+          className="fill-[var(--color-border-strong)]"
         />
       ))}
 
       {/* Broken link between the review and its context */}
       <path
         d="M136 84h6"
-        className="stroke-[var(--color-gr-accent)]"
+        className="stroke-[var(--color-primary)]"
         strokeWidth="1.5"
         strokeLinecap="round"
       />
       <path
         d="M150 84h6"
-        className="stroke-[var(--color-gr-accent)]"
+        className="stroke-[var(--color-primary)]"
         strokeWidth="1.5"
         strokeLinecap="round"
       />
@@ -82,7 +82,7 @@ function DisconnectedProviderArt() {
       />
       <path
         d="M190 66l3.2 7.3 7.3 3.2-7.3 3.2-3.2 7.3-3.2-7.3-7.3-3.2 7.3-3.2z"
-        className="fill-[var(--color-gr-accent)]"
+        className="fill-[var(--color-primary)]"
       />
       <rect
         x="172"
@@ -90,7 +90,7 @@ function DisconnectedProviderArt() {
         width="36"
         height="4"
         rx="2"
-        className="fill-[var(--color-gr-accent)] opacity-40"
+        className="fill-[var(--color-primary)] opacity-40"
       />
       <rect
         x="178"
@@ -98,7 +98,7 @@ function DisconnectedProviderArt() {
         width="24"
         height="4"
         rx="2"
-        className="fill-[var(--color-gr-accent)] opacity-25"
+        className="fill-[var(--color-primary)] opacity-25"
       />
     </svg>
   );
@@ -119,15 +119,14 @@ export function ConnectProviderPrompt() {
     >
       <DisconnectedProviderArt />
 
-      <h2 className="m-0 text-lg font-semibold text-gr-text">Connect an AI provider</h2>
+      <h2 className="m-0 text-lg font-semibold text-foreground">Connect an AI provider</h2>
 
-      <p className="m-0 text-base leading-relaxed text-gr-muted">
+      <p className="m-0 text-base leading-relaxed text-muted">
         You&rsquo;re reviewing this PR file by file. Setup AI and get your review done faster.
       </p>
 
       <div className="flex flex-col items-center gap-2">
         <Button
-          surface="overlay"
           size="sm"
           onClick={() => void openOptionsPage()}
           data-testid="connect-provider-open-settings"
@@ -141,7 +140,6 @@ export function ConnectProviderPrompt() {
           className={buttonClassName({
             variant: "ghost",
             size: "sm",
-            surface: "overlay",
           })}
           data-testid="connect-provider-learn-more"
         >

--- a/apps/extension/src/content/overlay/components/ContextPanel.tsx
+++ b/apps/extension/src/content/overlay/components/ContextPanel.tsx
@@ -42,7 +42,7 @@ export function ContextPanel({
         role="alert"
         data-testid="context-panel-error"
       >
-        <div className="mb-2 text-xs font-semibold tracking-[0.04em] text-gr-muted uppercase">
+        <div className="mb-2 text-xs font-semibold tracking-[0.04em] text-muted uppercase">
           Error
         </div>
 
@@ -50,16 +50,16 @@ export function ContextPanel({
           <dl className="mb-2 m-0 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-sm leading-normal">
             {error.statusCode !== undefined && (
               <>
-                <dt className="m-0 font-medium text-gr-muted">HTTP Status</dt>
-                <dd className="m-0 font-mono text-gr-danger" data-testid="error-status-code">
+                <dt className="m-0 font-medium text-muted">HTTP Status</dt>
+                <dd className="m-0 font-mono text-danger" data-testid="error-status-code">
                   {error.statusCode}
                 </dd>
               </>
             )}
             {error.code && (
               <>
-                <dt className="m-0 font-medium text-gr-muted">Error Code</dt>
-                <dd className="m-0 font-mono break-all text-gr-danger" data-testid="error-code">
+                <dt className="m-0 font-medium text-muted">Error Code</dt>
+                <dd className="m-0 font-mono break-all text-danger" data-testid="error-code">
                   {error.code}
                 </dd>
               </>
@@ -67,13 +67,13 @@ export function ContextPanel({
           </dl>
         )}
 
-        <pre className="m-0 max-h-[40vh] overflow-x-auto overflow-y-auto rounded-md border border-gr-danger bg-gr-danger-subtle p-3 text-left font-mono text-sm leading-normal break-words whitespace-pre-wrap text-gr-danger">
+        <pre className="m-0 max-h-[40vh] overflow-x-auto overflow-y-auto rounded-md border border-danger bg-danger-muted p-3 text-left font-mono text-sm leading-normal break-words whitespace-pre-wrap text-danger">
           <code data-testid="error-message">{error.message}</code>
         </pre>
 
         {onRetry && (
           <div className="mt-3">
-            <Button surface="overlay" size="sm" onClick={onRetry}>
+            <Button size="sm" onClick={onRetry}>
               Retry
             </Button>
           </div>
@@ -90,13 +90,13 @@ export function ContextPanel({
 
     return (
       <div className="rounded-none border-0 bg-transparent px-0 py-0.5 pb-1">
-        <div className="text-lg leading-[1.7] text-gr-text" data-testid="context-panel-body">
+        <div className="text-lg leading-[1.7] text-foreground" data-testid="context-panel-body">
           {hint}
         </div>
         {loading ? (
-          <div className="mt-4 flex items-center gap-2.5 border-t border-gr-border-muted pt-3">
+          <div className="mt-4 flex items-center gap-2.5 border-t border-border-strong pt-3">
             <Spinner label="Building remaining units" />
-            <p className="m-0 text-base text-gr-muted">Building remaining units…</p>
+            <p className="m-0 text-base text-muted">Building remaining units…</p>
           </div>
         ) : (
           <KeyboardShortcuts />
@@ -107,7 +107,7 @@ export function ContextPanel({
 
   return (
     <div className="rounded-none border-0 bg-transparent px-0 py-0.5 pb-1">
-      <div className="text-base leading-[1.7] text-gr-text" data-testid="context-panel-body">
+      <div className="text-base leading-[1.7] text-foreground" data-testid="context-panel-body">
         {unit.context}
       </div>
     </div>

--- a/apps/extension/src/content/overlay/components/DescriptionPane.tsx
+++ b/apps/extension/src/content/overlay/components/DescriptionPane.tsx
@@ -20,10 +20,10 @@ const STATUS_BADGE: Record<FileChangeStatus, { letter: string; label: string }> 
 };
 
 const STATUS_BADGE_CLASS: Record<FileChangeStatus, string> = {
-  added: "bg-gr-add-bg text-gr-add-text",
-  modified: "bg-gr-subtle text-gr-muted",
-  removed: "bg-gr-del-bg text-gr-del-text",
-  renamed: "bg-gr-subtle text-gr-syntax-entity",
+  added: "bg-diff-add-bg text-diff-add",
+  modified: "bg-surface-muted text-muted",
+  removed: "bg-diff-del-bg text-diff-del",
+  renamed: "bg-surface-muted text-syntax-entity",
 };
 
 /**
@@ -49,21 +49,21 @@ export function DescriptionPane({ prContext, diff }: DescriptionPaneProps) {
       data-testid="description-pane"
     >
       <div className="min-w-0 max-w-[720px] flex-1">
-        <h2 className="mb-5 text-[1.375rem] font-semibold leading-snug tracking-[-0.01em] text-gr-text">
+        <h2 className="mb-5 text-[1.375rem] font-semibold leading-snug tracking-[-0.01em] text-foreground">
           PR Description
         </h2>
         {descriptionHtml ? (
           <div
-            className="markdown-body text-[0.9375rem] leading-[1.7] break-words text-gr-text"
+            className="markdown-body text-[0.9375rem] leading-[1.7] break-words text-foreground"
             dangerouslySetInnerHTML={{ __html: descriptionHtml }}
           />
         ) : description ? (
-          <div className="text-[0.9375rem] leading-[1.7] break-words whitespace-pre-wrap text-gr-text">
+          <div className="text-[0.9375rem] leading-[1.7] break-words whitespace-pre-wrap text-foreground">
             {description}
           </div>
         ) : (
           <p
-            className="m-0 text-[0.9375rem] leading-relaxed text-gr-muted"
+            className="m-0 text-[0.9375rem] leading-relaxed text-muted"
             data-testid="description-pane-empty"
           >
             {emptyDescriptionCopy(hasTitle)}
@@ -73,13 +73,13 @@ export function DescriptionPane({ prContext, diff }: DescriptionPaneProps) {
 
       {summary && (
         <section
-          className="w-[min(100%,360px)] shrink-0 max-w-[400px] border-l border-gr-border pl-6"
+          className="w-[min(100%,360px)] shrink-0 max-w-[400px] border-l border-border pl-6"
           aria-label="Diff summary"
         >
-          <h3 className="mb-2.5 text-lg font-semibold text-gr-text">Changes</h3>
-          <p className="mb-3.5 text-[0.9375rem] text-gr-muted tabular-nums">
-            <span className="mr-2 font-semibold text-gr-add-text">+{summary.additions}</span>
-            <span className="mr-2 font-semibold text-gr-del-text">−{summary.deletions}</span>
+          <h3 className="mb-2.5 text-lg font-semibold text-foreground">Changes</h3>
+          <p className="mb-3.5 text-[0.9375rem] text-muted tabular-nums">
+            <span className="mr-2 font-semibold text-diff-add">+{summary.additions}</span>
+            <span className="mr-2 font-semibold text-diff-del">−{summary.deletions}</span>
             <span>
               · {summary.files} file{summary.files === 1 ? "" : "s"}
             </span>
@@ -114,22 +114,22 @@ function DiffSummaryFileRow({ file }: { file: FileDiffSummary }) {
       >
         {badge.letter}
       </span>
-      <span className="min-w-0 truncate text-gr-text" title={pathLabel}>
+      <span className="min-w-0 truncate text-foreground" title={pathLabel}>
         {pathLabel}
       </span>
       <span className="inline-flex min-w-[4.5rem] shrink-0 items-center justify-end gap-1.5 text-right tabular-nums">
         {file.isBinaryOrElided ? (
-          <span className="text-[0.8125rem] text-gr-faint">binary</span>
+          <span className="text-[0.8125rem] text-faint">binary</span>
         ) : (
           <>
             {file.additions > 0 && (
-              <span className="font-medium text-gr-add-text">+{file.additions}</span>
+              <span className="font-medium text-diff-add">+{file.additions}</span>
             )}
             {file.deletions > 0 && (
-              <span className="font-medium text-gr-del-text">−{file.deletions}</span>
+              <span className="font-medium text-diff-del">−{file.deletions}</span>
             )}
             {file.additions === 0 && file.deletions === 0 && (
-              <span className="text-[0.8125rem] text-gr-faint">0</span>
+              <span className="text-[0.8125rem] text-faint">0</span>
             )}
           </>
         )}

--- a/apps/extension/src/content/overlay/components/DiffPane.test.tsx
+++ b/apps/extension/src/content/overlay/components/DiffPane.test.tsx
@@ -343,20 +343,20 @@ describe("DiffPane", () => {
     const focus = screen.getByTestId("diff-line-focus");
     expect(focus).toHaveAttribute("data-line-id", addId);
     // Row wash + brand line-number gutter both mark focus.
-    expect(focus.className).toMatch(/bg-gr-accent-subtle/);
-    expect(focus.className).not.toMatch(/bg-gr-add-bg/);
+    expect(focus.className).toMatch(/bg-primary-muted/);
+    expect(focus.className).not.toMatch(/bg-diff-add-bg/);
 
     const focusNumbers = screen.getAllByTestId("diff-line-number-highlight");
     expect(focusNumbers.length).toBeGreaterThan(0);
     for (const num of focusNumbers) {
-      expect(num.className).toMatch(/bg-gr-accent/);
-      expect(num.className).toMatch(/text-gr-accent-on/);
+      expect(num.className).toMatch(/bg-primary/);
+      expect(num.className).toMatch(/text-primary-foreground/);
     }
 
     // Unfocused del line still uses del background.
     const delLine = document.querySelector(`[data-line-id="${delId}"]`);
-    expect(delLine?.className).toMatch(/bg-gr-del-bg/);
-    expect(delLine?.className).not.toMatch(/bg-gr-accent-subtle/);
+    expect(delLine?.className).toMatch(/bg-diff-del-bg/);
+    expect(delLine?.className).not.toMatch(/bg-primary-muted/);
   });
 
   it("highlights line numbers for every line in a multi-line selection", async () => {
@@ -403,8 +403,8 @@ describe("DiffPane", () => {
     expect(firstNums.length).toBeGreaterThan(0);
     expect(secondNums.length).toBeGreaterThan(0);
     for (const num of [...firstNums, ...secondNums]) {
-      expect(num.className).toMatch(/bg-gr-accent/);
-      expect(num.className).toMatch(/text-gr-accent-on/);
+      expect(num.className).toMatch(/bg-primary/);
+      expect(num.className).toMatch(/text-primary-foreground/);
     }
   });
 
@@ -468,9 +468,9 @@ describe("DiffPane", () => {
     renderPane();
 
     const card = screen.getByTestId("draft-comment");
-    expect(card.className).toMatch(/bg-gr-bg/);
-    expect(card.className).toMatch(/border-gr-border/);
-    expect(card.className).not.toMatch(/bg-gr-accent-subtle/);
+    expect(card.className).toMatch(/bg-surface/);
+    expect(card.className).toMatch(/border-border/);
+    expect(card.className).not.toMatch(/bg-primary-muted/);
     expect(card).toHaveTextContent("Looks good");
 
     await act(async () => {

--- a/apps/extension/src/content/overlay/components/DiffPane.tsx
+++ b/apps/extension/src/content/overlay/components/DiffPane.tsx
@@ -91,7 +91,7 @@ export function DiffPane({ files, unitTitle, unitId, selectableForUnit }: DiffPa
       </div>
       <div className="mb-4 flex items-center justify-between gap-4">
         <h2
-          className="min-w-0 truncate text-lg font-semibold text-gr-text"
+          className="min-w-0 truncate text-lg font-semibold text-foreground"
           data-testid="diff-unit-title"
           title={unitTitle}
         >
@@ -114,13 +114,13 @@ export function DiffPane({ files, unitTitle, unitId, selectableForUnit }: DiffPa
         const extension = file.path.includes(".") ? file.path.split(".").pop() : undefined;
         return (
           <div
-            className="mb-7 overflow-hidden rounded-lg border border-gr-border bg-gr-canvas"
+            className="mb-7 overflow-hidden rounded-lg border border-border bg-surface-raised"
             key={file.path}
           >
-            <div className="flex items-baseline gap-2.5 border-b border-gr-border bg-gr-chrome px-3 py-2 font-mono text-sm">
+            <div className="flex items-baseline gap-2.5 border-b border-border bg-background px-3 py-2 font-mono text-sm">
               {file.previousPath ? `${file.previousPath} → ${file.path}` : file.path}
               {!language && !file.isBinaryOrElided && (
-                <span className="font-normal text-gr-muted italic">
+                <span className="font-normal text-muted italic">
                   {extension
                     ? `no syntax highlighting for .${extension}`
                     : "no syntax highlighting"}

--- a/apps/extension/src/content/overlay/components/DraftCommentCard.tsx
+++ b/apps/extension/src/content/overlay/components/DraftCommentCard.tsx
@@ -56,19 +56,19 @@ export function DraftCommentCard({ comment, onRemove, onUpdate }: DraftCommentCa
 
   return (
     <div
-      className="border-y border-gr-border bg-gr-bg px-3 py-2.5"
+      className="border-y border-border bg-surface px-3 py-2.5"
       data-testid="draft-comment"
       data-draft-id={comment.id}
     >
       <div className="mb-1.5 flex items-center justify-between gap-2">
-        <span className="font-mono text-xs text-gr-muted">
+        <span className="font-mono text-xs text-muted">
           Draft · {formatLineRangeLabel(comment.filePath, comment.startLine, comment.endLine)}
         </span>
         <div className="flex items-center gap-1">
           {!editing && (
             <button
               type="button"
-              className="cursor-pointer rounded px-1.5 py-0.5 text-sm text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+              className="cursor-pointer rounded px-1.5 py-0.5 text-sm text-muted hover:bg-surface-muted hover:text-foreground"
               onClick={() => setEditing(true)}
               aria-label="Edit draft comment"
               data-testid="draft-comment-edit"
@@ -78,7 +78,7 @@ export function DraftCommentCard({ comment, onRemove, onUpdate }: DraftCommentCa
           )}
           <button
             type="button"
-            className="cursor-pointer rounded px-1.5 py-0.5 text-sm text-gr-muted hover:bg-gr-subtle hover:text-gr-text"
+            className="cursor-pointer rounded px-1.5 py-0.5 text-sm text-muted hover:bg-surface-muted hover:text-foreground"
             onClick={() => onRemove(comment.id)}
             aria-label="Remove draft comment"
             data-testid="draft-comment-remove"
@@ -91,8 +91,7 @@ export function DraftCommentCard({ comment, onRemove, onUpdate }: DraftCommentCa
         <>
           <Textarea
             ref={textareaRef}
-            surface="overlay"
-            className="bg-gr-chrome"
+            className="bg-background"
             value={body}
             onChange={(e) => setBody(e.target.value)}
             onKeyDown={handleKeyDown}
@@ -101,10 +100,9 @@ export function DraftCommentCard({ comment, onRemove, onUpdate }: DraftCommentCa
           />
           <div className="mt-2 flex flex-wrap items-center justify-end gap-2">
             <Button
-              surface="overlay"
               variant="secondary"
               size="sm"
-              className="bg-gr-chrome"
+              className="bg-background"
               onClick={exitEdit}
               data-testid="draft-comment-edit-cancel"
             >
@@ -112,7 +110,6 @@ export function DraftCommentCard({ comment, onRemove, onUpdate }: DraftCommentCa
               <Kbd>Esc</Kbd>
             </Button>
             <Button
-              surface="overlay"
               size="sm"
               disabled={!canSave}
               onClick={saveEdit}
@@ -126,7 +123,7 @@ export function DraftCommentCard({ comment, onRemove, onUpdate }: DraftCommentCa
         </>
       ) : (
         <div
-          className="whitespace-pre-wrap font-sans text-base leading-relaxed text-gr-text"
+          className="whitespace-pre-wrap font-sans text-base leading-relaxed text-foreground"
           data-testid="draft-comment-body"
         >
           {comment.body}

--- a/apps/extension/src/content/overlay/components/FooterNav.tsx
+++ b/apps/extension/src/content/overlay/components/FooterNav.tsx
@@ -15,12 +15,12 @@ export function FooterNav({ currentIndex, total, onPrev, onNext }: FooterNavProp
 
   return (
     <footer
-      className="flex shrink-0 items-center justify-between gap-3 border-t border-gr-border bg-gr-chrome px-5 py-3"
+      className="flex shrink-0 items-center justify-between gap-3 border-t border-border bg-background px-5 py-3"
       aria-label="Review navigation"
     >
       <button
         type="button"
-        className={cn(navBtnBase, "border-gr-border bg-gr-bg text-gr-text")}
+        className={cn(navBtnBase, "border-border bg-surface text-foreground")}
         onClick={onPrev}
         disabled={currentIndex === 0 || total === 0}
         aria-label="Previous step"
@@ -30,7 +30,7 @@ export function FooterNav({ currentIndex, total, onPrev, onNext }: FooterNavProp
       </button>
 
       <p
-        className="m-0 min-w-0 text-center text-base tabular-nums text-gr-muted"
+        className="m-0 min-w-0 text-center text-base tabular-nums text-muted"
         role="status"
         aria-live="polite"
         aria-atomic="true"
@@ -43,8 +43,8 @@ export function FooterNav({ currentIndex, total, onPrev, onNext }: FooterNavProp
         type="button"
         className={cn(
           navBtnBase,
-          "border-gr-accent bg-gr-accent text-gr-accent-on transition-colors",
-          "not-disabled:hover:border-gr-accent-hover not-disabled:hover:bg-gr-accent-hover",
+          "border-primary bg-primary text-primary-foreground transition-colors",
+          "not-disabled:hover:border-primary-hover not-disabled:hover:bg-primary-hover",
           "[&_[data-slot=kbd]]:bg-[rgba(13,8,6,0.12)] [&_[data-slot=kbd]]:text-inherit",
         )}
         onClick={onNext}

--- a/apps/extension/src/content/overlay/components/KeyboardShortcuts.tsx
+++ b/apps/extension/src/content/overlay/components/KeyboardShortcuts.tsx
@@ -61,18 +61,18 @@ function ShortcutRowKeys({ row }: { row: ShortcutRow }) {
 export function KeyboardShortcuts() {
   return (
     <section
-      className="mt-4 border-t border-gr-border-muted pt-3"
+      className="mt-4 border-t border-border-strong pt-3"
       aria-labelledby="keyboard-shortcuts-heading"
     >
       <h2
         id="keyboard-shortcuts-heading"
-        className="mb-2 text-xs font-semibold tracking-[0.04em] text-gr-muted uppercase"
+        className="mb-2 text-xs font-semibold tracking-[0.04em] text-muted uppercase"
       >
         Keyboard Shortcuts
       </h2>
       <ul className="m-0 flex list-none flex-col gap-2 p-0">
         {SHORTCUTS.map((row) => (
-          <li key={row.description} className="flex items-center gap-3 text-base text-gr-muted">
+          <li key={row.description} className="flex items-center gap-3 text-base text-muted">
             <span className="inline-flex min-w-[72px] shrink-0 items-center gap-1">
               <ShortcutRowKeys row={row} />
             </span>

--- a/apps/extension/src/content/overlay/components/ModalShell.tsx
+++ b/apps/extension/src/content/overlay/components/ModalShell.tsx
@@ -52,7 +52,7 @@ export function ModalShell({
       <div
         ref={panelRef}
         className={cn(
-          "flex w-full flex-col rounded-lg border border-gr-border bg-gr-chrome shadow-xl",
+          "flex w-full flex-col rounded-lg border border-border bg-background shadow-xl",
           maxWidthClassName,
           panelClassName,
         )}

--- a/apps/extension/src/content/overlay/components/ProgressHeader.tsx
+++ b/apps/extension/src/content/overlay/components/ProgressHeader.tsx
@@ -30,7 +30,7 @@ export function ProgressHeader({
   const logomarkUrl = chrome.runtime.getURL("logomark.svg");
 
   return (
-    <header className="flex shrink-0 flex-col gap-1.5 border-b border-gr-border bg-gr-chrome px-5 py-3.5">
+    <header className="flex shrink-0 flex-col gap-1.5 border-b border-border bg-background px-5 py-3.5">
       <div className="flex items-center justify-between gap-4">
         <div className="flex min-w-0 flex-1 items-center gap-3.5">
           <img
@@ -47,22 +47,22 @@ export function ProgressHeader({
                 {title}
               </h1>
               {prContext && (
-                <span className="shrink-0 text-base text-gr-muted">#{prContext.number}</span>
+                <span className="shrink-0 text-base text-muted">#{prContext.number}</span>
               )}
             </div>
             {prContext && (prContext.author || prContext.baseRef || prContext.headRef || stats) && (
-              <div className="flex items-center gap-2.5 text-sm text-gr-muted">
+              <div className="flex items-center gap-2.5 text-sm text-muted">
                 {prContext.author && <span>@{prContext.author}</span>}
                 {(prContext.baseRef || prContext.headRef) && (
-                  <span className="inline-block rounded-full border border-gr-border bg-gr-bg px-2.5 py-px font-mono text-xs text-gr-text">
+                  <span className="inline-block rounded-full border border-border bg-surface px-2.5 py-px font-mono text-xs text-foreground">
                     {prContext.baseRef || "?"} ← {prContext.headRef || "?"}
                   </span>
                 )}
                 {stats && (
                   <span>
                     {stats.files} file{stats.files === 1 ? "" : "s"} changed
-                    <span className="ml-1 text-gr-add-text"> +{stats.additions}</span>
-                    <span className="ml-1 text-gr-del-text"> −{stats.deletions}</span>
+                    <span className="ml-1 text-diff-add"> +{stats.additions}</span>
+                    <span className="ml-1 text-diff-del"> −{stats.deletions}</span>
                   </span>
                 )}
               </div>
@@ -72,7 +72,7 @@ export function ProgressHeader({
         <div className="flex shrink-0 items-center gap-3">
           <button
             type="button"
-            className={`${headerBtn} border-gr-accent bg-gr-accent text-gr-accent-on hover:border-gr-accent-hover hover:bg-gr-accent-hover [&_[data-slot=kbd]]:bg-[rgba(13,8,6,0.12)] [&_[data-slot=kbd]]:text-inherit`}
+            className={`${headerBtn} border-primary bg-primary text-primary-foreground hover:border-primary-hover hover:bg-primary-hover [&_[data-slot=kbd]]:bg-[rgba(13,8,6,0.12)] [&_[data-slot=kbd]]:text-inherit`}
             onClick={onSubmitReview}
             data-testid="submit-review-button"
           >
@@ -81,7 +81,7 @@ export function ProgressHeader({
           </button>
           <button
             type="button"
-            className={`${headerBtn} gap-2 border-gr-border bg-gr-bg text-gr-text hover:bg-gr-subtle`}
+            className={`${headerBtn} gap-2 border-border bg-surface text-foreground hover:bg-surface-muted`}
             onClick={onExit}
           >
             Exit

--- a/apps/extension/src/content/overlay/components/ReviewSubmittedModal.tsx
+++ b/apps/extension/src/content/overlay/components/ReviewSubmittedModal.tsx
@@ -60,7 +60,7 @@ export function ReviewSubmittedModal({
       }}
     >
       <div
-        className="mb-5 flex h-14 w-14 items-center justify-center rounded-full bg-gr-accent text-gr-accent-on"
+        className="mb-5 flex h-14 w-14 items-center justify-center rounded-full bg-primary text-primary-foreground"
         data-testid="review-submitted-icon"
         aria-hidden="true"
       >
@@ -78,12 +78,12 @@ export function ReviewSubmittedModal({
         </svg>
       </div>
 
-      <h2 id={titleId} className="m-0 text-center text-lg font-semibold text-gr-text">
+      <h2 id={titleId} className="m-0 text-center text-lg font-semibold text-foreground">
         Review Submitted
       </h2>
 
       <p
-        className="mt-2 mb-0 text-center text-base leading-relaxed text-gr-muted"
+        className="mt-2 mb-0 text-center text-base leading-relaxed text-muted"
         data-testid="review-submitted-summary"
       >
         {eventSummary(event, commentCount)}
@@ -91,7 +91,6 @@ export function ReviewSubmittedModal({
 
       <Button
         ref={exitButtonRef}
-        surface="overlay"
         className="mt-7"
         onClick={onExit}
         data-testid="review-submitted-exit"

--- a/apps/extension/src/content/overlay/components/Sidebar.tsx
+++ b/apps/extension/src/content/overlay/components/Sidebar.tsx
@@ -29,11 +29,11 @@ export function Sidebar({ plan, currentUnitIndex, stillBuilding, onSelectUnit }:
 
   return (
     <nav
-      className="mt-6 min-h-0 flex-[1_1_50%] overflow-y-auto border-t border-gr-border-muted pt-4"
+      className="mt-6 min-h-0 flex-[1_1_50%] overflow-y-auto border-t border-border-strong pt-4"
       aria-label="Review Units"
     >
       <div className="px-5">
-        <div className="px-2 pb-1 pt-2.5 text-xs tracking-[0.04em] text-gr-muted uppercase">
+        <div className="px-2 pb-1 pt-2.5 text-xs tracking-[0.04em] text-muted uppercase">
           Review Units
         </div>
 
@@ -46,12 +46,12 @@ export function Sidebar({ plan, currentUnitIndex, stillBuilding, onSelectUnit }:
               ref={isActive ? activeItemRef : undefined}
               aria-current={isActive ? "true" : undefined}
               className={cn(
-                "mb-0.5 block w-full cursor-pointer rounded-md border-none bg-transparent p-2 text-left text-base leading-snug text-gr-text",
-                isActive && "bg-gr-accent-subtle text-gr-accent! hover:bg-gr-accent-subtle",
+                "mb-0.5 block w-full cursor-pointer rounded-md border-none bg-transparent p-2 text-left text-base leading-snug text-foreground",
+                isActive && "bg-primary-muted text-primary! hover:bg-primary-muted",
               )}
               onClick={() => onSelectUnit(displayIndex)}
             >
-              <span className={cn("mr-1.5", isActive ? "text-gr-accent" : "text-gr-muted")}>
+              <span className={cn("mr-1.5", isActive ? "text-primary" : "text-muted")}>
                 {displayIndex + 1}.
               </span>
               {unit.title}
@@ -69,7 +69,7 @@ export function Sidebar({ plan, currentUnitIndex, stillBuilding, onSelectUnit }:
             >
               <span
                 data-skeleton-index={i}
-                className="block h-3 animate-gr-skeleton rounded bg-[linear-gradient(90deg,var(--color-gr-subtle)_0%,var(--color-gr-border-muted)_50%,var(--color-gr-subtle)_100%)] bg-size-[200%_100%]"
+                className="block h-3 animate-gr-skeleton rounded bg-[linear-gradient(90deg,var(--color-surface-muted)_0%,var(--color-border-strong)_50%,var(--color-surface-muted)_100%)] bg-size-[200%_100%]"
               />
             </div>
           ))}

--- a/apps/extension/src/content/overlay/components/SubmitReviewModal.tsx
+++ b/apps/extension/src/content/overlay/components/SubmitReviewModal.tsx
@@ -234,8 +234,8 @@ export function SubmitReviewModal({
         "data-step": step,
       }}
     >
-      <div className="flex items-center justify-between gap-3 border-b border-gr-border px-4 py-3">
-        <h2 id={titleId} className="m-0 text-lg font-semibold text-gr-text">
+      <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-3">
+        <h2 id={titleId} className="m-0 text-lg font-semibold text-foreground">
           Submit Review
         </h2>
         <CloseButton onClick={onClose} disabled={submitting} testId="submit-review-close" />
@@ -244,7 +244,7 @@ export function SubmitReviewModal({
       {step === "choose" ? (
         <>
           <div className="flex flex-col gap-3 px-4 py-4">
-            <p className="m-0 text-base text-gr-muted">Choose a review type.</p>
+            <p className="m-0 text-base text-muted">Choose a review type.</p>
             <div
               ref={listboxRef}
               role="listbox"
@@ -268,21 +268,19 @@ export function SubmitReviewModal({
                     className={[
                       "cursor-pointer rounded-md border px-3 py-2.5 transition-colors",
                       highlighted
-                        ? "border-gr-accent bg-gr-subtle"
-                        : "border-gr-border bg-gr-bg hover:bg-gr-subtle",
+                        ? "border-primary bg-surface-muted"
+                        : "border-border bg-surface hover:bg-surface-muted",
                     ].join(" ")}
                     onClick={() => confirmMode(index)}
                     onMouseEnter={() => setHighlight(index)}
                   >
-                    <div className="text-base font-semibold text-gr-text">{opt.label}</div>
-                    <div className="mt-0.5 text-sm leading-snug text-gr-muted">
-                      {opt.description}
-                    </div>
+                    <div className="text-base font-semibold text-foreground">{opt.label}</div>
+                    <div className="mt-0.5 text-sm leading-snug text-muted">{opt.description}</div>
                   </div>
                 );
               })}
             </div>
-            <div className="flex items-center gap-2 text-sm text-gr-faint">
+            <div className="flex items-center gap-2 text-sm text-faint">
               <KbdGroup>
                 <Kbd>↑</Kbd>
                 <Kbd>↓</Kbd>
@@ -294,9 +292,8 @@ export function SubmitReviewModal({
             </div>
           </div>
 
-          <div className="flex items-center justify-end gap-2 border-t border-gr-border px-4 py-3">
+          <div className="flex items-center justify-end gap-2 border-t border-border px-4 py-3">
             <Button
-              surface="overlay"
               variant="secondary"
               size="sm"
               onClick={onClose}
@@ -312,7 +309,6 @@ export function SubmitReviewModal({
           <div className="flex flex-col gap-4 px-4 py-4">
             <Textarea
               ref={textareaRef}
-              surface="overlay"
               className="min-h-[100px]"
               placeholder="Review summary (markdown supported)…"
               value={body}
@@ -324,12 +320,12 @@ export function SubmitReviewModal({
             />
 
             <div
-              className="rounded-md border border-gr-border bg-gr-bg px-3 py-2.5"
+              className="rounded-md border border-border bg-surface px-3 py-2.5"
               data-testid="submit-review-selected-event"
               data-event={selectedOpt.value}
             >
-              <div className="text-base font-semibold text-gr-text">{selectedOpt.label}</div>
-              <div className="mt-0.5 text-sm leading-snug text-gr-muted">
+              <div className="text-base font-semibold text-foreground">{selectedOpt.label}</div>
+              <div className="mt-0.5 text-sm leading-snug text-muted">
                 {selectedOpt.description}
               </div>
             </div>
@@ -345,9 +341,8 @@ export function SubmitReviewModal({
             ) : null}
           </div>
 
-          <div className="flex items-center justify-between gap-2 border-t border-gr-border px-4 py-3">
+          <div className="flex items-center justify-between gap-2 border-t border-border px-4 py-3">
             <Button
-              surface="overlay"
               variant="secondary"
               size="sm"
               onClick={goBack}
@@ -358,7 +353,6 @@ export function SubmitReviewModal({
             </Button>
             <div className="flex items-center gap-2">
               <Button
-                surface="overlay"
                 variant="secondary"
                 size="sm"
                 onClick={onClose}
@@ -369,7 +363,6 @@ export function SubmitReviewModal({
                 <Kbd>Esc</Kbd>
               </Button>
               <Button
-                surface="overlay"
                 size="sm"
                 onClick={handleSubmit}
                 disabled={submitting}

--- a/apps/extension/src/content/overlay/components/confirmation.tsx
+++ b/apps/extension/src/content/overlay/components/confirmation.tsx
@@ -251,18 +251,17 @@ function ConfirmationDialog({
       }}
     >
       <div className="flex flex-col gap-2 px-4 py-4">
-        <h2 id={titleId} className="m-0 text-lg font-semibold text-gr-text">
+        <h2 id={titleId} className="m-0 text-lg font-semibold text-foreground">
           {title}
         </h2>
-        <div id={bodyId} className="m-0 text-base leading-relaxed text-gr-muted">
+        <div id={bodyId} className="m-0 text-base leading-relaxed text-muted">
           {typeof body === "string" ? <p className="m-0">{body}</p> : body}
         </div>
       </div>
 
-      <div className="flex flex-wrap items-center justify-end gap-2 border-t border-gr-border px-4 py-3">
+      <div className="flex flex-wrap items-center justify-end gap-2 border-t border-border px-4 py-3">
         <Button
           ref={cancelRef}
-          surface="overlay"
           variant="secondary"
           size="sm"
           onClick={() => void handleCancel()}
@@ -273,7 +272,6 @@ function ConfirmationDialog({
           <Kbd>Esc</Kbd>
         </Button>
         <Button
-          surface="overlay"
           variant={variant === "destructive" ? "destructive" : "primary"}
           size="sm"
           onClick={() => void handleOk()}

--- a/apps/extension/src/content/overlay/components/diff/BinaryElidedEmptyState.tsx
+++ b/apps/extension/src/content/overlay/components/diff/BinaryElidedEmptyState.tsx
@@ -39,7 +39,7 @@ export function BinaryElidedEmptyState({ filePath }: { filePath: string }) {
       className="flex min-h-[8rem] flex-col items-center justify-center gap-3 px-4 py-12 text-center"
       data-testid="binary-elided-empty"
     >
-      <span className="font-mono text-base leading-relaxed text-gr-muted">
+      <span className="font-mono text-base leading-relaxed text-muted">
         (binary or elided — no textual diff available)
       </span>
       {githubUrl && (
@@ -47,7 +47,7 @@ export function BinaryElidedEmptyState({ filePath }: { filePath: string }) {
           href={githubUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-base font-medium text-gr-accent underline-offset-2 hover:underline"
+          className="text-base font-medium text-primary underline-offset-2 hover:underline"
           data-testid="binary-elided-github-link"
         >
           View File Diff on GitHub

--- a/apps/extension/src/content/overlay/components/diff/DiffToolbar.tsx
+++ b/apps/extension/src/content/overlay/components/diff/DiffToolbar.tsx
@@ -16,14 +16,14 @@ export function DiffViewToggle({
       aria-label="Diff view"
       data-testid="diff-view-toggle"
     >
-      <div className="inline-flex overflow-hidden rounded-md border border-gr-border bg-gr-bg">
+      <div className="inline-flex overflow-hidden rounded-md border border-border bg-surface">
         <button
           type="button"
           className={cn(
             "inline-flex cursor-pointer items-center gap-1.5 px-3 py-1.5 text-base transition-colors",
             mode === "unified"
-              ? "bg-gr-subtle text-gr-text"
-              : "bg-transparent text-gr-muted hover:bg-gr-subtle hover:text-gr-text",
+              ? "bg-surface-muted text-foreground"
+              : "bg-transparent text-muted hover:bg-surface-muted hover:text-foreground",
           )}
           aria-pressed={mode === "unified"}
           onClick={() => onChange("unified")}
@@ -36,10 +36,10 @@ export function DiffViewToggle({
         <button
           type="button"
           className={cn(
-            "inline-flex cursor-pointer items-center gap-1.5 border-l border-gr-border px-3 py-1.5 text-base transition-colors",
+            "inline-flex cursor-pointer items-center gap-1.5 border-l border-border px-3 py-1.5 text-base transition-colors",
             mode === "split"
-              ? "bg-gr-subtle text-gr-text"
-              : "bg-transparent text-gr-muted hover:bg-gr-subtle hover:text-gr-text",
+              ? "bg-surface-muted text-foreground"
+              : "bg-transparent text-muted hover:bg-surface-muted hover:text-foreground",
           )}
           aria-pressed={mode === "split"}
           onClick={() => onChange("split")}
@@ -57,11 +57,11 @@ export function DiffViewToggle({
 export function CommentModeChip() {
   return (
     <span
-      className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-gr-accent/40 bg-gr-accent-subtle px-2.5 py-1 text-sm text-gr-accent"
+      className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-primary/40 bg-primary-muted px-2.5 py-1 text-sm text-primary"
       data-testid="comment-mode-chip"
     >
       Comment Mode
-      <span className="inline-flex items-center gap-1 text-gr-muted">
+      <span className="inline-flex items-center gap-1 text-muted">
         · <Kbd>Esc</Kbd> exits
       </span>
     </span>
@@ -79,10 +79,10 @@ export function AddCommentButton({
     <button
       type="button"
       className={cn(
-        "inline-flex shrink-0 items-center gap-1.5 rounded-md border border-gr-border px-3 py-1.5 text-base transition-colors",
+        "inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-base transition-colors",
         disabled
-          ? "cursor-not-allowed bg-gr-bg text-gr-faint opacity-60"
-          : "cursor-pointer bg-gr-bg text-gr-text hover:bg-gr-subtle",
+          ? "cursor-not-allowed bg-surface text-faint opacity-60"
+          : "cursor-pointer bg-surface text-foreground hover:bg-surface-muted",
       )}
       disabled={disabled}
       data-testid="enter-comment-mode"

--- a/apps/extension/src/content/overlay/components/diff/SplitHunk.tsx
+++ b/apps/extension/src/content/overlay/components/diff/SplitHunk.tsx
@@ -46,8 +46,8 @@ function SplitCellView({
       className={cn(
         DIFF_LINE_WRAP,
         "flex-1 overflow-hidden",
-        showDiffBg && cell.type === "del" && "bg-gr-del-bg",
-        showDiffBg && cell.type === "add" && "bg-gr-add-bg",
+        showDiffBg && cell.type === "del" && "bg-diff-del-bg",
+        showDiffBg && cell.type === "add" && "bg-diff-add-bg",
         selectionClasses(lineId, selectedIds, focusId),
       )}
       data-side={side}
@@ -64,8 +64,8 @@ function SplitCellView({
       <span
         className={cn(
           "w-4 shrink-0 opacity-70",
-          cell.type === "add" && "text-gr-add-text",
-          cell.type === "del" && "text-gr-del-text",
+          cell.type === "add" && "text-diff-add",
+          cell.type === "del" && "text-diff-del",
         )}
       >
         {cell.type === "add" ? "+" : cell.type === "del" ? "-" : " "}
@@ -112,7 +112,7 @@ export function SplitHunk({
 
         return (
           <div key={i}>
-            <div className="flex min-w-0 border-b border-gr-border-muted last:border-b-0">
+            <div className="flex min-w-0 border-b border-border-strong last:border-b-0">
               <SplitCellView
                 cell={row.left}
                 highlighted={
@@ -123,7 +123,7 @@ export function SplitHunk({
                 selectedIds={selectedIds}
                 focusId={focusId}
               />
-              <div className="w-px shrink-0 bg-gr-border" aria-hidden="true" />
+              <div className="w-px shrink-0 bg-border" aria-hidden="true" />
               <SplitCellView
                 cell={row.right}
                 highlighted={
@@ -138,7 +138,7 @@ export function SplitHunk({
             {(showLeftExtras || showRightExtras) && (
               <div className="flex min-w-0" data-testid="split-line-extras">
                 <div className="min-w-0 flex-1" aria-hidden="true" />
-                <div className="w-px shrink-0 bg-gr-border" aria-hidden="true" />
+                <div className="w-px shrink-0 bg-border" aria-hidden="true" />
                 <div className="min-w-0 flex-1">
                   {showLeftExtras && leftId && (
                     <LineExtras

--- a/apps/extension/src/content/overlay/components/diff/UnifiedHunk.tsx
+++ b/apps/extension/src/content/overlay/components/diff/UnifiedHunk.tsx
@@ -43,8 +43,8 @@ export function UnifiedHunk({
               aria-current={isFocus ? "true" : undefined}
               className={cn(
                 DIFF_LINE_WRAP,
-                showDiffBg && line.type === "add" && "bg-gr-add-bg",
-                showDiffBg && line.type === "del" && "bg-gr-del-bg",
+                showDiffBg && line.type === "add" && "bg-diff-add-bg",
+                showDiffBg && line.type === "del" && "bg-diff-del-bg",
                 selectionClasses(id, selectedIds, focusId),
               )}
             >
@@ -63,8 +63,8 @@ export function UnifiedHunk({
               <span
                 className={cn(
                   "w-4 shrink-0 opacity-70",
-                  line.type === "add" && "text-gr-add-text",
-                  line.type === "del" && "text-gr-del-text",
+                  line.type === "add" && "text-diff-add",
+                  line.type === "del" && "text-diff-del",
                 )}
               >
                 {line.type === "add" ? "+" : line.type === "del" ? "-" : ""}

--- a/apps/extension/src/content/overlay/components/diff/hunkStyles.ts
+++ b/apps/extension/src/content/overlay/components/diff/hunkStyles.ts
@@ -32,10 +32,10 @@ export function selectionClasses(
   if (!lineId) return "";
   // Focus keeps the row wash; brand line-number gutter is layered on top.
   if (focusId === lineId) {
-    return "bg-gr-accent-subtle";
+    return "bg-primary-muted";
   }
   if (selectedIds.has(lineId)) {
-    return "bg-gr-accent-subtle/70";
+    return "bg-primary-muted/70";
   }
   return "";
 }
@@ -47,7 +47,7 @@ export function selectionClasses(
 export function lineNumberClasses(isHighlighted: boolean): string {
   return cn(
     "w-10 shrink-0 select-none pr-3 text-right",
-    isHighlighted ? "bg-gr-accent font-medium text-gr-accent-on" : "text-gr-faint",
+    isHighlighted ? "bg-primary font-medium text-primary-foreground" : "text-faint",
   );
 }
 

--- a/apps/extension/src/content/overlay/styles/_highlight.scss
+++ b/apps/extension/src/content/overlay/styles/_highlight.scss
@@ -2,7 +2,7 @@
 
 .hljs-comment,
 .hljs-quote {
-  color: var(--color-gr-syntax-comment);
+  color: var(--color-syntax-comment);
   font-style: italic;
 }
 
@@ -10,7 +10,7 @@
 .hljs-selector-tag,
 .hljs-subst,
 .hljs-operator {
-  color: var(--color-gr-syntax-keyword);
+  color: var(--color-syntax-keyword);
 }
 
 .hljs-title,
@@ -20,7 +20,7 @@
 .hljs-selector-class,
 .hljs-selector-id,
 .hljs-doctag {
-  color: var(--color-gr-syntax-entity);
+  color: var(--color-syntax-entity);
 }
 
 .hljs-string,
@@ -28,7 +28,7 @@
 .hljs-symbol,
 .hljs-bullet,
 .hljs-link {
-  color: var(--color-gr-syntax-string);
+  color: var(--color-syntax-string);
 }
 
 .hljs-variable,
@@ -36,7 +36,7 @@
 .hljs-selector-attr,
 .hljs-selector-pseudo,
 .hljs-attr {
-  color: var(--color-gr-syntax-variable);
+  color: var(--color-syntax-variable);
 }
 
 .hljs-number,
@@ -44,29 +44,29 @@
 .hljs-type,
 .hljs-built_in,
 .hljs-class .hljs-title {
-  color: var(--color-gr-syntax-constant);
+  color: var(--color-syntax-constant);
 }
 
 .hljs-tag,
 .hljs-name {
-  color: var(--color-gr-syntax-tag);
+  color: var(--color-syntax-tag);
 }
 
 .hljs-attribute {
-  color: var(--color-gr-syntax-attr);
+  color: var(--color-syntax-attr);
 }
 
 .hljs-meta,
 .hljs-meta .hljs-keyword {
-  color: var(--color-gr-syntax-meta);
+  color: var(--color-syntax-meta);
 }
 
 .hljs-deletion {
-  color: var(--color-gr-syntax-deleted);
+  color: var(--color-syntax-deleted);
 }
 
 .hljs-addition {
-  color: var(--color-gr-syntax-inserted);
+  color: var(--color-syntax-inserted);
 }
 
 .hljs-emphasis {

--- a/apps/extension/src/content/overlay/styles/_markdown.scss
+++ b/apps/extension/src/content/overlay/styles/_markdown.scss
@@ -24,21 +24,21 @@
     margin-bottom: 0.6em;
     font-weight: 600;
     line-height: 1.3;
-    color: var(--color-gr-text);
+    color: var(--color-foreground);
   }
 
   h1 {
     font-size: 1.75em;
     letter-spacing: -0.02em;
     padding-bottom: 0.3em;
-    border-bottom: 1px solid var(--color-gr-border);
+    border-bottom: 1px solid var(--color-border);
   }
 
   h2 {
     font-size: 1.4em;
     letter-spacing: -0.015em;
     padding-bottom: 0.3em;
-    border-bottom: 1px solid var(--color-gr-border);
+    border-bottom: 1px solid var(--color-border);
   }
 
   h3 {
@@ -55,7 +55,7 @@
 
   h6 {
     font-size: 0.875em;
-    color: var(--color-gr-muted);
+    color: var(--color-muted);
   }
 
   p,
@@ -76,7 +76,7 @@
   }
 
   a {
-    color: var(--color-gr-accent);
+    color: var(--color-primary);
     text-decoration: none;
 
     &:hover {
@@ -93,7 +93,7 @@
   strong,
   b {
     font-weight: 600;
-    color: var(--color-gr-text);
+    color: var(--color-foreground);
   }
 
   em,
@@ -103,12 +103,12 @@
 
   del {
     text-decoration: line-through;
-    color: var(--color-gr-muted);
+    color: var(--color-muted);
   }
 
   mark {
-    background: color-mix(in srgb, var(--color-gr-accent) 22%, transparent);
-    color: var(--color-gr-text);
+    background: color-mix(in srgb, var(--color-primary) 22%, transparent);
+    color: var(--color-foreground);
     border-radius: 2px;
     padding: 0.05em 0.2em;
   }
@@ -151,7 +151,7 @@
     height: 0.2em;
     padding: 0;
     margin: 1.5em 0;
-    background: var(--color-gr-border);
+    background: var(--color-border);
     border: 0;
     border-radius: 1px;
   }
@@ -217,14 +217,14 @@
   .task-list-item-checkbox {
     margin: 0 0.4em 0.2em -1.4em;
     vertical-align: middle;
-    accent-color: var(--color-gr-accent);
+    accent-color: var(--color-primary);
   }
 
   blockquote {
     margin: 0 0 1em;
     padding: 0 1em;
-    color: var(--color-gr-muted);
-    border-left: 0.25em solid var(--color-gr-border);
+    color: var(--color-muted);
+    border-left: 0.25em solid var(--color-border);
 
     > :first-child {
       margin-top: 0;
@@ -248,7 +248,7 @@
     padding: 0.2em 0.4em;
     margin: 0;
     white-space: break-spaces;
-    background: color-mix(in srgb, var(--color-gr-text) 10%, transparent);
+    background: color-mix(in srgb, var(--color-foreground) 10%, transparent);
     border-radius: 6px;
   }
 
@@ -267,9 +267,9 @@
     overflow-x: auto;
     font-size: 0.875em;
     line-height: 1.5;
-    color: var(--color-gr-text);
-    background: var(--color-gr-canvas);
-    border: 1px solid var(--color-gr-border-muted);
+    color: var(--color-foreground);
+    background: var(--color-surface-raised);
+    border: 1px solid var(--color-border-strong);
     border-radius: 8px;
     word-wrap: normal;
   }
@@ -309,13 +309,13 @@
       Consolas,
       monospace;
     line-height: 1.1;
-    color: var(--color-gr-text);
+    color: var(--color-foreground);
     vertical-align: middle;
-    background: var(--color-gr-subtle);
-    border: 1px solid var(--color-gr-border);
-    border-bottom-color: var(--color-gr-border);
+    background: var(--color-surface-muted);
+    border: 1px solid var(--color-border);
+    border-bottom-color: var(--color-border);
     border-radius: 6px;
-    box-shadow: inset 0 -1px 0 var(--color-gr-border);
+    box-shadow: inset 0 -1px 0 var(--color-border);
   }
 
   table {
@@ -334,15 +334,15 @@
     th,
     td {
       padding: 7px 13px;
-      border: 1px solid var(--color-gr-border);
+      border: 1px solid var(--color-border);
     }
 
     tr {
-      background: var(--color-gr-bg);
-      border-top: 1px solid var(--color-gr-border);
+      background: var(--color-surface);
+      border-top: 1px solid var(--color-border);
 
       &:nth-child(2n) {
-        background: var(--color-gr-subtle);
+        background: var(--color-surface-muted);
       }
     }
 
@@ -382,9 +382,9 @@
     padding: 0.6em 1em;
     margin-bottom: 1em;
     color: inherit;
-    border-left: 0.25em solid var(--color-gr-border);
+    border-left: 0.25em solid var(--color-border);
     border-radius: 0 6px 6px 0;
-    background: var(--color-gr-subtle);
+    background: var(--color-surface-muted);
 
     > :first-child {
       margin-top: 0;
@@ -413,10 +413,10 @@
   }
 
   .markdown-alert-tip {
-    border-left-color: var(--color-gr-add-text);
+    border-left-color: var(--color-diff-add);
 
     .markdown-alert-title {
-      color: var(--color-gr-add-text);
+      color: var(--color-diff-add);
     }
   }
 
@@ -437,40 +437,40 @@
   }
 
   .markdown-alert-caution {
-    border-left-color: var(--color-gr-danger);
+    border-left-color: var(--color-danger);
 
     .markdown-alert-title {
-      color: var(--color-gr-danger);
+      color: var(--color-danger);
     }
   }
 
   /* GitHub prettylights (scraped fenced-code spans) */
   .pl-c {
-    color: var(--color-gr-syntax-comment);
+    color: var(--color-syntax-comment);
     font-style: italic;
   }
 
   .pl-c1,
   .pl-s .pl-v {
-    color: var(--color-gr-syntax-constant);
+    color: var(--color-syntax-constant);
   }
 
   .pl-e,
   .pl-en {
-    color: var(--color-gr-syntax-entity);
+    color: var(--color-syntax-entity);
   }
 
   .pl-smi,
   .pl-s .pl-s1 {
-    color: var(--color-gr-text);
+    color: var(--color-foreground);
   }
 
   .pl-ent {
-    color: var(--color-gr-syntax-tag);
+    color: var(--color-syntax-tag);
   }
 
   .pl-k {
-    color: var(--color-gr-syntax-keyword);
+    color: var(--color-syntax-keyword);
   }
 
   .pl-s,
@@ -480,31 +480,31 @@
   .pl-sr .pl-cce,
   .pl-sr .pl-sre,
   .pl-sr .pl-sra {
-    color: var(--color-gr-syntax-string);
+    color: var(--color-syntax-string);
   }
 
   .pl-v,
   .pl-smw {
-    color: var(--color-gr-syntax-variable);
+    color: var(--color-syntax-variable);
   }
 
   .pl-bu {
-    color: var(--color-gr-danger);
+    color: var(--color-danger);
   }
 
   .pl-ii {
-    color: var(--color-gr-text);
-    background-color: var(--color-gr-danger-subtle);
+    color: var(--color-foreground);
+    background-color: var(--color-danger-muted);
   }
 
   .pl-c2 {
-    color: var(--color-gr-text);
+    color: var(--color-foreground);
     background-color: #b62324;
   }
 
   .pl-sr .pl-cce {
     font-weight: 600;
-    color: var(--color-gr-syntax-tag);
+    color: var(--color-syntax-tag);
   }
 
   .pl-ml {
@@ -520,22 +520,22 @@
 
   .pl-mi {
     font-style: italic;
-    color: var(--color-gr-text);
+    color: var(--color-foreground);
   }
 
   .pl-mb {
     font-weight: 600;
-    color: var(--color-gr-text);
+    color: var(--color-foreground);
   }
 
   .pl-md {
-    color: var(--color-gr-syntax-deleted);
-    background-color: var(--color-gr-del-bg);
+    color: var(--color-syntax-deleted);
+    background-color: var(--color-diff-del-bg);
   }
 
   .pl-mi1 {
-    color: var(--color-gr-syntax-inserted);
-    background-color: var(--color-gr-add-bg);
+    color: var(--color-syntax-inserted);
+    background-color: var(--color-diff-add-bg);
   }
 
   .pl-mc {
@@ -544,26 +544,26 @@
   }
 
   .pl-mi2 {
-    color: var(--color-gr-text);
+    color: var(--color-foreground);
     background-color: #1158c7;
   }
 
   .pl-mdr {
     font-weight: 600;
-    color: var(--color-gr-syntax-entity);
+    color: var(--color-syntax-entity);
   }
 
   .pl-ba {
-    color: var(--color-gr-muted);
+    color: var(--color-muted);
   }
 
   .pl-sg {
-    color: var(--color-gr-border);
+    color: var(--color-border);
   }
 
   .pl-corl {
     text-decoration: underline;
-    color: var(--color-gr-syntax-string);
+    color: var(--color-syntax-string);
   }
 
   /* Hide GitHub clipboard / anchor chrome that doesn't belong in the overlay */

--- a/apps/extension/src/content/overlay/styles/overlay.css
+++ b/apps/extension/src/content/overlay/styles/overlay.css
@@ -87,7 +87,7 @@
     [contenteditable="true"],
     [tabindex]:not([tabindex="-1"])
   ):focus-visible {
-    outline: 2px solid var(--color-gr-accent, #caff57);
+    outline: 2px solid var(--color-primary, #caff57);
     outline-offset: 2px;
   }
 }

--- a/apps/extension/src/options/About.tsx
+++ b/apps/extension/src/options/About.tsx
@@ -5,7 +5,7 @@ const TERMS_URL = `${SITE_URL}/terms`;
 const GITHUB_REPO_URL = "https://github.com/nshntarora/guidedreview";
 
 const textLink =
-  "font-medium focus-visible:rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-opt-accent";
+  "font-medium focus-visible:rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary";
 
 const LINKS = [
   { href: SITE_URL, label: "Website" },
@@ -34,17 +34,17 @@ export function About() {
           className="mx-auto block h-12 w-auto sm:h-14"
           aria-hidden="true"
         />
-        <h1 className="mt-5 m-0 font-brand text-2xl font-bold tracking-tight text-opt-text sm:text-3xl">
+        <h1 className="mt-5 m-0 font-brand text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
           Guided Review
         </h1>
         {version ? (
-          <p className="mt-2 m-0 font-mono text-xs text-opt-muted tabular-nums">v{version}</p>
+          <p className="mt-2 m-0 font-mono text-xs text-muted tabular-nums">v{version}</p>
         ) : null}
-        <p className="mt-5 m-0 text-base leading-relaxed text-opt-muted text-balance sm:text-lg">
+        <p className="mt-5 m-0 text-base leading-relaxed text-muted text-balance sm:text-lg">
           A Chrome extension that makes reading code better — clustered changes, short summaries,
           and a keyboard-first review overlay for GitHub pull requests.
         </p>
-        <p className="mt-3 m-0 font-mono text-xs text-opt-muted">
+        <p className="mt-3 m-0 font-mono text-xs text-muted">
           Free · Open source · Bring your own LLM key
         </p>
       </header>
@@ -52,14 +52,14 @@ export function About() {
       <section className="mt-12 text-left" aria-labelledby="about-how">
         <h2
           id="about-how"
-          className="m-0 font-brand text-lg font-bold tracking-tight text-opt-text"
+          className="m-0 font-brand text-lg font-bold tracking-tight text-foreground"
         >
           How it works
         </h2>
-        <ol className="mt-4 m-0 list-decimal space-y-3 pl-5 text-base leading-relaxed text-opt-muted">
+        <ol className="mt-4 m-0 list-decimal space-y-3 pl-5 text-base leading-relaxed text-muted">
           <li>Open a pull request on GitHub.</li>
           <li>
-            Click <strong className="font-semibold text-opt-text">Start Guided Review</strong> on
+            Click <strong className="font-semibold text-foreground">Start Guided Review</strong> on
             the PR page.
           </li>
           <li>
@@ -76,14 +76,14 @@ export function About() {
       <section className="mt-12 text-left" aria-labelledby="about-privacy">
         <h2
           id="about-privacy"
-          className="m-0 font-brand text-lg font-bold tracking-tight text-opt-text"
+          className="m-0 font-brand text-lg font-bold tracking-tight text-foreground"
         >
           Privacy
         </h2>
-        <p className="mt-4 m-0 text-base leading-relaxed text-opt-muted">
+        <p className="mt-4 m-0 text-base leading-relaxed text-muted">
           Your code never touches our infrastructure — we don&apos;t have any. Diffs and prompts go
           only to the provider you choose. Your API key stays in this browser via{" "}
-          <code className="rounded bg-opt-subtle px-1 py-0.5 font-mono text-sm text-opt-text">
+          <code className="rounded bg-surface-raised px-1 py-0.5 font-mono text-sm text-foreground">
             chrome.storage.local
           </code>
           .
@@ -97,7 +97,7 @@ export function About() {
         {LINKS.map((link, i) => (
           <span key={link.href} className="inline-flex items-center gap-x-3">
             {i > 0 ? (
-              <span className="text-opt-muted/50" aria-hidden="true">
+              <span className="text-muted/50" aria-hidden="true">
                 ·
               </span>
             ) : null}

--- a/apps/extension/src/options/GitHubAuthSection.tsx
+++ b/apps/extension/src/options/GitHubAuthSection.tsx
@@ -104,7 +104,7 @@ export function GitHubAuthSection() {
       titleId="github-heading"
       icon={
         <span
-          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gr-accent-subtle text-opt-accent"
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary-muted text-primary"
           aria-hidden="true"
         >
           <GitHubLogo size={18} data-testid="github-auth-logo" />
@@ -114,9 +114,9 @@ export function GitHubAuthSection() {
       data-testid="github-auth-section"
     >
       {!configured && (
-        <p className="m-0 text-base text-opt-muted" role="status">
+        <p className="m-0 text-base text-muted" role="status">
           GitHub connection isn’t configured in this build. Set{" "}
-          <code className="rounded bg-opt-bg/80 px-1 py-0.5 font-mono text-sm text-opt-text">
+          <code className="rounded bg-background/80 px-1 py-0.5 font-mono text-sm text-foreground">
             {GITHUB_CLIENT_ID_ENV_VAR}
           </code>{" "}
           and rebuild.
@@ -124,8 +124,8 @@ export function GitHubAuthSection() {
       )}
 
       {configured && session.kind === "loading" && flow.kind === "idle" && !showError && (
-        <p className="m-0 flex items-center gap-2 text-base text-opt-muted" role="status">
-          <Spinner surface="app" size={14} label="Loading GitHub connection" />
+        <p className="m-0 flex items-center gap-2 text-base text-muted" role="status">
+          <Spinner size={14} label="Loading GitHub connection" />
           Loading…
         </p>
       )}
@@ -139,10 +139,10 @@ export function GitHubAuthSection() {
             }}
             disabled={busy}
           >
-            {busy && <Spinner surface="app" size={14} label="Connecting to GitHub" />}
+            {busy && <Spinner size={14} label="Connecting to GitHub" />}
             {busy ? "Connecting…" : "Connect GitHub"}
           </Button>
-          <span className="text-sm text-opt-muted">Requests repo and read:user access.</span>
+          <span className="text-sm text-muted">Requests repo and read:user access.</span>
         </div>
       )}
 
@@ -150,7 +150,7 @@ export function GitHubAuthSection() {
         <div className="space-y-3" data-testid="github-auth-awaiting">
           <div className="flex flex-wrap items-center gap-2">
             <code
-              className="rounded-md border border-opt-border bg-opt-bg/60 px-3 py-2 font-mono text-lg tracking-widest text-opt-text"
+              className="rounded-md border border-border bg-background/60 px-3 py-2 font-mono text-lg tracking-widest text-foreground"
               data-testid="github-user-code"
             >
               {flow.userCode}
@@ -163,12 +163,12 @@ export function GitHubAuthSection() {
               {copied ? "Copied" : "Copy Code"}
             </Button>
           </div>
-          <p className="m-0 text-base text-opt-muted" data-testid="github-copy-hint">
+          <p className="m-0 text-base text-muted" data-testid="github-copy-hint">
             Copy this code, then paste it on the GitHub tab.
           </p>
           <div className="flex flex-wrap items-center gap-2.5">
-            <span className="flex items-center gap-2 text-base text-opt-muted" role="status">
-              <Spinner surface="app" size={14} label="Waiting for GitHub authorization" />
+            <span className="flex items-center gap-2 text-base text-muted" role="status">
+              <Spinner size={14} label="Waiting for GitHub authorization" />
               Waiting for authorization…
             </span>
             <Button variant="secondary" onClick={onCancel}>
@@ -186,7 +186,7 @@ export function GitHubAuthSection() {
 
       {configured && session.kind === "connected" && flow.kind === "idle" && !showError && (
         <div
-          className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-opt-border bg-opt-bg/60 p-3"
+          className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-border bg-background/60 p-3"
           data-testid="github-auth-connected"
         >
           <div className="flex min-w-0 items-center gap-3">
@@ -196,29 +196,29 @@ export function GitHubAuthSection() {
                 alt=""
                 width={36}
                 height={36}
-                className="h-9 w-9 rounded-full border border-opt-border"
+                className="h-9 w-9 rounded-full border border-border"
               />
             ) : (
               <div
-                className="flex h-9 w-9 items-center justify-center rounded-full border border-opt-border bg-opt-subtle text-xs font-semibold text-opt-muted"
+                className="flex h-9 w-9 items-center justify-center rounded-full border border-border bg-surface-raised text-xs font-semibold text-muted"
                 aria-hidden
               >
                 {session.auth.login.slice(0, 1).toUpperCase()}
               </div>
             )}
             <div className="min-w-0">
-              <p className="m-0 truncate text-base font-semibold text-opt-text">
+              <p className="m-0 truncate text-base font-semibold text-foreground">
                 @{session.auth.login}
               </p>
               {session.auth.name ? (
-                <p className="m-0 truncate text-sm text-opt-muted">{session.auth.name}</p>
+                <p className="m-0 truncate text-sm text-muted">{session.auth.name}</p>
               ) : (
-                <p className="m-0 text-sm text-opt-ok">Connected</p>
+                <p className="m-0 text-sm text-success">Connected</p>
               )}
             </div>
           </div>
           <Button variant="secondary" onClick={requestDisconnect} disabled={busy}>
-            {disconnectBusy && <Spinner surface="app" size={14} label="Disconnecting" />}
+            {disconnectBusy && <Spinner size={14} label="Disconnecting" />}
             Disconnect
           </Button>
         </div>
@@ -226,7 +226,7 @@ export function GitHubAuthSection() {
 
       {configured && showError && (
         <div className="space-y-3" role="alert">
-          <p className={cn("m-0 text-base text-opt-error")}>{showError}</p>
+          <p className={cn("m-0 text-base text-danger")}>{showError}</p>
           <Button
             onClick={() => {
               setDisconnectError(null);

--- a/apps/extension/src/options/Options.tsx
+++ b/apps/extension/src/options/Options.tsx
@@ -134,8 +134,10 @@ export function Options() {
   return (
     <main id="main-content">
       <header className="mb-8">
-        <h1 className="m-0 font-brand text-2xl font-bold tracking-tight text-opt-text">Settings</h1>
-        <p className="mt-2 m-0 text-base leading-relaxed text-opt-muted text-balance">
+        <h1 className="m-0 font-brand text-2xl font-bold tracking-tight text-foreground">
+          Settings
+        </h1>
+        <p className="mt-2 m-0 text-base leading-relaxed text-muted text-balance">
           Connect GitHub and choose an AI provider. Keys and tokens stay in this browser only.
         </p>
       </header>
@@ -153,7 +155,7 @@ export function Options() {
                 href={CONFIGURE_PROVIDER_DOCS_URL}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="font-medium focus-visible:rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-opt-accent"
+                className="font-medium focus-visible:rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
               >
                 Setup docs
               </a>
@@ -201,9 +203,9 @@ export function Options() {
                 disabled={busy}
                 aria-describedby="apiKey-hint"
               />
-              <p id="apiKey-hint" className="mt-1.5 m-0 text-sm text-opt-muted">
+              <p id="apiKey-hint" className="mt-1.5 m-0 text-sm text-muted">
                 Stored locally on this device via{" "}
-                <code className="rounded bg-opt-bg/80 px-1 py-0.5 font-mono text-sm text-opt-text">
+                <code className="rounded bg-background/80 px-1 py-0.5 font-mono text-sm text-foreground">
                   chrome.storage.local
                 </code>{" "}
                 — never synced.
@@ -212,9 +214,7 @@ export function Options() {
 
             <div className="flex flex-wrap items-center gap-2.5 pt-1">
               <Button onClick={onSave} disabled={busy}>
-                {saveStatus.kind === "working" && (
-                  <Spinner surface="app" size={14} label="Saving" />
-                )}
+                {saveStatus.kind === "working" && <Spinner size={14} label="Saving" />}
                 {saveStatus.kind === "working" ? "Saving…" : "Save"}
               </Button>
               <Button
@@ -222,9 +222,7 @@ export function Options() {
                 onClick={onTestConnection}
                 disabled={!settings.apiKey || busy}
               >
-                {connection.kind === "working" && (
-                  <Spinner surface="app" size={14} label="Testing connection" />
-                )}
+                {connection.kind === "working" && <Spinner size={14} label="Testing connection" />}
                 {connection.kind === "working" ? "Testing…" : "Test Connection"}
               </Button>
             </div>
@@ -244,11 +242,11 @@ export function Options() {
             <div className="min-w-0 flex-1">
               <p
                 id="autoOpenOnFilesTab-label"
-                className="m-0 font-brand text-base font-bold tracking-tight text-opt-text"
+                className="m-0 font-brand text-base font-bold tracking-tight text-foreground"
               >
                 Automatically open on Files changed
               </p>
-              <p id="autoOpenOnFilesTab-hint" className="mt-1 m-0 text-sm text-opt-muted">
+              <p id="autoOpenOnFilesTab-hint" className="mt-1 m-0 text-sm text-muted">
                 When enabled, Guided Review opens (or resumes) automatically on a PR’s Files changed
                 / Changes tab. You can still start it from the button anytime.
               </p>
@@ -264,7 +262,7 @@ export function Options() {
         </SettingsCard>
       </div>
 
-      <p className="mt-6 m-0 text-sm leading-relaxed text-opt-muted">
+      <p className="mt-6 m-0 text-sm leading-relaxed text-muted">
         Keys and tokens stay in this browser. Diffs go only to GitHub and the provider you choose.
       </p>
     </main>

--- a/apps/extension/src/options/OptionsShell.tsx
+++ b/apps/extension/src/options/OptionsShell.tsx
@@ -5,7 +5,7 @@ import type { OptionsRoute } from "./routes";
 const DOCS_URL = "https://guidedreview.dev/docs";
 
 const NAV_ITEM_CLASS =
-  "rounded-md border-b-0 px-3 py-1.5 text-base font-medium no-underline transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-opt-accent";
+  "rounded-md border-b-0 px-3 py-1.5 text-base font-medium no-underline transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary";
 
 const NAV: { route: OptionsRoute; href: string; label: string }[] = [
   { route: "settings", href: "#settings", label: "Settings" },
@@ -28,12 +28,12 @@ export function OptionsShell({ route, children }: OptionsShellProps) {
     <div className="relative min-h-screen">
       <a
         href="#main-content"
-        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-opt-accent focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-opt-accent-on"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-primary-foreground"
       >
         Skip to content
       </a>
 
-      <header className="sticky top-0 z-40 border-b border-gr-border bg-gr-chrome/95 backdrop-blur-sm">
+      <header className="sticky top-0 z-40 border-b border-border bg-background/95 backdrop-blur-sm">
         <div className="mx-auto flex max-w-3xl items-center justify-between gap-3 px-5 py-3.5 sm:px-6">
           <img
             src={logoUrl}
@@ -54,8 +54,8 @@ export function OptionsShell({ route, children }: OptionsShellProps) {
                   className={cn(
                     NAV_ITEM_CLASS,
                     active
-                      ? "bg-opt-subtle text-opt-text"
-                      : "text-opt-muted hover:bg-opt-subtle/60 hover:text-opt-text",
+                      ? "bg-surface-raised text-foreground"
+                      : "text-muted hover:bg-surface-raised/60 hover:text-foreground",
                   )}
                 >
                   {item.label}
@@ -68,7 +68,7 @@ export function OptionsShell({ route, children }: OptionsShellProps) {
               rel="noopener noreferrer"
               className={cn(
                 NAV_ITEM_CLASS,
-                "text-opt-muted hover:bg-opt-subtle/60 hover:text-opt-text",
+                "text-muted hover:bg-surface-raised/60 hover:text-foreground",
               )}
             >
               Docs

--- a/apps/extension/src/options/SettingsCard.tsx
+++ b/apps/extension/src/options/SettingsCard.tsx
@@ -29,7 +29,7 @@ export function SettingsCard({
   return (
     <section
       className={cn(
-        "rounded-lg border border-opt-border bg-opt-subtle/50 px-4 py-4 sm:px-5 sm:py-5",
+        "rounded-lg border border-border bg-surface-raised/50 px-4 py-4 sm:px-5 sm:py-5",
         className,
       )}
       aria-labelledby={titleId}
@@ -40,13 +40,13 @@ export function SettingsCard({
           {icon}
           <h2
             id={titleId}
-            className="m-0 font-brand text-lg font-bold tracking-tight text-opt-text"
+            className="m-0 font-brand text-lg font-bold tracking-tight text-foreground"
           >
             {title}
           </h2>
         </div>
         {description ? (
-          <div className="mt-1.5 text-sm leading-relaxed text-opt-muted">{description}</div>
+          <div className="mt-1.5 text-sm leading-relaxed text-muted">{description}</div>
         ) : null}
       </header>
       {children}

--- a/apps/extension/src/options/StatusCallout.tsx
+++ b/apps/extension/src/options/StatusCallout.tsx
@@ -16,9 +16,9 @@ export function StatusCallout({ kind, message, className }: StatusCalloutProps) 
       aria-live="polite"
       className={cn(
         "m-0 rounded-md border px-3 py-2 text-base",
-        kind === "ok" && "border-opt-border bg-opt-bg/60 text-opt-ok",
+        kind === "ok" && "border-border bg-background/60 text-success",
         kind === "error" &&
-          "border-[color-mix(in_srgb,var(--opt-error)_35%,var(--opt-border))] bg-[color-mix(in_srgb,var(--opt-error)_10%,var(--opt-subtle))] text-opt-error",
+          "border-[color-mix(in_srgb,var(--color-danger)_35%,var(--color-border))] bg-[color-mix(in_srgb,var(--color-danger)_10%,var(--color-surface-raised))] text-danger",
         className,
       )}
     >

--- a/apps/extension/src/options/Toggle.tsx
+++ b/apps/extension/src/options/Toggle.tsx
@@ -35,9 +35,9 @@ export function Toggle({
       onClick={() => onChange(!checked)}
       className={cn(
         "relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border transition-colors",
-        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-opt-accent",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
         "disabled:cursor-not-allowed disabled:opacity-60",
-        checked ? "border-opt-accent bg-opt-accent" : "border-opt-border bg-opt-subtle",
+        checked ? "border-primary bg-primary" : "border-border bg-surface-raised",
         className,
       )}
     >
@@ -45,7 +45,7 @@ export function Toggle({
         aria-hidden="true"
         className={cn(
           "pointer-events-none absolute top-0.5 left-0.5 size-4 rounded-full shadow-sm transition-transform",
-          checked ? "translate-x-5 bg-opt-accent-on" : "translate-x-0 bg-opt-muted",
+          checked ? "translate-x-5 bg-primary-foreground" : "translate-x-0 bg-muted",
         )}
       />
     </button>

--- a/apps/extension/src/options/options.scss
+++ b/apps/extension/src/options/options.scss
@@ -16,8 +16,8 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
-  background: var(--color-opt-bg);
-  color: var(--color-opt-text);
+  background: var(--color-background);
+  color: var(--color-foreground);
 }
 
 /* Faint grain for texture — same technique as the marketing site. */
@@ -38,20 +38,20 @@ body::before {
 }
 
 :focus-visible {
-  outline: 2px solid var(--color-opt-accent, #caff57);
+  outline: 2px solid var(--color-primary, #caff57);
   outline-offset: 2px;
 }
 
 ::selection {
-  background: var(--opt-accent);
-  color: var(--opt-accent-on);
+  background: var(--color-primary);
+  color: var(--color-primary-foreground);
 }
 
 /* Text links: accent + bottom border on hover (matches marketing globals).
    Button-styled anchors use `inline-flex` and keep their own chrome. */
 @layer base {
   a:not(.inline-flex) {
-    color: var(--opt-accent, #caff57);
+    color: var(--color-primary, #caff57);
     text-decoration: none;
     border-bottom: 1px solid transparent;
     transition: border-color 0.15s ease;

--- a/apps/extension/src/welcome/Welcome.tsx
+++ b/apps/extension/src/welcome/Welcome.tsx
@@ -9,7 +9,7 @@ const GITHUB_REPO_URL = "https://github.com/nshntarora/guidedreview";
 const GITHUB_PULLS_URL = "https://github.com/pulls";
 
 const textLink =
-  "font-medium focus-visible:rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-opt-accent";
+  "font-medium focus-visible:rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary";
 
 const LINKS = [
   { href: SITE_URL, label: "Website" },
@@ -56,22 +56,22 @@ export function Welcome() {
           className="mx-auto block h-11 w-auto sm:h-12"
           aria-hidden="true"
         />
-        <h1 className="mt-8 m-0 font-brand text-3xl font-bold tracking-tight text-opt-text sm:text-4xl">
+        <h1 className="mt-8 m-0 font-brand text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
           Welcome
         </h1>
-        <p className="mt-3 m-0 text-base leading-relaxed text-opt-muted sm:text-lg">
+        <p className="mt-3 m-0 text-base leading-relaxed text-muted sm:text-lg">
           Here&apos;s how to get started.
         </p>
       </header>
 
-      <ol className="mt-10 m-0 list-none space-y-0 divide-y divide-opt-border rounded-lg border border-opt-border bg-opt-subtle/50 p-0">
+      <ol className="mt-10 m-0 list-none space-y-0 divide-y divide-border rounded-lg border border-border bg-surface-raised/50 p-0">
         <Step n={1} title="Pin the extension" done={pinState === "pinned"}>
           {pinState === "pinned" ? (
-            <p className="m-0 text-base leading-relaxed text-opt-muted">
+            <p className="m-0 text-base leading-relaxed text-muted">
               Pinned to the toolbar — you&apos;re set.
             </p>
           ) : (
-            <p className="m-0 text-base leading-relaxed text-opt-muted">
+            <p className="m-0 text-base leading-relaxed text-muted">
               Open the puzzle-piece menu and pin Guided Review so it stays visible. Unpinned
               extensions are easy to forget.
             </p>
@@ -79,16 +79,16 @@ export function Welcome() {
         </Step>
 
         <Step n={2} title="Connect an AI provider">
-          <p className="m-0 text-base leading-relaxed text-opt-muted">
+          <p className="m-0 text-base leading-relaxed text-muted">
             Paste a key for Claude, OpenAI, or Grok. Keys stay in this browser — we don&apos;t have
             servers in the middle.
           </p>
         </Step>
 
         <Step n={3} title="Start a review on a PR">
-          <p className="m-0 text-base leading-relaxed text-opt-muted">
+          <p className="m-0 text-base leading-relaxed text-muted">
             Open any GitHub pull request and click{" "}
-            <strong className="font-semibold text-opt-text">Start Guided Review</strong>. The
+            <strong className="font-semibold text-foreground">Start Guided Review</strong>. The
             extension clusters related changes so you walk the PR in a sensible order.
           </p>
         </Step>
@@ -109,7 +109,7 @@ export function Welcome() {
         </a>
       </div>
 
-      <p className="mt-10 m-0 text-center text-sm leading-relaxed text-opt-muted text-balance">
+      <p className="mt-10 m-0 text-center text-sm leading-relaxed text-muted text-balance">
         Your code never touches our infrastructure. Diffs go only to the provider you choose.
       </p>
 
@@ -120,7 +120,7 @@ export function Welcome() {
         {LINKS.map((link, i) => (
           <span key={link.href} className="inline-flex items-center gap-x-3">
             {i > 0 ? (
-              <span className="text-opt-muted/50" aria-hidden="true">
+              <span className="text-muted/50" aria-hidden="true">
                 ·
               </span>
             ) : null}
@@ -150,15 +150,17 @@ function Step({
       <span
         className={
           done
-            ? "flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-opt-ok/40 bg-opt-ok/15 font-mono text-sm font-semibold tabular-nums text-opt-ok"
-            : "flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-opt-border bg-opt-bg font-mono text-sm font-semibold tabular-nums text-opt-text"
+            ? "flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-success/40 bg-success/15 font-mono text-sm font-semibold tabular-nums text-success"
+            : "flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-border bg-background font-mono text-sm font-semibold tabular-nums text-foreground"
         }
         aria-hidden="true"
       >
         {done ? "✓" : n}
       </span>
       <div className="min-w-0 pt-0.5">
-        <h2 className="m-0 font-brand text-base font-bold tracking-tight text-opt-text">{title}</h2>
+        <h2 className="m-0 font-brand text-base font-bold tracking-tight text-foreground">
+          {title}
+        </h2>
         <div className="mt-1.5">{children}</div>
       </div>
     </li>

--- a/apps/extension/src/welcome/welcome.scss
+++ b/apps/extension/src/welcome/welcome.scss
@@ -15,8 +15,8 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
-  background: var(--color-opt-bg);
-  color: var(--color-opt-text);
+  background: var(--color-background);
+  color: var(--color-foreground);
 }
 
 body::before {
@@ -36,18 +36,18 @@ body::before {
 }
 
 :focus-visible {
-  outline: 2px solid var(--color-opt-accent, #caff57);
+  outline: 2px solid var(--color-primary, #caff57);
   outline-offset: 2px;
 }
 
 ::selection {
-  background: var(--opt-accent);
-  color: var(--opt-accent-on);
+  background: var(--color-primary);
+  color: var(--color-primary-foreground);
 }
 
 @layer base {
   a:not(.inline-flex) {
-    color: var(--opt-accent, #caff57);
+    color: var(--color-primary, #caff57);
     text-decoration: none;
     border-bottom: 1px solid transparent;
     transition: border-color 0.15s ease;

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -11,13 +11,6 @@
   --font-serif: var(--font-newsreader), "Iowan Old Style", "Palatino Linotype", Georgia, serif;
 }
 
-/* Accent as *ink* on dark surfaces (illustrations, labels, hairline strokes).
-   Same lime as --opt-accent; kept as a named token so SVG stroke/fill can
-   reference it without fighting fill-only accent usage. */
-:root {
-  --gr-accent-ink: var(--opt-accent);
-}
-
 html,
 body {
   margin: 0;
@@ -32,8 +25,8 @@ html {
 body {
   position: relative;
   font-family: var(--font-sans, system-ui, sans-serif);
-  background: var(--opt-bg, #0d0806);
-  color: var(--opt-text, #fefefe);
+  background: var(--color-background, #0d0806);
+  color: var(--color-foreground, #fefefe);
 }
 
 /* Faint grain for texture — replaces the flat/grid look used elsewhere. */
@@ -50,7 +43,7 @@ body::before {
 
 @layer base {
   a {
-    color: var(--opt-accent, #caff57);
+    color: var(--color-primary, #caff57);
     text-decoration: none;
   }
 
@@ -67,8 +60,8 @@ body::before {
 }
 
 ::selection {
-  background: var(--opt-accent);
-  color: var(--opt-accent-on);
+  background: var(--color-primary);
+  color: var(--color-primary-foreground);
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -126,7 +119,7 @@ body::before {
 
 .docs-content :is(h1, h2, h3, h4, h5, h6) {
   scroll-margin-top: 5rem;
-  color: var(--opt-text);
+  color: var(--color-foreground);
 }
 
 .docs-content h1 {
@@ -166,7 +159,7 @@ body::before {
   line-height: 1.65;
   margin-top: 0.75rem;
   margin-bottom: 0.75rem;
-  color: var(--opt-muted);
+  color: var(--color-muted);
   overflow-wrap: anywhere;
 }
 
@@ -175,7 +168,7 @@ body::before {
   padding-left: 1.5rem;
   margin-top: 0.75rem;
   margin-bottom: 0.75rem;
-  color: var(--opt-muted);
+  color: var(--color-muted);
 }
 
 .docs-content ul {
@@ -183,7 +176,7 @@ body::before {
   padding-left: 1.5rem;
   margin-top: 0.75rem;
   margin-bottom: 0.75rem;
-  color: var(--opt-muted);
+  color: var(--color-muted);
 }
 
 .docs-content li {
@@ -201,14 +194,14 @@ body::before {
   font-family: var(--font-mono, ui-monospace, monospace);
   font-size: 0.875em;
   border-radius: 0.25rem;
-  background: var(--opt-subtle);
-  color: var(--opt-text);
+  background: var(--color-surface-raised);
+  color: var(--color-foreground);
   padding: 0.1em 0.35em;
 }
 
 .docs-content pre {
-  background: var(--opt-subtle);
-  border: 1px solid var(--opt-border);
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border);
   border-radius: 0.5rem;
   overflow-x: auto;
   margin: 1rem 0;
@@ -234,34 +227,34 @@ body::before {
 }
 
 .docs-content thead th {
-  background: var(--opt-subtle);
-  color: var(--opt-text);
+  background: var(--color-surface-raised);
+  color: var(--color-foreground);
   font-weight: 600;
   text-align: left;
   padding: 0.5rem 0.75rem;
-  border: 1px solid var(--opt-border);
+  border: 1px solid var(--color-border);
 }
 
 .docs-content tbody tr:nth-child(even) {
-  background: color-mix(in srgb, var(--opt-subtle) 55%, transparent);
+  background: color-mix(in srgb, var(--color-surface-raised) 55%, transparent);
 }
 
 .docs-content tbody td {
   padding: 0.5rem 0.75rem;
-  border: 1px solid var(--opt-border);
-  color: var(--opt-muted);
+  border: 1px solid var(--color-border);
+  color: var(--color-muted);
   vertical-align: top;
 }
 
 .docs-content hr {
   border: 0;
-  border-top: 1px solid var(--opt-border);
+  border-top: 1px solid var(--color-border);
   margin: 2rem 0;
 }
 
 .docs-content strong {
   font-weight: 600;
-  color: var(--opt-text);
+  color: var(--color-foreground);
 }
 
 /* Links inherit the site-wide text-link treatment from @layer base

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -68,15 +68,15 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <LineGutter />
         <a
           href="#main"
-          className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-gr-accent focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-gr-accent-on"
+          className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-primary-foreground"
         >
           Skip to content
         </a>
-        <header className="sticky top-0 z-40 border-b border-gr-border bg-gr-chrome/95 backdrop-blur-sm">
+        <header className="sticky top-0 z-40 border-b border-border bg-background/95 backdrop-blur-sm">
           <div className="mx-auto flex max-w-5xl items-center justify-between gap-3 px-4 py-3.5 sm:gap-4 sm:px-6">
             <Link
               href="/"
-              className="shrink-0 rounded-sm border-b-0 no-underline hover:border-b-transparent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gr-accent"
+              className="shrink-0 rounded-sm border-b-0 no-underline hover:border-b-transparent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
               aria-label="Guided Review home"
             >
               <img
@@ -93,18 +93,18 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             >
               <Link
                 href="/#features"
-                className="hidden text-gr-text hover:text-gr-accent md:inline"
+                className="hidden text-foreground hover:text-primary md:inline"
               >
                 Features
               </Link>
-              <Link href="/docs" className="hidden text-gr-text hover:text-gr-accent md:inline">
+              <Link href="/docs" className="hidden text-foreground hover:text-primary md:inline">
                 Docs
               </Link>
-              <Link href="/#faqs" className="hidden text-gr-text hover:text-gr-accent md:inline">
+              <Link href="/#faqs" className="hidden text-foreground hover:text-primary md:inline">
                 FAQ
               </Link>
-              <StarOnGitHubButton size="sm" surface="overlay" compact />
-              <InstallButton size="sm" surface="overlay" compact />
+              <StarOnGitHubButton size="sm" compact />
+              <InstallButton size="sm" compact />
             </nav>
           </div>
         </header>

--- a/apps/web/components/CtaButtons.tsx
+++ b/apps/web/components/CtaButtons.tsx
@@ -1,22 +1,21 @@
-import { buttonClassName, type ButtonSize, type Surface } from "@guided-review/ui";
+import { buttonClassName, type ButtonSize } from "@guided-review/ui";
 import { ariaKeyShortcuts, SITE_SHORTCUTS } from "../lib/shortcuts";
 import { GitHubIcon } from "./icons";
 import { ShortcutChord } from "./ShortcutChord";
 
 type CtaButtonProps = {
   size?: ButtonSize;
-  surface?: Surface;
   /** Shorter label for tight header nav. */
   compact?: boolean;
 };
 
-export function InstallButton({ size = "lg", surface = "app", compact = false }: CtaButtonProps) {
+export function InstallButton({ size = "lg", compact = false }: CtaButtonProps) {
   const { key, href, label } = SITE_SHORTCUTS.install;
   const displayLabel = compact ? "Install" : label;
   return (
     <a
       href={href}
-      className={buttonClassName({ size, surface })}
+      className={buttonClassName({ size })}
       target="_blank"
       rel="noopener noreferrer"
       aria-keyshortcuts={ariaKeyShortcuts(key)}
@@ -28,16 +27,12 @@ export function InstallButton({ size = "lg", surface = "app", compact = false }:
   );
 }
 
-export function StarOnGitHubButton({
-  size = "lg",
-  surface = "app",
-  compact = false,
-}: CtaButtonProps) {
+export function StarOnGitHubButton({ size = "lg", compact = false }: CtaButtonProps) {
   const { key, href, label } = SITE_SHORTCUTS.star;
   return (
     <a
       href={href}
-      className={buttonClassName({ variant: "secondary", size, surface })}
+      className={buttonClassName({ variant: "secondary", size })}
       target="_blank"
       rel="noopener noreferrer"
       aria-keyshortcuts={ariaKeyShortcuts(key)}

--- a/apps/web/components/Faqs.tsx
+++ b/apps/web/components/Faqs.tsx
@@ -123,21 +123,21 @@ export function Faqs() {
         <h2 className="m-0 text-center text-3xl font-bold tracking-tight sm:text-4xl font-brand">
           FAQs
         </h2>
-        <p className="mx-auto mt-4 max-w-2xl text-center text-lg text-opt-muted text-balance sm:text-xl">
+        <p className="mx-auto mt-4 max-w-2xl text-center text-lg text-muted text-balance sm:text-xl">
           The questions everyone asks before installing.
         </p>
 
         <WindowFrame label="faq.md" className="mt-14 sm:mt-20" bodyClassName="p-0">
-          <ul className="m-0 list-none divide-y divide-opt-border p-0">
+          <ul className="m-0 list-none divide-y divide-border p-0">
             {faqs.map((faq) => (
               <li key={faq.question}>
                 <details className="group [&_summary::-webkit-details-marker]:hidden">
-                  <summary className="flex cursor-pointer list-none items-center justify-between gap-3 p-4 text-base font-semibold tracking-tight transition-colors hover:text-opt-accent sm:gap-4 sm:p-6 sm:text-lg md:p-8 md:text-xl">
+                  <summary className="flex cursor-pointer list-none items-center justify-between gap-3 p-4 text-base font-semibold tracking-tight transition-colors hover:text-primary sm:gap-4 sm:p-6 sm:text-lg md:p-8 md:text-xl">
                     {faq.question}
                     <svg
                       aria-hidden="true"
                       viewBox="0 0 24 24"
-                      className="h-5 w-5 flex-shrink-0 text-opt-muted transition-transform duration-300 group-open:rotate-180"
+                      className="h-5 w-5 flex-shrink-0 text-muted transition-transform duration-300 group-open:rotate-180"
                       fill="none"
                       stroke="currentColor"
                       strokeWidth="2"
@@ -147,7 +147,7 @@ export function Faqs() {
                       <path d="m6 9 6 6 6-6" />
                     </svg>
                   </summary>
-                  <div className="space-y-3 px-4 pb-4 text-base leading-relaxed text-opt-muted sm:px-6 sm:pb-6 sm:text-lg md:px-8 md:pb-8">
+                  <div className="space-y-3 px-4 pb-4 text-base leading-relaxed text-muted sm:px-6 sm:pb-6 sm:text-lg md:px-8 md:pb-8">
                     {faq.answer.map((paragraph, index) => (
                       <p key={index} className="m-0">
                         {paragraph}

--- a/apps/web/components/FeatureGrid.tsx
+++ b/apps/web/components/FeatureGrid.tsx
@@ -65,7 +65,7 @@ export function FeatureGrid() {
         <h2 className="m-0 text-center text-3xl font-bold tracking-tight sm:text-4xl font-brand">
           Features
         </h2>
-        <p className="mx-auto mt-4 max-w-2xl text-center text-lg text-opt-muted text-balance sm:text-xl">
+        <p className="mx-auto mt-4 max-w-2xl text-center text-lg text-muted text-balance sm:text-xl">
           Built for humans who still have to read the code.
         </p>
 
@@ -94,12 +94,12 @@ function FeatureCard({ feature: f, wide = false }: { feature: Feature; wide?: bo
   return (
     <WindowFrame
       label={f.file}
-      className="group w-full transition-colors duration-300 hover:border-opt-accent/60"
+      className="group w-full transition-colors duration-300 hover:border-primary/60"
       bodyClassName={`flex flex-col gap-6 ${wide ? "md:flex-row md:items-center md:gap-10" : ""}`}
     >
       <div className={`flex flex-col ${wide ? "md:flex-1" : ""}`}>
         <h3 className="m-0 text-xl font-semibold tracking-tight sm:text-2xl">{f.title}</h3>
-        <div className="mt-3 space-y-3 text-base leading-relaxed text-opt-muted sm:text-lg">
+        <div className="mt-3 space-y-3 text-base leading-relaxed text-muted sm:text-lg">
           {f.body.map((paragraph) => (
             <p key={paragraph} className="m-0">
               {paragraph}
@@ -107,12 +107,12 @@ function FeatureCard({ feature: f, wide = false }: { feature: Feature; wide?: bo
           ))}
         </div>
         {f.footnote ? (
-          <p className="mt-4 m-0 text-sm italic leading-relaxed text-opt-muted/80">{f.footnote}</p>
+          <p className="mt-4 m-0 text-sm italic leading-relaxed text-muted/80">{f.footnote}</p>
         ) : null}
       </div>
 
       <div
-        className={`flex items-center justify-center rounded-lg bg-opt-bg/60 p-6 ${
+        className={`flex items-center justify-center rounded-lg bg-background/60 p-6 ${
           wide ? "md:w-[min(46%,26rem)]" : "mt-auto"
         }`}
       >

--- a/apps/web/components/FeatureIllustrations.tsx
+++ b/apps/web/components/FeatureIllustrations.tsx
@@ -31,15 +31,15 @@ function frame(props: IllustProps) {
  * ------------------------------------------------------------------ */
 
 /** Raised panel — one step above the card background. */
-const SURFACE = "fill-[var(--opt-subtle)] stroke-[var(--opt-border)]";
+const SURFACE = "fill-[var(--color-surface-raised)] stroke-[var(--color-border)]";
 /** Recessed control (input, key cap, pill) sitting inside a surface. */
-const INSET = "fill-[var(--opt-bg)] stroke-[var(--opt-border)]";
+const INSET = "fill-[var(--color-background)] stroke-[var(--color-border)]";
 /** Selected / active state — the single accent moment per illustration. */
 const ACCENT_WASH =
-  "fill-[color-mix(in_srgb,var(--opt-accent)_14%,transparent)] stroke-[var(--gr-accent-ink)]";
+  "fill-[color-mix(in_srgb,var(--color-primary)_14%,transparent)] stroke-[var(--color-primary)]";
 
-const ADD_WASH = "fill-[color-mix(in_srgb,var(--opt-ok)_20%,transparent)]";
-const DEL_WASH = "fill-[color-mix(in_srgb,var(--opt-error)_16%,transparent)]";
+const ADD_WASH = "fill-[color-mix(in_srgb,var(--color-success)_20%,transparent)]";
+const DEL_WASH = "fill-[color-mix(in_srgb,var(--color-danger)_16%,transparent)]";
 
 type PanelProps = {
   x: number;
@@ -92,7 +92,7 @@ function Txt({
   y,
   size = 8,
   anchor = "start",
-  className = "fill-[var(--opt-muted)]",
+  className = "fill-[var(--color-muted)]",
   weight,
   children,
 }: TxtProps) {
@@ -118,7 +118,7 @@ function SectionLabel({ x, y, children }: { x: number; y: number; children: Reac
       y={y}
       fontSize="7"
       letterSpacing="0.08em"
-      className="font-mono fill-[var(--opt-muted)] uppercase"
+      className="font-mono fill-[var(--color-muted)] uppercase"
     >
       {children}
     </text>
@@ -155,7 +155,7 @@ function KeyCap({
         y={y + 12.5}
         size={8.5}
         anchor="middle"
-        className={accent ? "fill-[var(--gr-accent-ink)]" : "fill-[var(--opt-text)]"}
+        className={accent ? "fill-[var(--color-primary)]" : "fill-[var(--color-foreground)]"}
       >
         {label}
       </Txt>
@@ -169,7 +169,7 @@ function Bar({
   y,
   w,
   h = 6,
-  className = "fill-[var(--opt-muted)]",
+  className = "fill-[var(--color-muted)]",
   opacity = 0.5,
 }: {
   x: number;
@@ -190,11 +190,11 @@ function Spark({ x, y, scale = 0.5 }: { x: number; y: number; scale?: number }) 
     <g transform={`translate(${x},${y}) scale(${scale})`}>
       <path
         d="M12 2c.6 3.6 2.4 5.4 6 6-3.6.6-5.4 2.4-6 6-.6-3.6-2.4-5.4-6-6 3.6-.6 5.4-2.4 6-6Z"
-        className="fill-[var(--gr-accent-ink)]"
+        className="fill-[var(--color-primary)]"
       />
       <path
         d="M19 15c.3 1.6 1.1 2.4 2.7 2.7-1.6.3-2.4 1.1-2.7 2.7-.3-1.6-1.1-2.4-2.7-2.7 1.6-.3 2.4-1.1 2.7-2.7Z"
-        className="fill-[var(--gr-accent-ink)]"
+        className="fill-[var(--color-primary)]"
         opacity="0.7"
       />
     </g>
@@ -221,7 +221,7 @@ export function ClusteredChangesIllustration(props: IllustProps) {
       <SectionLabel x={8} y={20}>
         changed files
       </SectionLabel>
-      <Txt x={120} y={20} size={7} anchor="end" className="fill-[var(--opt-muted)]">
+      <Txt x={120} y={20} size={7} anchor="end" className="fill-[var(--color-muted)]">
         a→z
       </Txt>
 
@@ -245,7 +245,7 @@ export function ClusteredChangesIllustration(props: IllustProps) {
       <Spark x={143} y={86} scale={0.62} />
       <path
         d="M128 111h44m-6-5 6 5-6 5"
-        className="stroke-[var(--opt-text)]"
+        className="stroke-[var(--color-foreground)]"
         strokeWidth="1.75"
         strokeLinecap="round"
         strokeLinejoin="round"
@@ -275,7 +275,7 @@ export function ClusteredChangesIllustration(props: IllustProps) {
               y={y + 17}
               size={9}
               weight={600}
-              className={active ? "fill-[var(--gr-accent-ink)]" : "fill-[var(--opt-text)]"}
+              className={active ? "fill-[var(--color-primary)]" : "fill-[var(--color-foreground)]"}
             >
               {unit.title}
             </Txt>
@@ -338,7 +338,7 @@ export function KeyboardFirstIllustration(props: IllustProps) {
       <SectionLabel x={48} y={38}>
         keymap
       </SectionLabel>
-      <rect x={82} y={31} width={4} height={9} className="fill-[var(--gr-accent-ink)]" />
+      <rect x={82} y={31} width={4} height={9} className="fill-[var(--color-primary)]" />
 
       {KEYMAP.map((row, i) => {
         const y = 50 + i * 33;
@@ -346,7 +346,7 @@ export function KeyboardFirstIllustration(props: IllustProps) {
         const startX = KEYS_RIGHT - total;
         return (
           <g key={row.action}>
-            <Txt x={48} y={y + 13} size={9} className="fill-[var(--opt-text)]">
+            <Txt x={48} y={y + 13} size={9} className="fill-[var(--color-foreground)]">
               {row.action}
             </Txt>
             {row.keys.map((key, k) => (
@@ -392,23 +392,23 @@ export function SummariesIllustration(props: IllustProps) {
         w={280}
         h={62}
         r={8}
-        className="fill-[var(--opt-bg)] stroke-[var(--gr-accent-ink)]"
+        className="fill-[var(--color-background)] stroke-[var(--color-primary)]"
         strokeWidth={1.5}
       />
       <Spark x={30} y={32} scale={0.6} />
-      <Txt x={52} y={45} size={8} weight={600} className="fill-[var(--gr-accent-ink)]">
+      <Txt x={52} y={45} size={8} weight={600} className="fill-[var(--color-primary)]">
         summary
       </Txt>
       <path
         d="M278 35l8 8m0-8-8 8"
-        className="stroke-[var(--opt-muted)]"
+        className="stroke-[var(--color-muted)]"
         strokeWidth="1.4"
         strokeLinecap="round"
       />
       <Bar x={32} y={58} w={252} opacity={0.5} />
       <Bar x={32} y={72} w={190} opacity={0.32} />
 
-      <path d="M20 102h280" className="stroke-[var(--opt-border)]" strokeWidth="1" />
+      <path d="M20 102h280" className="stroke-[var(--color-border)]" strokeWidth="1" />
 
       {DIFF_LINES.map((line, i) => {
         const y = 112 + i * 15;
@@ -430,7 +430,9 @@ export function SummariesIllustration(props: IllustProps) {
                 x={22}
                 y={y + 6}
                 size={8}
-                className={line.kind === "add" ? "fill-[var(--opt-ok)]" : "fill-[var(--opt-error)]"}
+                className={
+                  line.kind === "add" ? "fill-[var(--color-success)]" : "fill-[var(--color-danger)]"
+                }
               >
                 {line.kind === "add" ? "+" : "−"}
               </Txt>
@@ -441,10 +443,10 @@ export function SummariesIllustration(props: IllustProps) {
               w={line.w}
               className={
                 line.kind === "add"
-                  ? "fill-[var(--opt-ok)]"
+                  ? "fill-[var(--color-success)]"
                   : line.kind === "del"
-                    ? "fill-[var(--opt-error)]"
-                    : "fill-[var(--opt-muted)]"
+                    ? "fill-[var(--color-danger)]"
+                    : "fill-[var(--color-muted)]"
               }
               opacity={changed ? 0.6 : 0.4}
             />
@@ -482,12 +484,12 @@ export function ApprovedToolsIllustration(props: IllustProps) {
 
       {/* Provider select */}
       <Panel x={30} y={46} w={140} h={28} r={6} className={INSET} />
-      <Txt x={42} y={64} size={9} className="fill-[var(--opt-text)]">
+      <Txt x={42} y={64} size={9} className="fill-[var(--color-foreground)]">
         Anthropic
       </Txt>
       <path
         d="M152 58l4 4 4-4"
-        className="stroke-[var(--opt-muted)]"
+        className="stroke-[var(--color-muted)]"
         strokeWidth="1.4"
         strokeLinecap="round"
         strokeLinejoin="round"
@@ -500,7 +502,7 @@ export function ApprovedToolsIllustration(props: IllustProps) {
       </Txt>
 
       {/* Local-only status */}
-      <circle cx={34} cy={94} r={3.5} className="fill-[var(--gr-accent-ink)]" />
+      <circle cx={34} cy={94} r={3.5} className="fill-[var(--color-primary)]" />
       <Txt x={44} y={97} size={7.5}>
         connected · key stays on your machine
       </Txt>
@@ -517,7 +519,7 @@ export function ApprovedToolsIllustration(props: IllustProps) {
               y={146}
               size={8}
               anchor="middle"
-              className="fill-[var(--opt-text)]"
+              className="fill-[var(--color-foreground)]"
             >
               {chip.label}
             </Txt>
@@ -526,14 +528,21 @@ export function ApprovedToolsIllustration(props: IllustProps) {
       })}
 
       {/* …and you can read every line of what it does. */}
-      <rect x={98} y={166} width={124} height={24} rx={12} className="fill-[var(--opt-accent)]" />
+      <rect
+        x={98}
+        y={166}
+        width={124}
+        height={24}
+        rx={12}
+        className="fill-[var(--color-primary)]"
+      />
       <Txt
         x={160}
         y={182}
         size={9}
         weight={600}
         anchor="middle"
-        className="fill-[var(--opt-accent-on)]"
+        className="fill-[var(--color-primary-foreground)]"
       >
         open source
       </Txt>
@@ -556,48 +565,55 @@ export function NoBackendIllustration(props: IllustProps) {
 
       {/* Endpoints you already trust */}
       <Panel x={8} y={64} w={68} h={28} r={8} className={INSET} />
-      <Txt x={42} y={82} size={8.5} anchor="middle" className="fill-[var(--opt-text)]">
+      <Txt x={42} y={82} size={8.5} anchor="middle" className="fill-[var(--color-foreground)]">
         GitHub
       </Txt>
 
       <Panel x={244} y={64} w={68} h={28} r={8} className={INSET} />
-      <Txt x={278} y={82} size={8.5} anchor="middle" className="fill-[var(--opt-text)]">
+      <Txt x={278} y={82} size={8.5} anchor="middle" className="fill-[var(--color-foreground)]">
         LLM API
       </Txt>
 
       {/* Direct, two-way */}
       <path
         d="M80 78h24m-24 0 4-4m-4 4 4 4m20-4-4-4m4 4-4 4"
-        className="stroke-[var(--opt-text)]"
+        className="stroke-[var(--color-foreground)]"
         strokeWidth="1.5"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
       <path
         d="M216 78h24m-24 0 4-4m-4 4 4 4m20-4-4-4m4 4-4 4"
-        className="stroke-[var(--opt-text)]"
+        className="stroke-[var(--color-foreground)]"
         strokeWidth="1.5"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
 
       {/* The browser window itself */}
-      <rect x={112} y={40} width={96} height={76} rx={10} className="fill-[var(--opt-bg)]" />
+      <rect
+        x={112}
+        y={40}
+        width={96}
+        height={76}
+        rx={10}
+        className="fill-[var(--color-background)]"
+      />
       <path
         d="M112 50a10 10 0 0 1 10-10h76a10 10 0 0 1 10 10v10h-96V50Z"
-        className="fill-[var(--opt-subtle)]"
+        className="fill-[var(--color-surface-raised)]"
       />
-      <circle cx={124} cy={50} r={2.5} className="fill-[var(--opt-border)]" />
-      <circle cx={132} cy={50} r={2.5} className="fill-[var(--opt-border)]" />
-      <circle cx={140} cy={50} r={2.5} className="fill-[var(--opt-border)]" />
-      <rect x={126} y={74} width={68} height={24} rx={6} className="fill-[var(--opt-accent)]" />
+      <circle cx={124} cy={50} r={2.5} className="fill-[var(--color-border)]" />
+      <circle cx={132} cy={50} r={2.5} className="fill-[var(--color-border)]" />
+      <circle cx={140} cy={50} r={2.5} className="fill-[var(--color-border)]" />
+      <rect x={126} y={74} width={68} height={24} rx={6} className="fill-[var(--color-primary)]" />
       <Txt
         x={160}
         y={90}
         size={8.5}
         weight={600}
         anchor="middle"
-        className="fill-[var(--opt-accent-on)]"
+        className="fill-[var(--color-primary-foreground)]"
       >
         extension
       </Txt>
@@ -606,21 +622,21 @@ export function NoBackendIllustration(props: IllustProps) {
         y={40}
         w={96}
         h={76}
-        className="fill-none stroke-[var(--gr-accent-ink)]"
+        className="fill-none stroke-[var(--color-primary)]"
         strokeWidth={1.75}
       />
 
       {/* …and the path that does not exist */}
       <path
         d="M160 116v16"
-        className="stroke-[var(--opt-muted)]"
+        className="stroke-[var(--color-muted)]"
         strokeWidth="1.4"
         strokeDasharray="3 3"
         opacity="0.6"
       />
       <path
         d="M156 136l8 8m0-8-8 8"
-        className="stroke-[var(--opt-muted)]"
+        className="stroke-[var(--color-muted)]"
         strokeWidth="1.5"
         strokeLinecap="round"
         opacity="0.8"
@@ -632,7 +648,7 @@ export function NoBackendIllustration(props: IllustProps) {
           w={100}
           h={30}
           r={8}
-          className="fill-none stroke-[var(--opt-border)]"
+          className="fill-none stroke-[var(--color-border)]"
           strokeDasharray="4 3"
         />
         <Txt x={160} y={171} size={8} anchor="middle">

--- a/apps/web/components/Footer.tsx
+++ b/apps/web/components/Footer.tsx
@@ -3,9 +3,9 @@ import { GITHUB_REPO_URL } from "../lib/links";
 
 export function Footer() {
   return (
-    <footer className="mt-16 border-t border-gr-border bg-gr-bg">
+    <footer className="mt-16 border-t border-border bg-surface">
       <div className="mx-auto max-w-5xl px-4 py-12 sm:px-6">
-        <div className="flex flex-col items-start gap-4 text-sm text-gr-muted sm:flex-row sm:items-center sm:justify-between sm:gap-3">
+        <div className="flex flex-col items-start gap-4 text-sm text-muted sm:flex-row sm:items-center sm:justify-between sm:gap-3">
           <p className="m-0">© {new Date().getFullYear()} Guided Review</p>
           <div className="flex flex-wrap gap-x-4 gap-y-2">
             <a href={GITHUB_REPO_URL} target="_blank" rel="noopener noreferrer">

--- a/apps/web/components/Hero.tsx
+++ b/apps/web/components/Hero.tsx
@@ -16,13 +16,13 @@ export function Hero() {
           style={riseDelay(0.1)}
         >
           A better way for humans to{" "}
-          <span className="rounded-md bg-opt-accent px-2 py-0.5 text-opt-accent-on [box-decoration-break:clone] [-webkit-box-decoration-break:clone]">
+          <span className="rounded-md bg-primary px-2 py-0.5 text-primary-foreground [box-decoration-break:clone] [-webkit-box-decoration-break:clone]">
             review AI generated code
           </span>
         </h1>
 
         <p
-          className="gr-rise-in mx-auto mt-6 max-w-2xl text-lg leading-relaxed text-opt-muted text-balance sm:text-xl"
+          className="gr-rise-in mx-auto mt-6 max-w-2xl text-lg leading-relaxed text-muted text-balance sm:text-xl"
           style={riseDelay(0.2)}
         >
           Guided Review is a Chrome extension that makes &ldquo;reading code&rdquo; wayyyy better
@@ -36,7 +36,7 @@ export function Hero() {
           <InstallButton />
           <StarOnGitHubButton />
         </div>
-        <p className="gr-rise-in mt-4 font-mono text-xs text-opt-muted" style={riseDelay(0.35)}>
+        <p className="gr-rise-in mt-4 font-mono text-xs text-muted" style={riseDelay(0.35)}>
           Free · Open source · Bring your own LLM key
         </p>
 

--- a/apps/web/components/InstallCta.tsx
+++ b/apps/web/components/InstallCta.tsx
@@ -19,10 +19,10 @@ export function InstallCta() {
           <h2 className="mt-4 text-2xl font-bold tracking-tight sm:text-3xl font-brand">
             Get Guided Review
           </h2>
-          <p className="mt-3 text-lg text-opt-muted">
+          <p className="mt-3 text-lg text-muted">
             Install the Chrome extension, add an LLM API key in options, and open any GitHub pull
             request. Click{" "}
-            <strong className="font-semibold text-opt-text">Start Guided Review</strong> to begin.
+            <strong className="font-semibold text-foreground">Start Guided Review</strong> to begin.
           </p>
           <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
             <InstallButton />

--- a/apps/web/components/LegalDocument.tsx
+++ b/apps/web/components/LegalDocument.tsx
@@ -16,8 +16,8 @@ export function LegalDocument({ title, meta, children }: LegalDocumentProps) {
     <article className="mx-auto max-w-5xl px-4 py-12 sm:px-6 sm:py-16">
       <div className="mx-auto max-w-3xl">
         <h1 className="m-0 text-3xl font-bold tracking-tight">{title}</h1>
-        <p className="mt-2 text-sm text-opt-muted">{meta}</p>
-        <div className="legal-content mt-8 space-y-8 text-base leading-relaxed text-opt-text [&_h2]:m-0 [&_h2]:text-lg [&_h2]:font-semibold [&_h2]:tracking-tight [&_h3]:m-0 [&_h3]:mt-4 [&_h3]:text-base [&_h3]:font-semibold [&_p]:m-0 [&_p]:mt-3 [&_p]:text-opt-muted [&_ul]:m-0 [&_ul]:mt-3 [&_ul]:list-disc [&_ul]:space-y-2 [&_ul]:pl-5 [&_ul]:text-opt-muted [&_ol]:m-0 [&_ol]:mt-3 [&_ol]:list-decimal [&_ol]:space-y-2 [&_ol]:pl-5 [&_ol]:text-opt-muted [&_li]:leading-relaxed [&_strong]:font-semibold [&_strong]:text-opt-text [&_code]:rounded [&_code]:bg-opt-chrome [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[0.9em] [&_code]:text-opt-text">
+        <p className="mt-2 text-sm text-muted">{meta}</p>
+        <div className="legal-content mt-8 space-y-8 text-base leading-relaxed text-foreground [&_h2]:m-0 [&_h2]:text-lg [&_h2]:font-semibold [&_h2]:tracking-tight [&_h3]:m-0 [&_h3]:mt-4 [&_h3]:text-base [&_h3]:font-semibold [&_p]:m-0 [&_p]:mt-3 [&_p]:text-muted [&_ul]:m-0 [&_ul]:mt-3 [&_ul]:list-disc [&_ul]:space-y-2 [&_ul]:pl-5 [&_ul]:text-muted [&_ol]:m-0 [&_ol]:mt-3 [&_ol]:list-decimal [&_ol]:space-y-2 [&_ol]:pl-5 [&_ol]:text-muted [&_li]:leading-relaxed [&_strong]:font-semibold [&_strong]:text-foreground [&_code]:rounded [&_code]:bg-background [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[0.9em] [&_code]:text-foreground">
           {children}
         </div>
       </div>
@@ -27,8 +27,8 @@ export function LegalDocument({ title, meta, children }: LegalDocumentProps) {
 
 export function LegalContactBlock() {
   return (
-    <div className="mt-4 rounded-lg border border-opt-border bg-opt-chrome/40 px-4 py-4 text-sm leading-relaxed text-opt-muted">
-      <strong className="text-opt-text">Artery Ventures, LLP</strong>
+    <div className="mt-4 rounded-lg border border-border bg-background/40 px-4 py-4 text-sm leading-relaxed text-muted">
+      <strong className="text-foreground">Artery Ventures, LLP</strong>
       <br />
       FO-02, 4th Floor, 28/A, 80 Feet Rd
       <br />

--- a/apps/web/components/LineGutter.tsx
+++ b/apps/web/components/LineGutter.tsx
@@ -12,12 +12,12 @@ export function LineGutter() {
       aria-hidden="true"
       className="pointer-events-none fixed inset-y-0 left-0 right-0 -z-10 hidden select-none lg:block"
     >
-      <div className="absolute inset-y-0 left-0 flex w-12 flex-col justify-between overflow-hidden py-6 pl-4 font-mono text-[10px] leading-none text-opt-border/60">
+      <div className="absolute inset-y-0 left-0 flex w-12 flex-col justify-between overflow-hidden py-6 pl-4 font-mono text-[10px] leading-none text-border/60">
         {LINES.map((n) => (
           <span key={`l-${n}`}>{n}</span>
         ))}
       </div>
-      <div className="absolute inset-y-0 right-0 flex w-12 flex-col justify-between overflow-hidden py-6 pr-4 text-right font-mono text-[10px] leading-none text-opt-border/60">
+      <div className="absolute inset-y-0 right-0 flex w-12 flex-col justify-between overflow-hidden py-6 pr-4 text-right font-mono text-[10px] leading-none text-border/60">
         {LINES.map((n) => (
           <span key={`r-${n}`}>{n}</span>
         ))}

--- a/apps/web/components/ProductVideo.tsx
+++ b/apps/web/components/ProductVideo.tsx
@@ -233,14 +233,14 @@ export function ProductVideo() {
   );
 
   return (
-    <div className="mx-auto mt-16 max-w-3xl overflow-hidden rounded-xl border border-gr-border bg-gr-chrome text-left shadow-2xl">
-      <div className="flex items-center gap-1.5 border-b border-gr-border bg-gr-bg px-4 py-3">
-        <span className="h-2.5 w-2.5 rounded-full bg-gr-danger" aria-hidden="true" />
-        <span className="h-2.5 w-2.5 rounded-full bg-gr-syntax-variable" aria-hidden="true" />
-        <span className="h-2.5 w-2.5 rounded-full bg-gr-add-text" aria-hidden="true" />
-        <span className="ml-3 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 font-mono text-xs text-gr-muted">
+    <div className="mx-auto mt-16 max-w-3xl overflow-hidden rounded-xl border border-border bg-background text-left shadow-2xl">
+      <div className="flex items-center gap-1.5 border-b border-border bg-surface px-4 py-3">
+        <span className="h-2.5 w-2.5 rounded-full bg-danger" aria-hidden="true" />
+        <span className="h-2.5 w-2.5 rounded-full bg-syntax-variable" aria-hidden="true" />
+        <span className="h-2.5 w-2.5 rounded-full bg-diff-add" aria-hidden="true" />
+        <span className="ml-3 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 font-mono text-xs text-muted">
           <span>Product demo</span>
-          <span className="inline-flex items-center gap-1.5 text-gr-faint">
+          <span className="inline-flex items-center gap-1.5 text-faint">
             <ShortcutChord keyLabel="v" />
             <span>to play</span>
           </span>
@@ -248,7 +248,7 @@ export function ProductVideo() {
       </div>
 
       <div
-        className="relative aspect-video bg-gr-canvas select-none"
+        className="relative aspect-video bg-surface-raised select-none"
         onMouseMove={started ? revealControls : undefined}
         onMouseLeave={
           started
@@ -273,10 +273,10 @@ export function ProductVideo() {
             <button
               type="button"
               onClick={startPlayback}
-              className="absolute inset-0 flex cursor-pointer items-center justify-center bg-gr-chrome/25 transition-colors hover:bg-gr-chrome/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-4px] focus-visible:outline-gr-accent"
+              className="absolute inset-0 flex cursor-pointer items-center justify-center bg-background/25 transition-colors hover:bg-background/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-4px] focus-visible:outline-primary"
               aria-label="Play product demo video"
             >
-              <span className="flex h-16 w-16 items-center justify-center rounded-full border border-gr-accent bg-gr-accent text-gr-accent-on shadow-[0_8px_32px_rgba(0,0,0,0.45)] transition-transform hover:scale-105 sm:h-20 sm:w-20">
+              <span className="flex h-16 w-16 items-center justify-center rounded-full border border-primary bg-primary text-primary-foreground shadow-[0_8px_32px_rgba(0,0,0,0.45)] transition-transform hover:scale-105 sm:h-20 sm:w-20">
                 <PlayIcon className="ml-1 h-8 w-8 sm:h-9 sm:w-9" />
               </span>
             </button>
@@ -317,10 +317,10 @@ export function ProductVideo() {
               <button
                 type="button"
                 onClick={togglePlay}
-                className="absolute inset-0 z-10 flex cursor-pointer items-center justify-center bg-gr-chrome/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-4px] focus-visible:outline-gr-accent"
+                className="absolute inset-0 z-10 flex cursor-pointer items-center justify-center bg-background/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-4px] focus-visible:outline-primary"
                 aria-label="Play video"
               >
-                <span className="flex h-16 w-16 items-center justify-center rounded-full border border-gr-accent bg-gr-accent text-gr-accent-on shadow-[0_8px_32px_rgba(0,0,0,0.45)] sm:h-20 sm:w-20">
+                <span className="flex h-16 w-16 items-center justify-center rounded-full border border-primary bg-primary text-primary-foreground shadow-[0_8px_32px_rgba(0,0,0,0.45)] sm:h-20 sm:w-20">
                   <PlayIcon className="ml-1 h-8 w-8 sm:h-9 sm:w-9" />
                 </span>
               </button>
@@ -328,7 +328,7 @@ export function ProductVideo() {
 
             <div
               className={[
-                "absolute inset-x-0 bottom-0 z-20 bg-gradient-to-t from-gr-chrome via-gr-chrome/85 to-transparent px-3 pb-3 pt-10 transition-opacity duration-200",
+                "absolute inset-x-0 bottom-0 z-20 bg-gradient-to-t from-background via-background/85 to-transparent px-3 pb-3 pt-10 transition-opacity duration-200",
                 controlsVisible || scrubbing || !playing
                   ? "opacity-100"
                   : "pointer-events-none opacity-0",
@@ -347,7 +347,7 @@ export function ProductVideo() {
                 aria-valuemax={Math.round(duration) || 0}
                 aria-valuenow={Math.round(currentTime)}
                 aria-valuetext={`${formatTime(currentTime)} of ${formatTime(duration)}`}
-                className="group relative mb-2.5 h-1.5 cursor-pointer rounded-full bg-gr-border-muted touch-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gr-accent"
+                className="group relative mb-2.5 h-1.5 cursor-pointer rounded-full bg-border-strong touch-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
                 onPointerDown={onScrubPointerDown}
                 onPointerMove={onScrubPointerMove}
                 onPointerUp={onScrubPointerUp}
@@ -376,11 +376,11 @@ export function ProductVideo() {
                 }}
               >
                 <div
-                  className="absolute inset-y-0 left-0 rounded-full bg-gr-accent"
+                  className="absolute inset-y-0 left-0 rounded-full bg-primary"
                   style={{ width: `${progress * 100}%` }}
                 />
                 <div
-                  className="absolute top-1/2 h-3.5 w-3.5 -translate-y-1/2 rounded-full border-2 border-gr-accent-on bg-gr-accent shadow-sm opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
+                  className="absolute top-1/2 h-3.5 w-3.5 -translate-y-1/2 rounded-full border-2 border-primary-foreground bg-primary shadow-sm opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
                   style={{ left: `calc(${progress * 100}% - 7px)` }}
                 />
               </div>
@@ -389,7 +389,7 @@ export function ProductVideo() {
                 <button
                   type="button"
                   onClick={togglePlay}
-                  className="inline-flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-md border border-gr-border bg-gr-bg text-gr-text transition-colors hover:bg-gr-subtle hover:text-gr-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gr-accent"
+                  className="inline-flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-md border border-border bg-surface text-foreground transition-colors hover:bg-surface-muted hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
                   aria-label={playing ? "Pause" : "Play"}
                 >
                   {playing ? (
@@ -402,15 +402,15 @@ export function ProductVideo() {
                 <button
                   type="button"
                   onClick={toggleMute}
-                  className="inline-flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-md border border-gr-border bg-gr-bg text-gr-muted transition-colors hover:bg-gr-subtle hover:text-gr-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gr-accent"
+                  className="inline-flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-md border border-border bg-surface text-muted transition-colors hover:bg-surface-muted hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
                   aria-label={muted ? "Unmute" : "Mute"}
                 >
                   <VolumeIcon muted={muted} className="h-4 w-4" />
                 </button>
 
-                <span className="ml-1 font-mono text-xs tabular-nums text-gr-muted">
-                  <span className="text-gr-text">{formatTime(currentTime)}</span>
-                  <span className="mx-1 text-gr-faint">/</span>
+                <span className="ml-1 font-mono text-xs tabular-nums text-muted">
+                  <span className="text-foreground">{formatTime(currentTime)}</span>
+                  <span className="mx-1 text-faint">/</span>
                   {formatTime(duration)}
                 </span>
               </div>

--- a/apps/web/components/ShortcutChord.tsx
+++ b/apps/web/components/ShortcutChord.tsx
@@ -28,7 +28,7 @@ export function ShortcutChord({ keyLabel }: { keyLabel: string }) {
               +
             </span>
           ) : null}
-          <Kbd surface="app">{key}</Kbd>
+          <Kbd>{key}</Kbd>
         </Fragment>
       ))}
     </KbdGroup>

--- a/apps/web/components/TrustBand.tsx
+++ b/apps/web/components/TrustBand.tsx
@@ -19,12 +19,12 @@ export function TrustBand({ starCount }: TrustBandProps) {
         <h2 className="m-0 text-2xl font-bold tracking-tight sm:text-3xl font-brand">
           Your code never touches our infrastructure
         </h2>
-        <p className="mx-auto mt-4 max-w-2xl text-lg text-opt-muted text-balance sm:text-xl">
+        <p className="mx-auto mt-4 max-w-2xl text-lg text-muted text-balance sm:text-xl">
           The extension talks directly to your AI provider and GitHub. We never see your diffs, your
           keys, or your code — because there&apos;s nothing on our end to see them with.
         </p>
 
-        <div className="mx-auto mt-10 flex items-center justify-center rounded-lg bg-opt-bg/60 p-6">
+        <div className="mx-auto mt-10 flex items-center justify-center rounded-lg bg-background/60 p-6">
           <NoBackendIllustration className="h-auto w-full max-w-[480px]" />
         </div>
 
@@ -33,7 +33,7 @@ export function TrustBand({ starCount }: TrustBandProps) {
             href={GITHUB_REPO_URL}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 rounded-md border border-opt-border bg-opt-subtle/60 px-5 py-2.5 text-sm font-medium text-opt-text transition-colors hover:border-opt-accent/60 hover:bg-opt-subtle"
+            className="inline-flex items-center gap-2 rounded-md border border-border bg-surface-raised/60 px-5 py-2.5 text-sm font-medium text-foreground transition-colors hover:border-primary/60 hover:bg-surface-raised"
           >
             <GitHubIcon className="h-4 w-4" />
             {starCount !== null ? (
@@ -44,7 +44,7 @@ export function TrustBand({ starCount }: TrustBandProps) {
           </a>
           <a
             href="/docs/configure-provider"
-            className="inline-flex items-center gap-2 rounded-md border border-opt-border bg-opt-subtle/60 px-5 py-2.5 text-sm font-medium text-opt-text transition-colors hover:border-opt-accent/60 hover:bg-opt-subtle"
+            className="inline-flex items-center gap-2 rounded-md border border-border bg-surface-raised/60 px-5 py-2.5 text-sm font-medium text-foreground transition-colors hover:border-primary/60 hover:bg-surface-raised"
           >
             Bring your own LLM key
           </a>

--- a/apps/web/components/Why.tsx
+++ b/apps/web/components/Why.tsx
@@ -4,17 +4,17 @@ export function Why() {
   return (
     <section id="why" className="relative px-4 py-16 sm:px-6 sm:py-28">
       <div className="mx-auto max-w-5xl">
-        <h2 className="m-0 text-center text-2xl font-bold tracking-tight text-opt-accent font-brand sm:text-3xl">
+        <h2 className="m-0 text-center text-2xl font-bold tracking-tight text-primary font-brand sm:text-3xl">
           Why?
         </h2>
-        <h3 className="m-0 mt-3 text-center text-xl font-bold tracking-tight text-opt-text font-brand sm:text-2xl">
+        <h3 className="m-0 mt-3 text-center text-xl font-bold tracking-tight text-foreground font-brand sm:text-2xl">
           Code review is hard,
           <br />
           and it&apos;s only getting harder
         </h3>
 
         <WindowFrame label="why.md" className="mt-10">
-          <div className="grid gap-8 font-serif text-lg leading-relaxed text-opt-muted sm:grid-cols-2 sm:gap-10 sm:text-xl">
+          <div className="grid gap-8 font-serif text-lg leading-relaxed text-muted sm:grid-cols-2 sm:gap-10 sm:text-xl">
             <div className="space-y-4">
               <p>
                 AI agents are writing code for you, and you have PRs pending your review. When you

--- a/apps/web/components/WindowFrame.tsx
+++ b/apps/web/components/WindowFrame.tsx
@@ -18,15 +18,15 @@ export function WindowFrame({ label, children, className, bodyClassName }: Windo
   return (
     <div
       className={cn(
-        "overflow-hidden rounded-lg border border-opt-border bg-opt-subtle/50 shadow-[0_1px_0_rgba(0,0,0,0.02)]",
+        "overflow-hidden rounded-lg border border-border bg-surface-raised/50 shadow-[0_1px_0_rgba(0,0,0,0.02)]",
         className,
       )}
     >
-      <div className="flex items-center gap-1.5 border-b border-opt-border bg-opt-bg/70 px-4 py-2.5">
-        <span className="h-2.5 w-2.5 rounded-full bg-gr-danger/70" aria-hidden="true" />
-        <span className="h-2.5 w-2.5 rounded-full bg-gr-syntax-variable/70" aria-hidden="true" />
-        <span className="h-2.5 w-2.5 rounded-full bg-gr-add-text/70" aria-hidden="true" />
-        <span className="ml-2.5 truncate font-mono text-xs text-opt-muted">{label}</span>
+      <div className="flex items-center gap-1.5 border-b border-border bg-background/70 px-4 py-2.5">
+        <span className="h-2.5 w-2.5 rounded-full bg-danger/70" aria-hidden="true" />
+        <span className="h-2.5 w-2.5 rounded-full bg-syntax-variable/70" aria-hidden="true" />
+        <span className="h-2.5 w-2.5 rounded-full bg-diff-add/70" aria-hidden="true" />
+        <span className="ml-2.5 truncate font-mono text-xs text-muted">{label}</span>
       </div>
       <div className={cn("p-4 sm:p-6 md:p-8", bodyClassName)}>{children}</div>
     </div>

--- a/apps/web/components/docs/Callout.tsx
+++ b/apps/web/components/docs/Callout.tsx
@@ -11,22 +11,22 @@ export type CalloutProps = {
 
 const config: Record<CalloutType, { className: string; titleDefault: string }> = {
   note: {
-    className: "border-opt-border bg-opt-subtle text-opt-text",
+    className: "border-border bg-surface-raised text-foreground",
     titleDefault: "Note",
   },
   tip: {
     className:
-      "border-[color-mix(in_srgb,var(--opt-ok)_40%,var(--opt-border))] bg-[color-mix(in_srgb,var(--opt-ok)_10%,var(--opt-bg))] text-opt-text",
+      "border-[color-mix(in_srgb,var(--color-success)_40%,var(--color-border))] bg-[color-mix(in_srgb,var(--color-success)_10%,var(--color-background))] text-foreground",
     titleDefault: "Tip",
   },
   warning: {
     className:
-      "border-[color-mix(in_srgb,#d4a72c_45%,var(--opt-border))] bg-[color-mix(in_srgb,#d4a72c_12%,var(--opt-bg))] text-opt-text",
+      "border-[color-mix(in_srgb,#d4a72c_45%,var(--color-border))] bg-[color-mix(in_srgb,#d4a72c_12%,var(--color-background))] text-foreground",
     titleDefault: "Warning",
   },
   danger: {
     className:
-      "border-[color-mix(in_srgb,var(--opt-error)_40%,var(--opt-border))] bg-[color-mix(in_srgb,var(--opt-error)_10%,var(--opt-bg))] text-opt-text",
+      "border-[color-mix(in_srgb,var(--color-danger)_40%,var(--color-border))] bg-[color-mix(in_srgb,var(--color-danger)_10%,var(--color-background))] text-foreground",
     titleDefault: "Danger",
   },
 };
@@ -45,7 +45,7 @@ export function Callout({ type = "note", title, children }: CalloutProps) {
     >
       <div className="min-w-0 flex-1">
         <div className="mb-1 text-sm font-semibold">{label}</div>
-        <div className="text-sm leading-relaxed text-opt-muted [&>p]:m-0 [&>p]:leading-relaxed">
+        <div className="text-sm leading-relaxed text-muted [&>p]:m-0 [&>p]:leading-relaxed">
           {children}
         </div>
       </div>

--- a/apps/web/components/docs/CopyButton.tsx
+++ b/apps/web/components/docs/CopyButton.tsx
@@ -27,7 +27,7 @@ export function CopyButton({ text, className }: CopyButtonProps) {
       onClick={handleCopy}
       aria-label={copied ? "Copied" : "Copy code"}
       className={cn(
-        buttonClassName({ variant: "secondary", size: "sm", surface: "app" }),
+        buttonClassName({ variant: "secondary", size: "sm" }),
         "px-2 py-1 text-xs",
         className,
       )}

--- a/apps/web/components/docs/DocsBreadcrumbs.tsx
+++ b/apps/web/components/docs/DocsBreadcrumbs.tsx
@@ -31,19 +31,19 @@ export function DocsBreadcrumbs({ slug, basePath = "/docs" }: DocsBreadcrumbsPro
   }
 
   return (
-    <nav aria-label="Breadcrumb" className="mb-6 text-xs text-opt-muted">
+    <nav aria-label="Breadcrumb" className="mb-6 text-xs text-muted">
       <ol className="m-0 flex list-none flex-wrap items-center gap-1 p-0">
         <li>
           <Link
             href={basePath}
-            className="border-b-0 text-opt-muted no-underline hover:border-b-transparent hover:text-opt-text"
+            className="border-b-0 text-muted no-underline hover:border-b-transparent hover:text-foreground"
           >
             Docs
           </Link>
         </li>
         {sectionTitle ? (
           <>
-            <li aria-hidden="true" className="text-opt-muted/60">
+            <li aria-hidden="true" className="text-muted/60">
               /
             </li>
             <li>
@@ -53,11 +53,11 @@ export function DocsBreadcrumbs({ slug, basePath = "/docs" }: DocsBreadcrumbsPro
         ) : null}
         {pageTitle ? (
           <>
-            <li aria-hidden="true" className="text-opt-muted/60">
+            <li aria-hidden="true" className="text-muted/60">
               /
             </li>
             <li>
-              <span className="font-medium text-opt-text" aria-current="page">
+              <span className="font-medium text-foreground" aria-current="page">
                 {pageTitle}
               </span>
             </li>

--- a/apps/web/components/docs/DocsMobileNav.tsx
+++ b/apps/web/components/docs/DocsMobileNav.tsx
@@ -23,17 +23,17 @@ export function DocsMobileNav() {
   }, [open]);
 
   return (
-    <div className="sticky top-[3.6rem] z-30 flex items-center gap-3 border-b border-opt-border bg-opt-bg/95 px-4 py-3 backdrop-blur-sm lg:hidden">
+    <div className="sticky top-[3.6rem] z-30 flex items-center gap-3 border-b border-border bg-background/95 px-4 py-3 backdrop-blur-sm lg:hidden">
       <button
         type="button"
-        className={cn(buttonClassName({ variant: "ghost", size: "sm", surface: "app" }), "gap-2")}
+        className={cn(buttonClassName({ variant: "ghost", size: "sm" }), "gap-2")}
         onClick={() => setOpen(true)}
         aria-expanded={open}
         aria-controls="docs-mobile-drawer"
       >
         Menu
       </button>
-      <span className="text-sm text-opt-muted">Documentation</span>
+      <span className="text-sm text-muted">Documentation</span>
 
       {open ? (
         <div
@@ -44,21 +44,21 @@ export function DocsMobileNav() {
         >
           <button
             type="button"
-            className="absolute inset-0 border-0 bg-opt-text/30"
+            className="absolute inset-0 border-0 bg-foreground/30"
             aria-label="Close menu"
             onClick={() => setOpen(false)}
           />
           <div
             id="docs-mobile-drawer"
-            className="absolute inset-y-0 left-0 flex w-72 max-w-[85vw] flex-col border-r border-opt-border bg-opt-bg shadow-lg"
+            className="absolute inset-y-0 left-0 flex w-72 max-w-[85vw] flex-col border-r border-border bg-background shadow-lg"
           >
-            <div className="flex items-center justify-between border-b border-opt-border px-4 py-3">
-              <p id={titleId} className="m-0 text-sm font-semibold text-opt-text">
+            <div className="flex items-center justify-between border-b border-border px-4 py-3">
+              <p id={titleId} className="m-0 text-sm font-semibold text-foreground">
                 Docs
               </p>
               <button
                 type="button"
-                className={buttonClassName({ variant: "ghost", size: "sm", surface: "app" })}
+                className={buttonClassName({ variant: "ghost", size: "sm" })}
                 onClick={() => setOpen(false)}
               >
                 Close

--- a/apps/web/components/docs/DocsPager.tsx
+++ b/apps/web/components/docs/DocsPager.tsx
@@ -24,16 +24,16 @@ export function DocsPager({ slug, basePath = "/docs" }: DocsPagerProps) {
   if (!prev && !next) return null;
 
   return (
-    <div className="mt-12 grid grid-cols-2 gap-4 border-t border-opt-border pt-6">
+    <div className="mt-12 grid grid-cols-2 gap-4 border-t border-border pt-6">
       {prev ? (
         <Link
           href={getHref(prev.slug, basePath)}
-          className="group inline-flex h-auto flex-col items-start gap-1 rounded-lg border border-opt-border bg-opt-subtle/40 p-4 no-underline transition-colors hover:border-opt-muted hover:bg-opt-subtle"
+          className="group inline-flex h-auto flex-col items-start gap-1 rounded-lg border border-border bg-surface-raised/40 p-4 no-underline transition-colors hover:border-muted hover:bg-surface-raised"
         >
-          <span className="flex items-center gap-1 text-xs uppercase tracking-widest text-opt-muted">
+          <span className="flex items-center gap-1 text-xs uppercase tracking-widest text-muted">
             ← Previous
           </span>
-          <span className="text-sm font-medium text-opt-text group-hover:text-opt-text">
+          <span className="text-sm font-medium text-foreground group-hover:text-foreground">
             {prev.title}
           </span>
         </Link>
@@ -43,12 +43,12 @@ export function DocsPager({ slug, basePath = "/docs" }: DocsPagerProps) {
       {next ? (
         <Link
           href={getHref(next.slug, basePath)}
-          className="group inline-flex h-auto flex-col items-end gap-1 rounded-lg border border-opt-border bg-opt-subtle/40 p-4 no-underline transition-colors hover:border-opt-muted hover:bg-opt-subtle"
+          className="group inline-flex h-auto flex-col items-end gap-1 rounded-lg border border-border bg-surface-raised/40 p-4 no-underline transition-colors hover:border-muted hover:bg-surface-raised"
         >
-          <span className="flex items-center gap-1 text-xs uppercase tracking-widest text-opt-muted">
+          <span className="flex items-center gap-1 text-xs uppercase tracking-widest text-muted">
             Next →
           </span>
-          <span className="text-sm font-medium text-opt-text group-hover:text-opt-text">
+          <span className="text-sm font-medium text-foreground group-hover:text-foreground">
             {next.title}
           </span>
         </Link>

--- a/apps/web/components/docs/DocsSidebar.tsx
+++ b/apps/web/components/docs/DocsSidebar.tsx
@@ -22,7 +22,7 @@ export function DocsSidebar({ basePath = "/docs", onNavigate }: DocsSidebarProps
               <li
                 key={`h-${idx}`}
                 className={cn(
-                  "mb-1.5 text-[0.65rem] font-semibold uppercase tracking-widest text-opt-muted",
+                  "mb-1.5 text-[0.65rem] font-semibold uppercase tracking-widest text-muted",
                   idx === 0 ? "mt-0" : "mt-5",
                 )}
               >
@@ -42,8 +42,8 @@ export function DocsSidebar({ basePath = "/docs", onNavigate }: DocsSidebarProps
                 className={cn(
                   "mb-0.5 block rounded-md border-b-0 px-2.5 py-1.5 text-sm no-underline transition-colors hover:border-b-transparent",
                   active
-                    ? "bg-opt-subtle font-medium text-opt-text"
-                    : "text-opt-muted hover:bg-opt-subtle/70 hover:text-opt-text",
+                    ? "bg-surface-raised font-medium text-foreground"
+                    : "text-muted hover:bg-surface-raised/70 hover:text-foreground",
                 )}
                 aria-current={active ? "page" : undefined}
               >

--- a/apps/web/components/docs/TocCard.tsx
+++ b/apps/web/components/docs/TocCard.tsx
@@ -7,14 +7,14 @@ export function TocCard({ toc }: { toc: TocEntry[] }) {
 
   return (
     <nav aria-label="On this page" className="not-prose my-6">
-      <div className="mb-3 text-xs uppercase tracking-widest text-opt-muted">On this page</div>
+      <div className="mb-3 text-xs uppercase tracking-widest text-muted">On this page</div>
       <ol className="p-0">
         {toc.map(({ id, label, level }) => (
           <li key={id} className={level === 3 ? "pl-3" : ""}>
             <Link
               href={`#${id}`}
               className={cn(
-                "list-item border-b-0 py-0.5 text-sm leading-snug text-opt-muted no-underline transition-colors hover:border-b-transparent hover:text-opt-text",
+                "list-item border-b-0 py-0.5 text-sm leading-snug text-muted no-underline transition-colors hover:border-b-transparent hover:text-foreground",
               )}
             >
               {label}

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -27,21 +27,31 @@ import {
   Label,
   Select,
 } from "@guided-review/ui";
-import type { Surface, SelectOption } from "@guided-review/ui";
+import type { SelectOption } from "@guided-review/ui";
 import "@guided-review/ui/theme.css";
 import iconUrl from "@guided-review/ui/assets/icon.png";
 ```
 
-### Surfaces
+### Design tokens
 
-Shared controls accept `surface?: "app" | "overlay"`:
+One dark palette in `src/styles/theme.css` (`@theme` → Tailwind utilities + `var(--color-*)`):
 
-| Surface   | Tokens  | Used by                           |
-| --------- | ------- | --------------------------------- |
-| `app`     | `opt-*` | Options page, marketing site      |
-| `overlay` | `gr-*`  | Review overlay (dark-only chrome) |
+| Token                                                                | Utilities           | Role                       |
+| -------------------------------------------------------------------- | ------------------- | -------------------------- |
+| `background`                                                         | `bg-background`     | Page / chrome root         |
+| `surface`                                                            | `bg-surface`        | Main panels                |
+| `surface-raised`                                                     | `bg-surface-raised` | Cards, inputs              |
+| `surface-muted`                                                      | `bg-surface-muted`  | Hover / inset              |
+| `foreground`                                                         | `text-foreground`   | Body text                  |
+| `muted`                                                              | `text-muted`        | Secondary text             |
+| `faint`                                                              | `text-faint`        | Placeholders, line numbers |
+| `border` / `border-strong`                                           | `border-border`     | UI borders                 |
+| `primary` / `primary-hover` / `primary-foreground` / `primary-muted` | `bg-primary`, …     | Brand lime                 |
+| `success` / `danger` / `danger-muted`                                | `text-success`, …   | Status                     |
+| `diff-add` / `diff-del` (+ `-bg`)                                    | `text-diff-add`, …  | Diff chrome                |
+| `syntax-*`                                                           | —                   | highlight.js (SCSS)        |
 
-Defaults: form controls default to `app`; `Spinner` defaults to `overlay` for back-compat.
+Used by the marketing site, options page, welcome page, and review overlay.
 
 ### Form controls
 

--- a/packages/ui/src/components/Button.test.tsx
+++ b/packages/ui/src/components/Button.test.tsx
@@ -18,20 +18,16 @@ describe("Button", () => {
     expect(screen.getByRole("button")).toBeDisabled();
   });
 
-  it("buttonClassName includes primary app styles by default", () => {
-    expect(buttonClassName()).toContain("bg-opt-accent");
-    expect(buttonClassName({ surface: "overlay", variant: "secondary" })).toContain("bg-gr-bg");
+  it("buttonClassName includes primary styles by default", () => {
+    expect(buttonClassName()).toContain("bg-primary");
+    expect(buttonClassName({ variant: "secondary" })).toContain("bg-surface-raised");
   });
 
   it("uses not-disabled:hover so hover works on anchors and enabled buttons", () => {
     // `:enabled` only matches form controls — link-styled CTAs would never hover.
     const primary = buttonClassName();
-    expect(primary).toContain("not-disabled:hover:bg-opt-accent-hover");
+    expect(primary).toContain("not-disabled:hover:bg-primary-hover");
     expect(primary).not.toContain("enabled:hover:");
-
-    const overlayPrimary = buttonClassName({ surface: "overlay" });
-    expect(overlayPrimary).toContain("not-disabled:hover:bg-gr-accent-hover");
-    expect(overlayPrimary).not.toContain("enabled:hover:");
   });
 
   it("includes transition-colors for hover feedback", () => {

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -1,6 +1,5 @@
 import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from "react";
 import { cn } from "../cn";
-import type { Surface } from "../surface";
 
 export type ButtonVariant = "primary" | "secondary" | "destructive" | "ghost";
 export type ButtonSize = "sm" | "md" | "lg";
@@ -8,11 +7,6 @@ export type ButtonSize = "sm" | "md" | "lg";
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;
   size?: ButtonSize;
-  /**
-   * Token set: `app` (options + marketing, opt-*) or `overlay` (dark review UI, gr-*).
-   * Defaults to `app`.
-   */
-  surface?: Surface;
   children?: ReactNode;
 }
 
@@ -28,53 +22,28 @@ const sizeClasses: Record<ButtonSize, string> = {
  * only matches form controls, so link-buttons never received hover under the
  * old selector.
  */
-const appVariants: Record<ButtonVariant, string> = {
+const variants: Record<ButtonVariant, string> = {
   primary: cn(
-    "border-opt-accent bg-opt-accent font-semibold text-opt-accent-on",
-    "not-disabled:hover:border-opt-accent-hover not-disabled:hover:bg-opt-accent-hover",
-    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-opt-accent",
-    // Nested keyboard keys on accent fill need inverted kbd chrome.
+    "border-primary bg-primary font-semibold text-primary-foreground",
+    "not-disabled:hover:border-primary-hover not-disabled:hover:bg-primary-hover",
+    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
+    // Nested keyboard keys on primary fill need inverted kbd chrome.
     "[&_[data-slot=kbd]]:bg-[rgba(13,8,6,0.12)] [&_[data-slot=kbd]]:text-inherit",
   ),
   secondary: cn(
-    "border-opt-border bg-opt-subtle font-semibold text-opt-text",
-    "not-disabled:hover:border-opt-muted not-disabled:hover:bg-[color-mix(in_srgb,var(--opt-muted)_10%,var(--opt-subtle))]",
-    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-opt-accent",
+    "border-border bg-surface-raised font-semibold text-foreground",
+    "not-disabled:hover:border-muted not-disabled:hover:bg-[color-mix(in_srgb,var(--color-muted)_10%,var(--color-surface-raised))]",
+    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
   ),
   destructive: cn(
-    "border-opt-error bg-opt-subtle font-semibold text-opt-error",
-    "not-disabled:hover:bg-[color-mix(in_srgb,var(--opt-error)_12%,var(--opt-subtle))]",
-    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-opt-error",
+    "border-danger bg-danger-muted font-semibold text-danger",
+    "not-disabled:hover:bg-[color-mix(in_srgb,var(--color-danger)_20%,var(--color-danger-muted))]",
+    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-danger",
   ),
   ghost: cn(
-    "border-transparent bg-transparent font-medium text-opt-muted",
-    "not-disabled:hover:bg-opt-subtle not-disabled:hover:text-opt-text",
-    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-opt-accent",
-  ),
-};
-
-const overlayVariants: Record<ButtonVariant, string> = {
-  primary: cn(
-    "border-gr-accent bg-gr-accent font-medium text-gr-accent-on",
-    "not-disabled:hover:border-gr-accent-hover not-disabled:hover:bg-gr-accent-hover",
-    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gr-accent",
-    // Nested keyboard keys on accent fill need inverted kbd chrome.
-    "[&_[data-slot=kbd]]:bg-[rgba(13,8,6,0.12)] [&_[data-slot=kbd]]:text-inherit",
-  ),
-  secondary: cn(
-    "border-gr-border bg-gr-bg text-gr-muted",
-    "not-disabled:hover:bg-gr-subtle not-disabled:hover:text-gr-text",
-    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gr-accent",
-  ),
-  destructive: cn(
-    "border-gr-danger bg-gr-danger-subtle font-medium text-gr-danger",
-    "not-disabled:hover:bg-[rgba(255,123,114,0.2)]",
-    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gr-danger",
-  ),
-  ghost: cn(
-    "border-transparent bg-transparent text-gr-muted",
-    "not-disabled:hover:bg-gr-subtle not-disabled:hover:text-gr-text",
-    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gr-accent",
+    "border-transparent bg-transparent font-medium text-muted",
+    "not-disabled:hover:bg-surface-muted not-disabled:hover:text-foreground",
+    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
   ),
 };
 
@@ -82,15 +51,12 @@ const overlayVariants: Record<ButtonVariant, string> = {
 export function buttonClassName({
   variant = "primary",
   size = "md",
-  surface = "app",
   className,
 }: {
   variant?: ButtonVariant;
   size?: ButtonSize;
-  surface?: Surface;
   className?: string;
 } = {}): string {
-  const variants = surface === "overlay" ? overlayVariants : appVariants;
   return cn(
     "inline-flex cursor-pointer items-center justify-center border no-underline transition-colors",
     "disabled:cursor-not-allowed disabled:opacity-60",
@@ -101,22 +67,14 @@ export function buttonClassName({
 }
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
-  {
-    variant = "primary",
-    size = "md",
-    surface = "app",
-    className,
-    type = "button",
-    children,
-    ...props
-  },
+  { variant = "primary", size = "md", className, type = "button", children, ...props },
   ref,
 ) {
   return (
     <button
       ref={ref}
       type={type}
-      className={buttonClassName({ variant, size, surface, className })}
+      className={buttonClassName({ variant, size, className })}
       {...props}
     >
       {children}

--- a/packages/ui/src/components/Input.tsx
+++ b/packages/ui/src/components/Input.tsx
@@ -1,34 +1,20 @@
 import { forwardRef, type InputHTMLAttributes } from "react";
 import { cn } from "../cn";
-import type { Surface } from "../surface";
 
-export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
-  /**
-   * Token set: `app` (options + marketing, opt-*) or `overlay` (dark review UI, gr-*).
-   * Defaults to `app`.
-   */
-  surface?: Surface;
-}
+export type InputProps = InputHTMLAttributes<HTMLInputElement>;
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
-  { surface = "app", className, ...props },
+  { className, ...props },
   ref,
 ) {
   return (
     <input
       ref={ref}
       className={cn(
-        "w-full rounded-md border px-2.5 py-2 text-base",
+        "w-full rounded-md border border-border bg-surface-raised px-2.5 py-2 text-base text-foreground",
+        "placeholder:text-faint",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-primary",
         "disabled:cursor-not-allowed disabled:opacity-60",
-        surface === "overlay"
-          ? cn(
-              "border-gr-border bg-gr-bg text-gr-text placeholder:text-gr-faint",
-              "focus:border-gr-accent focus:outline-none",
-            )
-          : cn(
-              "border-opt-border bg-opt-subtle text-opt-text placeholder:text-opt-muted",
-              "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-opt-accent",
-            ),
         className,
       )}
       {...props}

--- a/packages/ui/src/components/Kbd.test.tsx
+++ b/packages/ui/src/components/Kbd.test.tsx
@@ -10,20 +10,12 @@ describe("Kbd", () => {
     expect(el).toHaveAttribute("data-slot", "kbd");
   });
 
-  it("applies overlay tokens by default", () => {
+  it("applies shared surface tokens", () => {
     render(<Kbd>Esc</Kbd>);
     const el = screen.getByText("Esc");
-    expect(el.className).toContain("border-gr-border");
-    expect(el.className).toContain("bg-gr-subtle");
-    expect(el.className).toContain("text-gr-muted");
-  });
-
-  it("applies app tokens when surface is app", () => {
-    render(<Kbd surface="app">⌘</Kbd>);
-    const el = screen.getByText("⌘");
-    expect(el.className).toContain("border-opt-border");
-    expect(el.className).toContain("bg-opt-subtle");
-    expect(el.className).toContain("text-opt-muted");
+    expect(el.className).toContain("border-border");
+    expect(el.className).toContain("bg-surface-muted");
+    expect(el.className).toContain("text-muted");
   });
 
   it("merges className", () => {

--- a/packages/ui/src/components/Kbd.tsx
+++ b/packages/ui/src/components/Kbd.tsx
@@ -1,29 +1,19 @@
 import type { ComponentProps } from "react";
 import { cn } from "../cn";
-import type { Surface } from "../surface";
 
-export type KbdProps = ComponentProps<"kbd"> & {
-  /**
-   * Token set: `app` (options + marketing, opt-*) or `overlay` (dark review UI, gr-*).
-   * Defaults to `overlay` for back-compat with existing review UI usage.
-   */
-  surface?: Surface;
-};
+export type KbdProps = ComponentProps<"kbd">;
 
 /**
  * Keyboard key badge — mirrors shadcn/ui `Kbd`.
  * @see https://ui.shadcn.com/docs/components/kbd
  */
-function Kbd({ className, surface = "overlay", ...props }: KbdProps) {
+function Kbd({ className, ...props }: KbdProps) {
   return (
     <kbd
       data-slot="kbd"
       className={cn(
-        "pointer-events-none inline-flex h-5 w-fit min-w-5 select-none items-center justify-center gap-1 rounded-sm border px-1 font-sans text-sm",
+        "pointer-events-none inline-flex h-5 w-fit min-w-5 select-none items-center justify-center gap-1 rounded-sm border border-border bg-surface-muted px-1 font-sans text-sm text-muted",
         "[&_svg:not([class*='size-'])]:size-3 opacity-75",
-        surface === "app"
-          ? "border-opt-border bg-opt-subtle text-opt-muted"
-          : "border-gr-border bg-gr-subtle text-gr-muted",
         className,
       )}
       {...props}

--- a/packages/ui/src/components/Label.tsx
+++ b/packages/ui/src/components/Label.tsx
@@ -1,24 +1,14 @@
 import type { LabelHTMLAttributes, ReactNode } from "react";
 import { cn } from "../cn";
-import type { Surface } from "../surface";
 
 export interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement> {
-  /**
-   * Token set: `app` (options + marketing, opt-*) or `overlay` (dark review UI, gr-*).
-   * Defaults to `app`.
-   */
-  surface?: Surface;
   children?: ReactNode;
 }
 
-export function Label({ surface = "app", className, children, ...props }: LabelProps) {
+export function Label({ className, children, ...props }: LabelProps) {
   return (
     <label
-      className={cn(
-        "mb-1.5 block text-base font-semibold",
-        surface === "overlay" ? "text-gr-text" : "text-opt-text",
-        className,
-      )}
+      className={cn("mb-1.5 block text-base font-semibold text-foreground", className)}
       {...props}
     >
       {children}

--- a/packages/ui/src/components/Select.tsx
+++ b/packages/ui/src/components/Select.tsx
@@ -12,7 +12,6 @@ import {
   type ReactNode,
 } from "react";
 import { cn } from "../cn";
-import type { Surface } from "../surface";
 
 export interface SelectOption<T extends string = string> {
   value: T;
@@ -39,11 +38,6 @@ export interface SelectProps<T extends string = string> {
   className?: string;
   /** Placeholder when value is not in options (should be rare after normalize). */
   placeholder?: string;
-  /**
-   * Token set: `app` (options + marketing, opt-*) or `overlay` (dark review UI, gr-*).
-   * Defaults to `app`.
-   */
-  surface?: Surface;
 }
 
 function findNextEnabled(options: SelectOption[], from: number, direction: 1 | -1): number {
@@ -71,7 +65,6 @@ export function Select<T extends string = string>({
   disabled = false,
   className,
   placeholder = "Select…",
-  surface = "app",
 }: SelectProps<T>) {
   const listboxId = useId();
   const rootRef = useRef<HTMLDivElement>(null);
@@ -219,8 +212,6 @@ export function Select<T extends string = string>({
   const activeDescendant =
     open && highlightIndex >= 0 ? `${listboxId}-opt-${highlightIndex}` : undefined;
 
-  const isApp = surface === "app";
-
   return (
     <div ref={rootRef} className={cn("relative", className)}>
       <button
@@ -236,17 +227,9 @@ export function Select<T extends string = string>({
         aria-label={ariaLabel}
         disabled={disabled}
         className={cn(
-          "flex w-full items-center gap-2 rounded-md border px-2.5 py-2 text-left text-base",
+          "flex w-full items-center gap-2 rounded-md border border-border bg-surface-raised px-2.5 py-2 text-left text-base text-foreground",
+          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-primary",
           "disabled:cursor-not-allowed disabled:opacity-60",
-          isApp
-            ? cn(
-                "border-opt-border bg-opt-subtle text-opt-text",
-                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-opt-accent",
-              )
-            : cn(
-                "border-gr-border bg-gr-bg text-gr-text",
-                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-gr-accent",
-              ),
         )}
         onClick={() => (open ? close(true) : openList())}
         onKeyDown={onTriggerKeyDown}
@@ -259,14 +242,13 @@ export function Select<T extends string = string>({
               selected.label
             )
           ) : (
-            <span className={isApp ? "text-opt-muted" : "text-gr-muted"}>{placeholder}</span>
+            <span className="text-muted">{placeholder}</span>
           )}
         </span>
         <svg
           aria-hidden
           className={cn(
-            "h-3.5 w-3.5 shrink-0 transition-transform",
-            isApp ? "text-opt-muted" : "text-gr-muted",
+            "h-3.5 w-3.5 shrink-0 text-muted transition-transform",
             open && "rotate-180",
           )}
           viewBox="0 0 16 16"
@@ -289,12 +271,7 @@ export function Select<T extends string = string>({
           role="listbox"
           tabIndex={-1}
           aria-labelledby={ariaLabelledBy}
-          className={cn(
-            "absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-md border py-1 shadow-md",
-            isApp
-              ? "border-opt-border bg-opt-bg text-opt-text"
-              : "border-gr-border bg-gr-chrome text-gr-text",
-          )}
+          className="absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-md border border-border bg-background py-1 text-foreground shadow-md"
           onKeyDown={onListKeyDown}
         >
           {options.map((opt, index) => {
@@ -309,7 +286,7 @@ export function Select<T extends string = string>({
                 aria-disabled={opt.disabled || undefined}
                 className={cn(
                   "flex cursor-pointer items-center gap-2 px-2.5 py-1.5 text-base",
-                  isHighlighted && (isApp ? "bg-opt-subtle" : "bg-gr-subtle"),
+                  isHighlighted && "bg-surface-muted",
                   isSelected && "font-semibold",
                   opt.disabled && "cursor-not-allowed opacity-50",
                 )}

--- a/packages/ui/src/components/Spinner.tsx
+++ b/packages/ui/src/components/Spinner.tsx
@@ -1,34 +1,20 @@
 import { cn } from "../cn";
-import type { Surface } from "../surface";
 
 interface SpinnerProps {
   /** Accessible label announced to screen readers. */
   label?: string;
   /** Visual size in pixels. Defaults to 24. */
   size?: number;
-  /**
-   * Token set: `app` (options + marketing) or `overlay` (dark review UI).
-   * Defaults to `overlay` for back-compat with existing overlay usage.
-   */
-  surface?: Surface;
   className?: string;
 }
 
-export function Spinner({
-  label = "Loading",
-  size = 24,
-  surface = "overlay",
-  className,
-}: SpinnerProps) {
+export function Spinner({ label = "Loading", size = 24, className }: SpinnerProps) {
   const thin = size <= 16;
   return (
     <span
       className={cn(
-        "inline-block shrink-0 animate-gr-spin rounded-full border-solid",
+        "inline-block shrink-0 animate-gr-spin rounded-full border-solid border-border border-t-primary",
         thin ? "border-2" : "border-[3px]",
-        surface === "app"
-          ? "border-opt-border border-t-opt-text"
-          : "border-gr-border border-t-gr-accent",
         className,
       )}
       role="status"

--- a/packages/ui/src/components/Textarea.tsx
+++ b/packages/ui/src/components/Textarea.tsx
@@ -1,34 +1,20 @@
 import { forwardRef, type TextareaHTMLAttributes } from "react";
 import { cn } from "../cn";
-import type { Surface } from "../surface";
 
-export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
-  /**
-   * Token set: `app` (options + marketing, opt-*) or `overlay` (dark review UI, gr-*).
-   * Defaults to `app`.
-   */
-  surface?: Surface;
-}
+export type TextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
-  { surface = "app", className, ...props },
+  { className, ...props },
   ref,
 ) {
   return (
     <textarea
       ref={ref}
       className={cn(
-        "min-h-[88px] w-full resize-y rounded-md border px-3 py-2 font-sans text-base leading-relaxed",
+        "min-h-[88px] w-full resize-y rounded-md border border-border bg-surface-raised px-3 py-2 font-sans text-base leading-relaxed text-foreground",
+        "placeholder:text-faint",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-primary",
         "disabled:cursor-not-allowed disabled:opacity-60",
-        surface === "overlay"
-          ? cn(
-              "border-gr-border bg-gr-bg text-gr-text placeholder:text-gr-faint",
-              "focus:border-gr-accent focus:outline-none",
-            )
-          : cn(
-              "border-opt-border bg-opt-subtle text-opt-text placeholder:text-opt-muted",
-              "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-opt-accent",
-            ),
         className,
       )}
       {...props}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,6 +1,5 @@
 export { cn } from "./cn";
 export { isMacPlatform } from "./platform";
-export type { Surface } from "./surface";
 
 export { Spinner } from "./components/Spinner";
 export { Kbd, KbdGroup } from "./components/Kbd";

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -2,57 +2,59 @@
  * Shared Tailwind entry + design tokens.
  * App customizations/overrides live in SCSS; this file exists because
  * Tailwind v4's @import / @theme are CSS-first.
+ *
+ * Single dark palette for marketing, options, welcome, and review overlay.
+ * Utilities: bg-background, text-foreground, border-border, bg-primary, …
+ * Raw CSS: var(--color-background), var(--color-primary), …
  */
 @import "tailwindcss";
 
 @theme {
-  /* Overlay (dark-only) surface hierarchy */
-  --color-gr-chrome: #0d0806;
-  --color-gr-bg: #110e0b;
-  --color-gr-canvas: #16120f;
-  --color-gr-subtle: #1c1814;
-  /* Borders ≥ 3:1 against gr-bg/gr-chrome for WCAG 1.4.11 UI contrast */
-  --color-gr-border: #312d29;
-  --color-gr-border-muted: #4a433c;
-  --color-gr-text: #fefefe;
-  --color-gr-muted: #fefefea1;
-  /* ≥ 4.5:1 on gr-bg for normal text (line numbers, placeholders) */
-  --color-gr-faint: #768088;
-  --color-gr-accent: #caff57;
-  --color-gr-accent-hover: #b6e64e;
-  --color-gr-accent-on: #0d0806;
-  --color-gr-accent-subtle: #1a2408;
-  --color-gr-danger: #ff7b72;
-  --color-gr-danger-subtle: #3d0f0f;
-  --color-gr-add-bg: #0f2c1d;
-  --color-gr-add-text: #56d364;
-  --color-gr-del-bg: #2d1416;
-  --color-gr-del-text: #ff7b72;
+  /* Surface ladder (dark → elevated) */
+  --color-background: #0d0806;
+  --color-surface: #110e0b;
+  --color-surface-raised: #16120f;
+  --color-surface-muted: #1c1814;
+
+  /* Text */
+  --color-foreground: #fefefe;
+  --color-muted: #fefefea1;
+  /* ≥ 4.5:1 on surface for normal text (line numbers, placeholders) */
+  --color-faint: #768088;
+
+  /* Borders ≥ 3:1 against background/surface for WCAG 1.4.11 UI contrast */
+  --color-border: #312d29;
+  --color-border-strong: #4a433c;
+
+  /* Brand (lime) */
+  --color-primary: #caff57;
+  --color-primary-hover: #b6e64e;
+  --color-primary-foreground: #0d0806;
+  --color-primary-muted: #1a2408;
+
+  /* Status */
+  --color-success: #3fb950;
+  --color-danger: #ff7b72;
+  --color-danger-muted: #3d0f0f;
+
+  /* Diff (overlay + illustrations) */
+  --color-diff-add-bg: #0f2c1d;
+  --color-diff-add: #56d364;
+  --color-diff-del-bg: #2d1416;
+  --color-diff-del: #ff7b72;
 
   /* highlight.js / syntax (consumed by SCSS) */
-  --color-gr-syntax-comment: #8b949e;
-  --color-gr-syntax-keyword: #ff7b72;
-  --color-gr-syntax-entity: #d2a8ff;
-  --color-gr-syntax-string: #a5d6ff;
-  --color-gr-syntax-variable: #ffa657;
-  --color-gr-syntax-constant: #79c0ff;
-  --color-gr-syntax-tag: #7ee787;
-  --color-gr-syntax-attr: #79c0ff;
-  --color-gr-syntax-meta: #8b949e;
-  --color-gr-syntax-deleted: #ffdcd7;
-  --color-gr-syntax-inserted: #aff5b4;
-
-  /* Options + marketing surfaces (dark-only) */
-  --color-opt-bg: var(--opt-bg);
-  --color-opt-subtle: var(--opt-subtle);
-  --color-opt-border: var(--opt-border);
-  --color-opt-text: var(--opt-text);
-  --color-opt-muted: var(--opt-muted);
-  --color-opt-accent: var(--opt-accent);
-  --color-opt-accent-hover: var(--opt-accent-hover);
-  --color-opt-accent-on: var(--opt-accent-on);
-  --color-opt-ok: var(--opt-ok);
-  --color-opt-error: var(--opt-error);
+  --color-syntax-comment: #8b949e;
+  --color-syntax-keyword: #ff7b72;
+  --color-syntax-entity: #d2a8ff;
+  --color-syntax-string: #a5d6ff;
+  --color-syntax-variable: #ffa657;
+  --color-syntax-constant: #79c0ff;
+  --color-syntax-tag: #7ee787;
+  --color-syntax-attr: #79c0ff;
+  --color-syntax-meta: #8b949e;
+  --color-syntax-deleted: #ffdcd7;
+  --color-syntax-inserted: #aff5b4;
 
   --font-sans:
     system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
@@ -83,20 +85,8 @@
   }
 }
 
-/* Options + marketing tokens (dark-only; referenced by @theme above) */
 :root {
   color-scheme: dark;
-  --opt-bg: #0d0806;
-  --opt-subtle: #16120f;
-  /* ≥ 3:1 against opt-bg for control borders (1.4.11) */
-  --opt-border: #312d29;
-  --opt-text: #fefefe;
-  --opt-muted: #fefefea1;
-  --opt-accent: #caff57;
-  --opt-accent-hover: #b6e64e;
-  --opt-accent-on: #0d0806;
-  --opt-ok: #3fb950;
-  --opt-error: #ff7b72;
 }
 
 /* WCAG 2.3.3 — respect reduced-motion preference (overlay + options import this file) */

--- a/packages/ui/src/surface.ts
+++ b/packages/ui/src/surface.ts
@@ -1,2 +1,0 @@
-/** Visual token set for shared controls. */
-export type Surface = "app" | "overlay";


### PR DESCRIPTION
## Summary

- Replace parallel `opt-*` (options/marketing) and `gr-*` (overlay) color tokens with one semantic dark palette in `@guided-review/ui/theme.css` (`background`, `surface*`, `foreground`/`muted`/`faint`, `border*`, `primary*`, `success`/`danger`, `diff-*`, `syntax-*`).
- Remove the `surface?: "app" | "overlay"` prop and dual style tables from shared UI components (`Button`, `Input`, `Select`, etc.).
- Migrate extension overlay, options, welcome, and marketing site to the new utilities / `var(--color-*)` names.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (extension + ui)
- [x] `npm run build:extension`
- [x] `npm run build:web`
- [ ] Spot-check options, welcome, marketing header/CTAs, and review overlay (chrome, diff colors, syntax)