### PR TITLE
ci: auto-fix lint and format on CI and commit to branch

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -108,11 +108,9 @@ jobs:
         if: >
           github.event_name == 'push' ||
           github.event.pull_request.head.repo.full_name == github.repository
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "style: auto-fix lint and format"
-          commit_user_name: github-actions[bot]
-          commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com
 
       # Hard gates: fail on remaining (non-auto-fixable) issues after any commit.
       - name: Lint

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -65,8 +65,16 @@ jobs:
   lint:
     name: Lint and typecheck
     runs-on: ubuntu-latest
+    # Write so auto-fixed lint/format can be committed back to the PR branch.
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          # PR: head branch. Push: branch name. Avoids the PR merge commit so
+          # autofix commits land on the contributor branch.
+          ref: ${{ github.head_ref || github.ref_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:
@@ -76,6 +84,37 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Apply what tools can fix; continue so unfixable ESLint errors still
+      # allow Prettier to run and partial fixes to be committed.
+      - name: Apply ESLint autofixes
+        continue-on-error: true
+        run: npm run lint:fix
+
+      - name: Apply Prettier
+        run: npm run format
+
+      # GITHUB_TOKEN cannot push to fork heads; fail clearly if a commit is needed.
+      - name: Fail fork PRs that need autofix commit
+        if: >
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::Lint/format issues are auto-fixable, but this is a fork PR so CI cannot push. Run: npm run lint:fix && npm run format"
+            exit 1
+          fi
+
+      - name: Commit autofixes
+        if: >
+          github.event_name == 'push' ||
+          github.event.pull_request.head.repo.full_name == github.repository
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "style: auto-fix lint and format"
+          commit_user_name: github-actions[bot]
+          commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com
+
+      # Hard gates: fail on remaining (non-auto-fixable) issues after any commit.
       - name: Lint
         run: npm run lint
 


### PR DESCRIPTION
## Summary

- In the Lint and typecheck job, run `eslint --fix` and `prettier --write` before the hard checks.
- When the working tree changes on a same-repo PR or push, commit and push with `style: auto-fix lint and format` via `git-auto-commit-action`.
- Re-run strict `lint`, `format:check`, and `typecheck` so remaining (non-auto-fixable) issues still fail the job.
- Fork PRs that would need a commit fail with a clear local-fix message (GITHUB_TOKEN cannot push to forks).

## Notes

- Job grants `contents: write` only on the lint job; other jobs stay read-only.
- Checkout uses the PR head / branch ref so autofix commits land on the contributor branch.
- If branch protection blocks `GITHUB_TOKEN` pushes, allow GitHub Actions to push to those branches.

## Test plan

- [ ] Open a same-repo PR that only has Prettier/ESLint-fixable drift; confirm CI commits a style fix and a follow-up run is green.
- [ ] Open a PR with a real unfixable ESLint error; confirm the job still fails after any partial autofix.
- [ ] Confirm fork PRs that need autofix fail with the documented local command.
- [ ] Confirm a clean PR does not produce an empty autofix commit.