### PR TITLE
fix(extension): skip Start Guided Review on conflict resolution page

### DIFF
--- a/apps/extension/src/content/index.tsx
+++ b/apps/extension/src/content/index.tsx
@@ -1,6 +1,7 @@
 import { createRoot } from "react-dom/client";
 import { getAutoOpenOnFilesTab, onAutoOpenOnFilesTabChanged } from "../lib/autoOpenOnFilesTab";
 import { parsePRUrl, type PRIdentity } from "../lib/github/diffFetch";
+import { isIgnoredPrPath } from "../lib/github/ignoredPrPaths";
 import { fetchConversationDescription, scrapePRContext } from "../lib/github/prContext";
 import { requestPRDiff, streamReviewPlan } from "../lib/messaging";
 import { getProviderSettings, onProviderSettingsChanged } from "../lib/settings";
@@ -123,8 +124,9 @@ function removeStartButton(): void {
 
 function tryInjectButton(): void {
   const pr = parsePRUrl(window.location.href);
-  // Content script matches all github.com; tear down UI when the SPA leaves a PR.
-  if (!pr) {
+  // Content script matches all github.com; tear down UI when the SPA leaves a PR,
+  // or lands on a PR surface we intentionally skip (e.g. conflict resolution).
+  if (!pr || isIgnoredPrPath(window.location.pathname)) {
     removeStartButton();
     return;
   }
@@ -252,6 +254,7 @@ function retryAnnotation(): void {
 async function onStartReview(): Promise<void> {
   // Prefer the cached identity from button injection; re-parse the URL so a
   // toolbar-icon click still works if the button hasn't painted yet.
+  if (isIgnoredPrPath(window.location.pathname)) return;
   const pr = currentPR ?? parsePRUrl(window.location.href);
   if (!pr) return;
   currentPR = pr;

--- a/apps/extension/src/lib/github/ignoredPrPaths.test.ts
+++ b/apps/extension/src/lib/github/ignoredPrPaths.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { isIgnoredPrPath } from "./ignoredPrPaths";
+
+describe("isIgnoredPrPath", () => {
+  it("matches the conflicts resolution path", () => {
+    expect(isIgnoredPrPath("/acme/widgets/pull/1/conflicts")).toBe(true);
+    expect(isIgnoredPrPath("/acme/widgets/pull/42/conflicts")).toBe(true);
+  });
+
+  it("matches trailing slash and nested segments under conflicts", () => {
+    expect(isIgnoredPrPath("/acme/widgets/pull/1/conflicts/")).toBe(true);
+    expect(isIgnoredPrPath("/acme/widgets/pull/1/conflicts/file.ts")).toBe(true);
+  });
+
+  it("does not match conversation or other PR tabs", () => {
+    expect(isIgnoredPrPath("/acme/widgets/pull/1")).toBe(false);
+    expect(isIgnoredPrPath("/acme/widgets/pull/1/")).toBe(false);
+    expect(isIgnoredPrPath("/acme/widgets/pull/1/files")).toBe(false);
+    expect(isIgnoredPrPath("/acme/widgets/pull/1/changes")).toBe(false);
+    expect(isIgnoredPrPath("/acme/widgets/pull/1/commits")).toBe(false);
+    expect(isIgnoredPrPath("/acme/widgets/pull/1/checks")).toBe(false);
+  });
+
+  it("does not match lookalike path segments", () => {
+    expect(isIgnoredPrPath("/acme/widgets/pull/1/conflictsx")).toBe(false);
+    expect(isIgnoredPrPath("/acme/widgets/pull/1/xconflicts")).toBe(false);
+  });
+
+  it("does not match non-PR paths", () => {
+    expect(isIgnoredPrPath("/acme/widgets/issues/1/conflicts")).toBe(false);
+    expect(isIgnoredPrPath("/conflicts")).toBe(false);
+    expect(isIgnoredPrPath("/")).toBe(false);
+  });
+});

--- a/apps/extension/src/lib/github/ignoredPrPaths.ts
+++ b/apps/extension/src/lib/github/ignoredPrPaths.ts
@@ -1,0 +1,21 @@
+/**
+ * Path segments under `/pull/:n/<segment>` where we never inject Start Guided
+ * Review (and should not start a review from other entry points).
+ *
+ * Append more segments here as we find PR surfaces that are not suitable for
+ * guided review (e.g. specialized editors).
+ */
+export const IGNORED_PR_PATH_SEGMENTS = ["conflicts"] as const;
+
+const IGNORED_SET = new Set<string>(IGNORED_PR_PATH_SEGMENTS);
+
+/**
+ * True when `pathname` is a PR sub-path we should not surface the start button
+ * on (e.g. `…/pull/42/conflicts`). Optional trailing segments are ignored.
+ */
+export function isIgnoredPrPath(pathname: string): boolean {
+  const normalized = pathname.replace(/\/+$/, "") || "/";
+  const match = /\/pull\/\d+\/([^/]+)/.exec(normalized);
+  if (!match) return false;
+  return IGNORED_SET.has(match[1]);
+}

--- a/apps/extension/src/popup/main.ts
+++ b/apps/extension/src/popup/main.ts
@@ -1,9 +1,12 @@
 import { parsePRUrl } from "../lib/github/diffFetch";
+import { isIgnoredPrPath } from "../lib/github/ignoredPrPaths";
 import type { StartGuidedReviewMessage } from "../lib/types";
 import "./popup.css";
 
 const NOT_ON_PR = "Open a GitHub pull request page to start a review.";
 const RELOAD_PR = "Reload this pull request page, then try again.";
+const IGNORED_PR_PATH =
+  "Guided Review is not available on this pull request page (for example, conflict resolution).";
 
 /** Path registered as `options_page` in the manifest (stable across builds). */
 const OPTIONS_PAGE = "src/options/index.html";
@@ -35,9 +38,15 @@ async function init(): Promise<void> {
 
   const tab = await getActiveTab();
   const tabId = tab?.id;
-  const pr = tab?.url ? parsePRUrl(tab.url) : null;
+  const tabUrl = tab?.url;
+  const pr = tabUrl ? parsePRUrl(tabUrl) : null;
 
-  if (tabId != null && pr) {
+  if (tabId != null && pr && tabUrl) {
+    if (isIgnoredPrPath(new URL(tabUrl).pathname)) {
+      showMessage(root, messageEl, IGNORED_PR_PATH);
+      return;
+    }
+
     const message: StartGuidedReviewMessage = { type: "START_GUIDED_REVIEW" };
     try {
       await chrome.tabs.sendMessage(tabId, message);


### PR DESCRIPTION
## Summary
- Add an extensible `IGNORED_PR_PATH_SEGMENTS` list (currently `conflicts`) and `isIgnoredPrPath()` helper.
- Skip / tear down the Start Guided Review button when the SPA is on an ignored PR path.
- Block starting a review from the toolbar popup on those paths with a clear message.

## Test plan
- [ ] Unit tests: `npm test --workspace=@guided-review/extension -- src/lib/github/ignoredPrPaths.test.ts`
- [ ] Build extension, reload unpacked from `apps/extension/dist`
- [ ] On a PR conversation/files tab: Start Guided Review button still appears
- [ ] On `/pull/:n/conflicts`: button is not injected
- [ ] SPA navigate conversation → conflicts: button is removed
- [ ] SPA navigate conflicts → files: button returns
- [ ] Toolbar icon on conflicts page shows “not available” message instead of opening review