### PR TITLE
feat(extension): separate tests units and tighten review plan consistency

### DIFF
--- a/apps/extension/e2e/overlay.spec.ts
+++ b/apps/extension/e2e/overlay.spec.ts
@@ -29,6 +29,7 @@ const CANNED_PLAN: ReviewPlan = {
     {
       id: "u1",
       title: "Update foo's exported constant",
+      kind: "change",
       context: "Bumping const b to 3 and adding const c, per the PR description.",
       files: [{ fileId: "src/foo.ts", hunkIds: ["src/foo.ts#0"], role: "core_logic" }],
     },

--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -34,7 +34,11 @@ import { fetchPRDiff } from "../lib/github/diffFetch";
 import { submitPullRequestReview } from "../lib/github/submitReview";
 import { chunkDiffByFile } from "../lib/review/buildPrompt";
 import { StreamPlanParser } from "../lib/review/streamPlanParser";
-import { prefixChunkUnitId, validateAndCleanUnit } from "../lib/review/reviewPlan";
+import {
+  prefixChunkUnitId,
+  stripDuplicateHunks,
+  validateAndCleanUnit,
+} from "../lib/review/reviewPlan";
 import { getProviderSettings } from "../lib/settings";
 import { getProviderClient } from "./providers";
 import { ProviderError } from "./providers/types";
@@ -218,6 +222,8 @@ async function handleAnnotateReviewStream(
   const client = getProviderClient(settings.provider);
   const chunks = chunkDiffByFile(request.diff);
   const allUnits: ReviewUnit[] = [];
+  /** First unit that claims a hunk id wins; later duplicates are stripped. */
+  const seenHunkIds = new Set<string>();
 
   let chunkIndex = 0;
   for (const chunk of chunks) {
@@ -236,14 +242,14 @@ async function handleAnnotateReviewStream(
       if (event.type === "text_delta") {
         const rawUnits = parser.push(event.text);
         for (const raw of rawUnits) {
-          emitUnit(raw, knownFiles, chunkIndex, allUnits, port, signal);
+          emitUnit(raw, knownFiles, chunkIndex, allUnits, seenHunkIds, port, signal);
         }
       }
 
       if (event.type === "done") {
         const remaining = parser.finish();
         for (const raw of remaining) {
-          emitUnit(raw, knownFiles, chunkIndex, allUnits, port, signal);
+          emitUnit(raw, knownFiles, chunkIndex, allUnits, seenHunkIds, port, signal);
         }
       }
     }
@@ -262,17 +268,23 @@ function emitUnit(
   knownFiles: Map<string, DiffFile>,
   chunkIndex: number,
   allUnits: ReviewUnit[],
+  seenHunkIds: Set<string>,
   port: chrome.runtime.Port,
   signal: AbortSignal,
 ): void {
   if (signal.aborted) return;
 
-  const cleaned = validateAndCleanUnit(raw, knownFiles);
-  if (!cleaned) return;
+  const cleanedUnits = validateAndCleanUnit(raw, knownFiles);
+  for (const cleaned of cleanedUnits) {
+    if (signal.aborted) return;
 
-  const unit: ReviewUnit = { ...cleaned, id: prefixChunkUnitId(chunkIndex, cleaned.id) };
-  allUnits.push(unit);
-  postEvent(port, { type: "UNIT", unit });
+    const deduped = stripDuplicateHunks(cleaned, knownFiles, seenHunkIds);
+    if (!deduped) continue;
+
+    const unit: ReviewUnit = { ...deduped, id: prefixChunkUnitId(chunkIndex, deduped.id) };
+    allUnits.push(unit);
+    postEvent(port, { type: "UNIT", unit });
+  }
 }
 
 function postEvent(port: chrome.runtime.Port, event: AnnotateReviewStreamEvent): void {

--- a/apps/extension/src/content/index.test.tsx
+++ b/apps/extension/src/content/index.test.tsx
@@ -156,7 +156,9 @@ describe("content script review orchestration", () => {
     await chrome.storage.session.set({
       [SESSION_KEY]: {
         diff: diffFixture(),
-        plan: { units: [{ id: "u1", title: "Saved unit", context: "why", files: [] }] },
+        plan: {
+          units: [{ id: "u1", title: "Saved unit", kind: "change", context: "why", files: [] }],
+        },
         prContext: null,
         currentUnitIndex: 1,
         draftComments: [],

--- a/apps/extension/src/content/overlay/Overlay.test.tsx
+++ b/apps/extension/src/content/overlay/Overlay.test.tsx
@@ -60,6 +60,7 @@ function planFixture(): ReviewPlan {
       {
         id: "u1",
         title: "Update foo",
+        kind: "change",
         context: "because it needed updating",
         files: [{ fileId: "src/foo.ts", hunkIds: ["src/foo.ts#0"], role: "core_logic" }],
       },

--- a/apps/extension/src/content/overlay/Overlay.tsx
+++ b/apps/extension/src/content/overlay/Overlay.tsx
@@ -317,6 +317,7 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
             <DiffPane
               files={resolvedFiles}
               unitTitle={currentReviewUnit?.title ?? ""}
+              isTestsUnit={currentReviewUnit?.kind === "tests"}
               unitId={currentReviewUnit?.id}
               selectableForUnit={selectableForUnit}
               searchScrollTarget={searchScrollTarget}

--- a/apps/extension/src/content/overlay/components/DiffPane.tsx
+++ b/apps/extension/src/content/overlay/components/DiffPane.tsx
@@ -11,6 +11,7 @@ import { BinaryElidedEmptyState } from "./diff/BinaryElidedEmptyState";
 import { SplitHunk } from "./diff/SplitHunk";
 import { UnifiedHunk } from "./diff/UnifiedHunk";
 import { useSelectionDerived } from "./diff/useSelectionDerived";
+import { TestsUnitIcon } from "./TestsUnitIcon";
 
 /** How long the search-match flash highlight stays on the target line/file. */
 const SEARCH_HIGHLIGHT_MS = 1600;
@@ -19,6 +20,8 @@ interface DiffPaneProps {
   files: ResolvedUnitFile[];
   /** Title of the currently active review unit. */
   unitTitle: string;
+  /** When true, show the flask icon (tests review unit). */
+  isTestsUnit?: boolean;
   /** Review unit id for associating saved drafts. */
   unitId?: string;
   /**
@@ -35,6 +38,7 @@ interface DiffPaneProps {
 export function DiffPane({
   files,
   unitTitle,
+  isTestsUnit = false,
   unitId,
   selectableForUnit,
   searchScrollTarget = null,
@@ -149,11 +153,12 @@ export function DiffPane({
       </div>
       <div className="mb-4 flex items-center justify-between gap-4">
         <h2
-          className="min-w-0 truncate text-lg font-semibold text-foreground"
+          className="flex min-w-0 items-center gap-1.5 text-lg font-semibold text-foreground"
           data-testid="diff-unit-title"
           title={unitTitle}
         >
-          {unitTitle}
+          {isTestsUnit && <TestsUnitIcon className="shrink-0 text-muted" size={16} />}
+          <span className="min-w-0 truncate">{unitTitle}</span>
         </h2>
         <div className="flex shrink-0 items-center gap-2">
           {commentModeActive ? (

--- a/apps/extension/src/content/overlay/components/Sidebar.test.tsx
+++ b/apps/extension/src/content/overlay/components/Sidebar.test.tsx
@@ -8,6 +8,7 @@ function planWithUnits(count: number): ReviewPlan {
     units: Array.from({ length: count }, (_, i) => ({
       id: `u${i + 1}`,
       title: `Unit ${i + 1}`,
+      kind: "change" as const,
       context: `Context for unit ${i + 1}`,
       files: [],
     })),
@@ -88,5 +89,34 @@ describe("Sidebar", () => {
     );
 
     expect(screen.queryAllByTestId("unit-skeleton")).toHaveLength(0);
+  });
+
+  it("shows a flask icon only on tests units", () => {
+    const plan: ReviewPlan = {
+      units: [
+        {
+          id: "c1",
+          title: "Add feature",
+          kind: "change",
+          context: "why",
+          files: [],
+        },
+        {
+          id: "t1",
+          title: "Tests for Add feature",
+          kind: "tests",
+          context: "why",
+          files: [],
+        },
+      ],
+    };
+
+    render(
+      <Sidebar plan={plan} currentUnitIndex={1} stillBuilding={false} onSelectUnit={() => {}} />,
+    );
+
+    expect(screen.getAllByTestId("unit-tests-icon")).toHaveLength(1);
+    expect(screen.getByText("Tests for Add feature")).toBeInTheDocument();
+    expect(screen.getByText("Add feature")).toBeInTheDocument();
   });
 });

--- a/apps/extension/src/content/overlay/components/Sidebar.tsx
+++ b/apps/extension/src/content/overlay/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import type { ReviewPlan } from "../../../lib/types";
 import { cn } from "@guided-review/ui";
 import { buildDisplayUnits } from "../displayUnits";
+import { TestsUnitIcon } from "./TestsUnitIcon";
 
 const SKELETON_COUNT = 4;
 
@@ -39,6 +40,7 @@ export function Sidebar({ plan, currentUnitIndex, stillBuilding, onSelectUnit }:
 
         {displayUnits.map((unit, displayIndex) => {
           const isActive = displayIndex === currentUnitIndex;
+          const isTestsUnit = unit.kind === "review" && unit.unit.kind === "tests";
           return (
             <button
               key={unit.id}
@@ -46,15 +48,20 @@ export function Sidebar({ plan, currentUnitIndex, stillBuilding, onSelectUnit }:
               ref={isActive ? activeItemRef : undefined}
               aria-current={isActive ? "true" : undefined}
               className={cn(
-                "mb-0.5 block w-full cursor-pointer rounded-md border-none bg-transparent p-2 text-left text-base leading-snug text-foreground",
+                "mb-0.5 flex w-full cursor-pointer items-start rounded-md border-none bg-transparent p-2 text-left text-base leading-snug text-foreground",
                 isActive && "bg-primary-muted text-primary! hover:bg-primary-muted",
               )}
               onClick={() => onSelectUnit(displayIndex)}
             >
-              <span className={cn("mr-1.5", isActive ? "text-primary" : "text-muted")}>
+              <span className={cn("mr-1.5 shrink-0", isActive ? "text-primary" : "text-muted")}>
                 {displayIndex + 1}.
               </span>
-              {unit.title}
+              {isTestsUnit && (
+                <TestsUnitIcon
+                  className={cn("mr-1.5 mt-0.5 shrink-0", isActive ? "text-primary" : "text-muted")}
+                />
+              )}
+              <span className="min-w-0">{unit.title}</span>
             </button>
           );
         })}

--- a/apps/extension/src/content/overlay/components/TestsUnitIcon.tsx
+++ b/apps/extension/src/content/overlay/components/TestsUnitIcon.tsx
@@ -1,0 +1,26 @@
+/** Flask mark for `kind: "tests"` review units — filled via currentColor. */
+export function TestsUnitIcon({
+  className,
+  size = 14,
+  "data-testid": testId = "unit-tests-icon",
+}: {
+  className?: string;
+  size?: number;
+  "data-testid"?: string;
+}) {
+  return (
+    <svg
+      className={className}
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      data-testid={testId}
+    >
+      {/* Simple flask: neck + bulb */}
+      <path d="M6.25 1.5a.75.75 0 0 0 0 1.5h.5v3.38L3.22 12.1A2 2 0 0 0 4.9 15h6.2a2 2 0 0 0 1.68-2.9L9.25 6.38V3h.5a.75.75 0 0 0 0-1.5h-3.5ZM7.75 6.9l3.35 5.58a.5.5 0 0 1-.42.72H5.32a.5.5 0 0 1-.42-.72L8.25 6.9V3h-.5v3.9Z" />
+    </svg>
+  );
+}

--- a/apps/extension/src/content/overlay/diffSearch/findUnitForFile.test.ts
+++ b/apps/extension/src/content/overlay/diffSearch/findUnitForFile.test.ts
@@ -8,6 +8,7 @@ function planFixture(): ReviewPlan {
       {
         id: "u0",
         title: "Auth",
+        kind: "change",
         context: "login flow",
         files: [
           { fileId: "src/auth/login.ts", hunkIds: ["src/auth/login.ts#0"], role: "core_logic" },
@@ -15,12 +16,17 @@ function planFixture(): ReviewPlan {
       },
       {
         id: "u1",
-        title: "Utils + tests",
+        title: "Utils",
+        kind: "change",
         context: "helpers",
-        files: [
-          { fileId: "src/utils/format.ts", hunkIds: [], role: "core_logic" },
-          { fileId: "src/auth/login.ts", hunkIds: ["src/auth/login.ts#1"], role: "test" },
-        ],
+        files: [{ fileId: "src/utils/format.ts", hunkIds: [], role: "core_logic" }],
+      },
+      {
+        id: "u2",
+        title: "Tests for Auth",
+        kind: "tests",
+        context: "login tests",
+        files: [{ fileId: "src/auth/login.ts", hunkIds: ["src/auth/login.ts#1"], role: "test" }],
       },
     ],
   };
@@ -41,8 +47,8 @@ describe("findUnitForFile", () => {
   });
 
   it("prefers the unit that owns the specific hunk when provided", () => {
-    // login.ts#1 is only on u1 → display index 2
-    expect(findUnitForFile(planFixture(), "src/auth/login.ts", "src/auth/login.ts#1")).toBe(2);
+    // login.ts#1 is only on the tests unit → display index 3
+    expect(findUnitForFile(planFixture(), "src/auth/login.ts", "src/auth/login.ts#1")).toBe(3);
     // login.ts#0 is on u0 → display index 1
     expect(findUnitForFile(planFixture(), "src/auth/login.ts", "src/auth/login.ts#0")).toBe(1);
   });

--- a/apps/extension/src/content/overlay/displayUnits.test.ts
+++ b/apps/extension/src/content/overlay/displayUnits.test.ts
@@ -4,8 +4,8 @@ import type { ReviewPlan } from "../../lib/types";
 
 const plan: ReviewPlan = {
   units: [
-    { id: "u1", title: "One", context: "c1", files: [] },
-    { id: "u2", title: "Two", context: "c2", files: [] },
+    { id: "u1", title: "One", kind: "change", context: "c1", files: [] },
+    { id: "u2", title: "Two", kind: "tests", context: "c2", files: [] },
   ],
 };
 

--- a/apps/extension/src/content/overlay/store.test.ts
+++ b/apps/extension/src/content/overlay/store.test.ts
@@ -12,6 +12,7 @@ function planFixture(unitCount: number): ReviewPlan {
     units: Array.from({ length: unitCount }, (_, i) => ({
       id: `u${i}`,
       title: `Unit ${i}`,
+      kind: "change" as const,
       context: "because",
       files: [],
     })),

--- a/apps/extension/src/lib/messaging.test.ts
+++ b/apps/extension/src/lib/messaging.test.ts
@@ -58,6 +58,7 @@ describe("messaging", () => {
     const unit: ReviewUnit = {
       id: "c0-u1",
       title: "Update foo",
+      kind: "change",
       context: "because",
       files: [{ fileId: "src/foo.ts", hunkIds: [], role: "core_logic" }],
     };

--- a/apps/extension/src/lib/review/buildPrompt.test.ts
+++ b/apps/extension/src/lib/review/buildPrompt.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildUserPrompt, chunkDiffByFile } from "./buildPrompt";
+import { buildUserPrompt, chunkDiffByFile, SYSTEM_PROMPT } from "./buildPrompt";
 import type { DiffFile, ParsedDiff, PRContext } from "../types";
 
 function fileFixture(path: string, extraLineCount = 0): DiffFile {
@@ -65,6 +65,15 @@ describe("chunkDiffByFile", () => {
   });
 });
 
+describe("SYSTEM_PROMPT", () => {
+  it("requires separate tests units and consistency rules", () => {
+    expect(SYSTEM_PROMPT).toContain('kind "tests"');
+    expect(SYSTEM_PROMPT.toLowerCase()).toContain("never mix");
+    expect(SYSTEM_PROMPT).toContain("exactly one");
+    expect(SYSTEM_PROMPT).toContain("model-first");
+  });
+});
+
 describe("buildUserPrompt", () => {
   const prContext: PRContext = {
     owner: "acme",
@@ -114,6 +123,14 @@ describe("buildUserPrompt", () => {
     const prompt = buildUserPrompt({ files: [fileFixture("src/foo.ts")] }, prContext);
     expect(prompt).toContain("[hunk id: src/foo.ts#0]");
     expect(prompt).toContain("### File: src/foo.ts (modified)");
+  });
+
+  it("includes a hunk inventory and slice disclaimer", () => {
+    const prompt = buildUserPrompt({ files: [fileFixture("src/foo.ts")] }, prContext);
+    expect(prompt).toContain("Hunk inventory");
+    expect(prompt).toContain("src/foo.ts: src/foo.ts#0");
+    expect(prompt).toContain("slice of a larger PR");
+    expect(prompt).not.toContain("Checklist before you finish");
   });
 
   it("marks binary files without dumping hunk content", () => {

--- a/apps/extension/src/lib/review/buildPrompt.ts
+++ b/apps/extension/src/lib/review/buildPrompt.ts
@@ -1,13 +1,23 @@
 import type { DiffFile, ParsedDiff, PRContext } from "../types";
 
-export const SYSTEM_PROMPT = `You are an expert senior engineer helping a human review a pull request that may have been written by an AI coding agent. You do not write or rewrite code — you plan how a human should walk through an existing diff, and explain it.
+export const SYSTEM_PROMPT = `You are an expert senior engineer helping a human review a pull request that may have been written by an AI coding agent. You do not write or rewrite code — you plan how a human should walk through an existing diff, and explain intent.
 
-Follow these review-structuring conventions:
-1. Order review units so schema/data-model changes come first, then the core logic that depends on them, then consumers/call-sites, then tests and generated/config files last (model-changes-first ordering).
-2. Group related hunks — possibly spanning multiple files — into one logical "review unit" per coherent change, rather than one unit per file.
-3. For each unit, explain why the change was made — infer the intent behind it from the PR title/description and the diff. Assume the reviewer already understands the surrounding code; give them the context of the change, not instructions on what to inspect or verify.
+Produce a consistent review plan: the same diff should yield the same partition of hunks into units, the same unit order, and the same kind assignment. Titles and context prose may vary slightly.
 
-Never invent code that isn't in the diff. Every fileId and hunkId you reference must come from the diff exactly as given.`;
+## Rules
+1. kind "change" = production and optional config/generated only. kind "tests" = test files only (role "test"). Never mix production and tests in one unit.
+2. Group production hunks by coherent feature or API-level change (multi-file units preferred over one unit per file). Split independent features or bugfixes even when they share a file — list explicit hunkIds when splitting; use empty hunkIds only when every hunk in that file belongs to the unit.
+3. Every hunk id from the inventory appears in exactly one unit. Never invent paths or hunk ids.
+4. Order change units model-first (schema/types → core logic → call-sites). After each feature's change unit(s), immediately emit the matching tests unit — do not dump all tests at the end when they map to earlier features. Unassociated tests go last. Test-only slices: only kind "tests" units.
+5. Attach lockfiles/config to the change unit that caused them when obvious; otherwise a final change unit of only config/generated after feature+tests pairs.
+6. id: unique kebab-case slug; tests units end with "-tests". title: short theme (not a raw path when a clearer label exists). For tests units prefer "Tests for …". context: 2–5 sentences of why the change exists (intent only) — never verify/check/ensure checklists.
+7. This prompt may be a slice of a larger PR. Structure only the files and hunks given.
+
+Example (feature then tests):
+{ "units": [
+  { "id": "add-retry-policy", "kind": "change", "title": "Add retryPolicy to Job model", "context": "…", "files": [{ "fileId": "src/job.ts", "hunkIds": ["src/job.ts#0"], "role": "schema_or_model" }] },
+  { "id": "add-retry-policy-tests", "kind": "tests", "title": "Tests for Add retryPolicy to Job model", "context": "…", "files": [{ "fileId": "src/job.test.ts", "hunkIds": [], "role": "test" }] }
+]}`;
 
 /**
  * Rendering is pure per file, and chunkDiffByFile measures every file before
@@ -80,6 +90,17 @@ export function chunkDiffByFile(
   return chunks.length > 0 ? chunks : [{ files: [] }];
 }
 
+function renderHunkInventory(diff: ParsedDiff): string {
+  const lines = diff.files.map((file) => {
+    if (file.isBinaryOrElided || file.hunks.length === 0) {
+      return `- ${file.path}: (no textual hunks)`;
+    }
+    const ids = file.hunks.map((h) => h.id).join(", ");
+    return `- ${file.path}: ${ids}`;
+  });
+  return ["Hunk inventory (every id must appear in exactly one unit):", ...lines].join("\n");
+}
+
 export function buildUserPrompt(diff: ParsedDiff, prContext: PRContext): string {
   const title = prContext.title.trim();
   const description = prContext.description.trim();
@@ -89,6 +110,10 @@ export function buildUserPrompt(diff: ParsedDiff, prContext: PRContext): string 
     prContext.baseRef && prContext.headRef
       ? `Merging ${prContext.headRef} into ${prContext.baseRef}.`
       : "",
+    "",
+    "This may be a slice of a larger PR. Structure only the files and hunk ids below.",
+    "",
+    renderHunkInventory(diff),
     "",
     "Diff:",
     // Hunk ids are annotated inline so the model can reference them exactly.

--- a/apps/extension/src/lib/review/fileReviewPlan.test.ts
+++ b/apps/extension/src/lib/review/fileReviewPlan.test.ts
@@ -73,6 +73,11 @@ describe("buildFileReviewPlan", () => {
     ]);
   });
 
+  it("sets kind tests only for test paths", () => {
+    const plan = buildFileReviewPlan(diffFixture());
+    expect(plan.units.map((u) => u.kind)).toEqual(["change", "tests", "change"]);
+  });
+
   it("returns an empty plan for an empty diff", () => {
     expect(buildFileReviewPlan({ files: [] })).toEqual({ units: [] });
   });

--- a/apps/extension/src/lib/review/fileReviewPlan.ts
+++ b/apps/extension/src/lib/review/fileReviewPlan.ts
@@ -1,14 +1,5 @@
-import type { FileRole, ParsedDiff, ReviewPlan, ReviewUnit } from "../types";
-
-const TEST_PATH = /(^|\/)(tests?|__tests__|spec)\/|\.(test|spec)\.[jt]sx?$/i;
-const CONFIG_PATH =
-  /(^|\/)(package-lock\.json|yarn\.lock|pnpm-lock\.yaml|go\.sum|Cargo\.lock)$|\.(json|ya?ml|toml|ini|lock)$|\.config\.[jt]s$/i;
-
-function roleForPath(path: string): FileRole {
-  if (TEST_PATH.test(path)) return "test";
-  if (CONFIG_PATH.test(path)) return "config_or_generated";
-  return "core_logic";
-}
+import type { ParsedDiff, ReviewPlan, ReviewUnit } from "../types";
+import { roleForPath } from "./pathClass";
 
 /**
  * Fallback plan for when no AI provider is configured: one review unit per
@@ -17,14 +8,18 @@ function roleForPath(path: string): FileRole {
  * AI-chosen ordering and per-step context.
  */
 export function buildFileReviewPlan(diff: ParsedDiff): ReviewPlan {
-  const units: ReviewUnit[] = diff.files.map((file, index) => ({
-    id: `file-${index}-${file.path}`,
-    title: file.path,
-    // Deliberately empty: the context panel shows the connect-a-provider
-    // prompt instead of inventing commentary we have no model to write.
-    context: "",
-    files: [{ fileId: file.path, hunkIds: [], role: roleForPath(file.path) }],
-  }));
+  const units: ReviewUnit[] = diff.files.map((file, index) => {
+    const role = roleForPath(file.path);
+    return {
+      id: `file-${index}-${file.path}`,
+      title: file.path,
+      kind: role === "test" ? "tests" : "change",
+      // Deliberately empty: the context panel shows the connect-a-provider
+      // prompt instead of inventing commentary we have no model to write.
+      context: "",
+      files: [{ fileId: file.path, hunkIds: [], role }],
+    };
+  });
 
   return { units };
 }

--- a/apps/extension/src/lib/review/pathClass.ts
+++ b/apps/extension/src/lib/review/pathClass.ts
@@ -1,0 +1,22 @@
+import type { FileRole } from "../types";
+
+/** Paths that belong in `kind: "tests"` units (role `test`). */
+export const TEST_PATH = /(^|\/)(tests?|__tests__|spec)\/|\.(test|spec)\.[jt]sx?$/i;
+
+/** Lockfiles and obvious config/generated paths (role `config_or_generated`). */
+export const CONFIG_PATH =
+  /(^|\/)(package-lock\.json|yarn\.lock|pnpm-lock\.yaml|go\.sum|Cargo\.lock)$|\.(json|ya?ml|toml|ini|lock)$|\.config\.[jt]s$/i;
+
+export function isTestPath(path: string): boolean {
+  return TEST_PATH.test(path);
+}
+
+/**
+ * Deterministic path → role heuristic used by the no-provider fallback and
+ * by validation (force test paths to role `test` so mixed units can be split).
+ */
+export function roleForPath(path: string): FileRole {
+  if (isTestPath(path)) return "test";
+  if (CONFIG_PATH.test(path)) return "config_or_generated";
+  return "core_logic";
+}

--- a/apps/extension/src/lib/review/reviewPlan.test.ts
+++ b/apps/extension/src/lib/review/reviewPlan.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { isCompleteReviewUnit, prefixChunkUnitId, validateAndCleanUnit } from "./reviewPlan";
+import {
+  isCompleteReviewUnit,
+  prefixChunkUnitId,
+  stripDuplicateHunks,
+  validateAndCleanUnit,
+} from "./reviewPlan";
 import type { DiffFile, ReviewUnit } from "../types";
 
 /** The known-files map `validateAndCleanUnit` validates against. */
 function diffFixture(): Map<string, DiffFile> {
-  const file: DiffFile = {
+  const foo: DiffFile = {
     path: "src/foo.ts",
     status: "modified",
     isBinaryOrElided: false,
@@ -18,14 +23,49 @@ function diffFixture(): Map<string, DiffFile> {
         newLines: 1,
         lines: [],
       },
+      {
+        id: "src/foo.ts#1",
+        header: "@@ -5,1 +5,1 @@",
+        oldStart: 5,
+        oldLines: 1,
+        newStart: 5,
+        newLines: 1,
+        lines: [],
+      },
     ],
   };
-  return new Map([[file.path, file]]);
+  const testFile: DiffFile = {
+    path: "src/foo.test.ts",
+    status: "added",
+    isBinaryOrElided: false,
+    hunks: [
+      {
+        id: "src/foo.test.ts#0",
+        header: "@@ -0,0 +1,1 @@",
+        oldStart: 0,
+        oldLines: 0,
+        newStart: 1,
+        newLines: 1,
+        lines: [],
+      },
+    ],
+  };
+  return new Map([
+    [foo.path, foo],
+    [testFile.path, testFile],
+  ]);
 }
 
 describe("validateAndCleanUnit", () => {
-  function unitWith(files: ReviewUnit["files"]): ReviewUnit {
-    return { id: "u1", title: "Update foo", context: "because", files };
+  function unitWith(files: ReviewUnit["files"], overrides: Partial<ReviewUnit> = {}): ReviewUnit {
+    return {
+      id: "u1",
+      title: "Update foo",
+      kind: "change",
+      context: "because",
+      files,
+      ...overrides,
+    };
   }
 
   it("keeps a unit whose file/hunk refs all exist in the diff", () => {
@@ -34,7 +74,9 @@ describe("validateAndCleanUnit", () => {
       diffFixture(),
     );
 
-    expect(cleaned?.files[0].hunkIds).toEqual(["src/foo.ts#0"]);
+    expect(cleaned).toHaveLength(1);
+    expect(cleaned[0].files[0].hunkIds).toEqual(["src/foo.ts#0"]);
+    expect(cleaned[0].kind).toBe("change");
   });
 
   it("drops hallucinated hunk ids but keeps the file ref if the file is real", () => {
@@ -45,7 +87,7 @@ describe("validateAndCleanUnit", () => {
       diffFixture(),
     );
 
-    expect(cleaned?.files[0].hunkIds).toEqual(["src/foo.ts#0"]);
+    expect(cleaned[0].files[0].hunkIds).toEqual(["src/foo.ts#0"]);
   });
 
   it("treats an empty hunkIds list as a whole-file reference and keeps it", () => {
@@ -54,20 +96,20 @@ describe("validateAndCleanUnit", () => {
       diffFixture(),
     );
 
-    expect(cleaned?.files).toHaveLength(1);
-    expect(cleaned?.files[0].hunkIds).toEqual([]);
+    expect(cleaned[0].files).toHaveLength(1);
+    expect(cleaned[0].files[0].hunkIds).toEqual([]);
   });
 
-  it("returns null when every file ref is hallucinated", () => {
+  it("returns an empty array when every file ref is hallucinated", () => {
     const cleaned = validateAndCleanUnit(
       unitWith([{ fileId: "src/does-not-exist.ts", hunkIds: [], role: "core_logic" }]),
       diffFixture(),
     );
 
-    expect(cleaned).toBeNull();
+    expect(cleaned).toEqual([]);
   });
 
-  it("falls back to core_logic for an unrecognized role", () => {
+  it("falls back to core_logic for an unrecognized role on production paths", () => {
     const cleaned = validateAndCleanUnit(
       unitWith([
         {
@@ -79,12 +121,137 @@ describe("validateAndCleanUnit", () => {
       diffFixture(),
     );
 
-    expect(cleaned?.files[0].role).toBe("core_logic");
+    expect(cleaned[0].files[0].role).toBe("core_logic");
+  });
+
+  it("forces test paths to role test and kind tests", () => {
+    const cleaned = validateAndCleanUnit(
+      unitWith([{ fileId: "src/foo.test.ts", hunkIds: [], role: "core_logic" }], {
+        kind: "change",
+        title: "Tests for foo",
+      }),
+      diffFixture(),
+    );
+
+    expect(cleaned).toHaveLength(1);
+    expect(cleaned[0].kind).toBe("tests");
+    expect(cleaned[0].files[0].role).toBe("test");
+  });
+
+  it("splits mixed production+test units into change then tests", () => {
+    const cleaned = validateAndCleanUnit(
+      unitWith(
+        [
+          { fileId: "src/foo.ts", hunkIds: ["src/foo.ts#0"], role: "core_logic" },
+          { fileId: "src/foo.test.ts", hunkIds: [], role: "test" },
+        ],
+        { id: "add-foo", title: "Add foo", kind: "change" },
+      ),
+      diffFixture(),
+    );
+
+    expect(cleaned).toHaveLength(2);
+    expect(cleaned[0]).toMatchObject({
+      id: "add-foo",
+      kind: "change",
+      title: "Add foo",
+    });
+    expect(cleaned[0].files.map((f) => f.fileId)).toEqual(["src/foo.ts"]);
+    expect(cleaned[1]).toMatchObject({
+      id: "add-foo-tests",
+      kind: "tests",
+      title: "Tests for Add foo",
+    });
+    expect(cleaned[1].files.map((f) => f.fileId)).toEqual(["src/foo.test.ts"]);
+  });
+
+  it("sorts files within a unit by role then path", () => {
+    const cleaned = validateAndCleanUnit(
+      unitWith([
+        { fileId: "src/z.ts", hunkIds: [], role: "core_logic" },
+        { fileId: "src/a.ts", hunkIds: [], role: "schema_or_model" },
+        { fileId: "src/m.ts", hunkIds: [], role: "core_logic" },
+      ]),
+      new Map([
+        ["src/z.ts", { path: "src/z.ts", status: "modified", isBinaryOrElided: false, hunks: [] }],
+        ["src/a.ts", { path: "src/a.ts", status: "modified", isBinaryOrElided: false, hunks: [] }],
+        ["src/m.ts", { path: "src/m.ts", status: "modified", isBinaryOrElided: false, hunks: [] }],
+      ]),
+    );
+
+    expect(cleaned[0].files.map((f) => f.fileId)).toEqual(["src/a.ts", "src/m.ts", "src/z.ts"]);
+  });
+});
+
+describe("stripDuplicateHunks", () => {
+  it("keeps the first claim on a hunk and drops later units that only had that hunk", () => {
+    const known = diffFixture();
+    const seen = new Set<string>();
+
+    const first = stripDuplicateHunks(
+      {
+        id: "a",
+        title: "A",
+        kind: "change",
+        context: "",
+        files: [{ fileId: "src/foo.ts", hunkIds: ["src/foo.ts#0"], role: "core_logic" }],
+      },
+      known,
+      seen,
+    );
+    const second = stripDuplicateHunks(
+      {
+        id: "b",
+        title: "B",
+        kind: "change",
+        context: "",
+        files: [{ fileId: "src/foo.ts", hunkIds: ["src/foo.ts#0"], role: "core_logic" }],
+      },
+      known,
+      seen,
+    );
+
+    expect(first?.files[0].hunkIds).toEqual(["src/foo.ts#0"]);
+    expect(second).toBeNull();
+  });
+
+  it("keeps remaining hunks when only some were already claimed", () => {
+    const known = diffFixture();
+    const seen = new Set<string>(["src/foo.ts#0"]);
+
+    const unit = stripDuplicateHunks(
+      {
+        id: "a",
+        title: "A",
+        kind: "change",
+        context: "",
+        files: [
+          {
+            fileId: "src/foo.ts",
+            hunkIds: ["src/foo.ts#0", "src/foo.ts#1"],
+            role: "core_logic",
+          },
+        ],
+      },
+      known,
+      seen,
+    );
+
+    expect(unit?.files[0].hunkIds).toEqual(["src/foo.ts#1"]);
   });
 });
 
 describe("isCompleteReviewUnit", () => {
   it("accepts a well-formed unit and rejects incomplete objects", () => {
+    expect(
+      isCompleteReviewUnit({
+        id: "u1",
+        title: "T",
+        kind: "tests",
+        context: "C",
+        files: [{ fileId: "a.ts", hunkIds: [], role: "test" }],
+      }),
+    ).toBe(true);
     expect(
       isCompleteReviewUnit({
         id: "u1",

--- a/apps/extension/src/lib/review/reviewPlan.ts
+++ b/apps/extension/src/lib/review/reviewPlan.ts
@@ -1,7 +1,17 @@
-import type { DiffFile, ReviewUnit, ReviewUnitFileRef } from "../types";
-import { DEFAULT_FILE_ROLE, FILE_ROLES } from "../types";
+import type { DiffFile, FileRole, ReviewUnit, ReviewUnitFileRef, UnitKind } from "../types";
+import { DEFAULT_FILE_ROLE, DEFAULT_UNIT_KIND, FILE_ROLES } from "../types";
+import { isTestPath } from "./pathClass";
 
 const KNOWN_FILE_ROLES: ReadonlySet<string> = new Set(FILE_ROLES);
+
+/** Role rank for within-unit sort (lower first). */
+const ROLE_RANK: Record<FileRole, number> = {
+  schema_or_model: 0,
+  core_logic: 1,
+  consumer_or_call_site: 2,
+  test: 3,
+  config_or_generated: 4,
+};
 
 /**
  * Namespace a unit id by chunk index so units from different `chunkDiffByFile`
@@ -11,23 +21,42 @@ export function prefixChunkUnitId(chunkIndex: number, unitId: string): string {
   return `c${chunkIndex}-${unitId}`;
 }
 
+function sortFileRefs(files: ReviewUnitFileRef[]): ReviewUnitFileRef[] {
+  return [...files].sort((a, b) => {
+    const rank = ROLE_RANK[a.role] - ROLE_RANK[b.role];
+    if (rank !== 0) return rank;
+    return a.fileId < b.fileId ? -1 : a.fileId > b.fileId ? 1 : 0;
+  });
+}
+
+function testsUnitId(baseId: string): string {
+  if (baseId.endsWith("-tests")) return `${baseId}-files`;
+  return `${baseId}-tests`;
+}
+
+function testsTitle(changeTitle: string): string {
+  const trimmed = changeTitle.trim();
+  if (!trimmed) return "Tests";
+  if (/^tests\b/i.test(trimmed)) return trimmed;
+  return `Tests for ${trimmed}`;
+}
+
 /**
- * Validate a single review unit against the real diff. Returns null when
- * nothing real remains (all file refs hallucinated) so callers can drop it.
+ * Validate a raw review unit against the real diff and enforce purity:
+ * no mixed production+test units. Returns zero, one, or two units
+ * (change then tests when a mixed unit is split).
  *
  * The LLM plans structure and writes commentary, but the actual code shown to
  * the reviewer must always come from the real diff. Every fileId/hunkId the
  * model referenced is checked against the diff it was given, and anything that
- * doesn't exist is dropped rather than trusted — a model that hallucinates a
- * file path should never surface as a broken or misleading step in the UI.
+ * doesn't exist is dropped rather than trusted.
  *
- * Mutates hunk id lists on a shallow copy of the unit's file refs only —
- * never mutates the caller's original unit.
+ * Never mutates the caller's original unit.
  */
 export function validateAndCleanUnit(
   unit: ReviewUnit,
   knownFiles: Map<string, DiffFile>,
-): ReviewUnit | null {
+): ReviewUnit[] {
   const files: ReviewUnitFileRef[] = [];
 
   for (const ref of unit.files) {
@@ -42,26 +71,121 @@ export function validateAndCleanUnit(
         ? []
         : ref.hunkIds.filter((id) => file.hunks.some((h) => h.id === id));
 
+    // Path class wins for test files so purity splits are deterministic.
+    let role: FileRole = KNOWN_FILE_ROLES.has(ref.role)
+      ? (ref.role as FileRole)
+      : DEFAULT_FILE_ROLE;
+    if (isTestPath(ref.fileId)) role = "test";
+
     files.push({
       fileId: ref.fileId,
       hunkIds,
-      role: KNOWN_FILE_ROLES.has(ref.role) ? ref.role : DEFAULT_FILE_ROLE,
+      role,
+    });
+  }
+
+  if (files.length === 0) return [];
+
+  const testFiles = sortFileRefs(files.filter((f) => f.role === "test"));
+  const otherFiles = sortFileRefs(files.filter((f) => f.role !== "test"));
+
+  // Pure tests.
+  if (otherFiles.length === 0) {
+    return [
+      {
+        id: unit.id,
+        title: unit.title,
+        context: unit.context,
+        kind: "tests",
+        files: testFiles,
+      },
+    ];
+  }
+
+  // Pure change (production + optional config).
+  if (testFiles.length === 0) {
+    return [
+      {
+        id: unit.id,
+        title: unit.title,
+        context: unit.context,
+        kind: "change",
+        files: otherFiles,
+      },
+    ];
+  }
+
+  // Mixed — always split: change first, then tests immediately after.
+  const changeTitle = unit.title;
+  return [
+    {
+      id: unit.id,
+      title: changeTitle,
+      context: unit.context,
+      kind: "change",
+      files: otherFiles,
+    },
+    {
+      id: testsUnitId(unit.id),
+      title: testsTitle(changeTitle),
+      context: unit.context,
+      kind: "tests",
+      files: testFiles,
+    },
+  ];
+}
+
+/**
+ * Drop hunk ids already claimed by earlier units (first occurrence wins).
+ * Whole-file refs (`hunkIds: []`) claim every hunk on that file.
+ * Returns null when nothing remains after stripping.
+ */
+export function stripDuplicateHunks(
+  unit: ReviewUnit,
+  knownFiles: Map<string, DiffFile>,
+  seenHunkIds: Set<string>,
+): ReviewUnit | null {
+  const files: ReviewUnitFileRef[] = [];
+
+  for (const ref of unit.files) {
+    const file = knownFiles.get(ref.fileId);
+    if (!file) continue;
+
+    const candidateIds = ref.hunkIds.length === 0 ? file.hunks.map((h) => h.id) : ref.hunkIds;
+
+    if (candidateIds.length === 0) {
+      // Binary/elided or empty file — keep once via a synthetic claim key.
+      const claimKey = `${ref.fileId}#*`;
+      if (seenHunkIds.has(claimKey)) continue;
+      seenHunkIds.add(claimKey);
+      files.push(ref);
+      continue;
+    }
+
+    const kept = candidateIds.filter((id) => !seenHunkIds.has(id));
+    if (kept.length === 0) continue;
+
+    for (const id of kept) seenHunkIds.add(id);
+
+    // If we kept every original candidate, preserve whole-file empty list.
+    const wasWholeFile = ref.hunkIds.length === 0;
+    const keptAll = wasWholeFile && kept.length === file.hunks.length;
+    files.push({
+      fileId: ref.fileId,
+      hunkIds: keptAll ? [] : kept,
+      role: ref.role,
     });
   }
 
   if (files.length === 0) return null;
-
-  return {
-    id: unit.id,
-    title: unit.title,
-    context: unit.context,
-    files,
-  };
+  return { ...unit, files: sortFileRefs(files) };
 }
 
 /**
  * Lightweight structural check for a raw parsed unit before validation.
  * Incomplete or malformed objects from partial JSON must never reach the UI.
+ * `kind` is optional here — validation defaults it — so streaming order of
+ * properties cannot drop a unit.
  */
 export function isCompleteReviewUnit(value: unknown): value is ReviewUnit {
   if (!value || typeof value !== "object") return false;
@@ -70,6 +194,7 @@ export function isCompleteReviewUnit(value: unknown): value is ReviewUnit {
   if (typeof u.title !== "string") return false;
   if (typeof u.context !== "string") return false;
   if (!Array.isArray(u.files)) return false;
+  if (u.kind !== undefined && typeof u.kind !== "string") return false;
 
   for (const file of u.files) {
     if (!file || typeof file !== "object") return false;
@@ -77,6 +202,11 @@ export function isCompleteReviewUnit(value: unknown): value is ReviewUnit {
     if (typeof f.fileId !== "string") return false;
     if (!Array.isArray(f.hunkIds) || !f.hunkIds.every((id) => typeof id === "string")) return false;
     if (typeof f.role !== "string") return false;
+  }
+
+  // Fill kind for the type assertion when missing; validation will re-resolve.
+  if (u.kind === undefined) {
+    (u as { kind: UnitKind }).kind = DEFAULT_UNIT_KIND;
   }
 
   return true;

--- a/apps/extension/src/lib/review/reviewSchema.test.ts
+++ b/apps/extension/src/lib/review/reviewSchema.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { REVIEW_PLAN_JSON_SCHEMA } from "./reviewSchema";
 import { validateAndCleanUnit } from "./reviewPlan";
-import { FILE_ROLES, type DiffFile, type ReviewUnit } from "../types";
+import { FILE_ROLES, UNIT_KINDS, type DiffFile, type ReviewUnit } from "../types";
 
 const roleSchema =
   REVIEW_PLAN_JSON_SCHEMA.properties.units.items.properties.files.items.properties.role;
+const kindSchema = REVIEW_PLAN_JSON_SCHEMA.properties.units.items.properties.kind;
 
 function diffWith(path: string): Map<string, DiffFile> {
   return new Map([[path, { path, status: "modified", isBinaryOrElided: false, hunks: [] }]]);
@@ -15,20 +16,33 @@ describe("REVIEW_PLAN_JSON_SCHEMA", () => {
     expect([...roleSchema.enum]).toEqual([...FILE_ROLES]);
   });
 
+  it("advertises exactly the unit kinds declared in UNIT_KINDS", () => {
+    expect([...kindSchema.enum]).toEqual([...UNIT_KINDS]);
+  });
+
+  it("requires kind on every unit", () => {
+    expect(REVIEW_PLAN_JSON_SCHEMA.properties.units.items.required).toContain("kind");
+  });
+
   it("accepts every advertised role through runtime validation", () => {
     // The model can only return roles the schema allows, so validation must not
     // silently rewrite any of them — a mismatch here means a role was added to
     // the schema but not to the validator's known set.
+    // Skip "test" here: path src/foo.ts is production; test role alone still
+    // yields kind tests via purity rules, but role is preserved.
     for (const role of FILE_ROLES) {
+      const path = role === "test" ? "src/foo.test.ts" : "src/foo.ts";
       const unit: ReviewUnit = {
         id: `u-${role}`,
         title: "T",
+        kind: role === "test" ? "tests" : "change",
         context: "C",
-        files: [{ fileId: "src/foo.ts", hunkIds: [], role }],
+        files: [{ fileId: path, hunkIds: [], role }],
       };
 
-      const cleaned = validateAndCleanUnit(unit, diffWith("src/foo.ts"));
-      expect(cleaned?.files[0].role).toBe(role);
+      const cleaned = validateAndCleanUnit(unit, diffWith(path));
+      expect(cleaned).toHaveLength(1);
+      expect(cleaned[0].files[0].role).toBe(role);
     }
   });
 });

--- a/apps/extension/src/lib/review/reviewSchema.ts
+++ b/apps/extension/src/lib/review/reviewSchema.ts
@@ -1,4 +1,4 @@
-import { FILE_ROLES } from "../types";
+import { FILE_ROLES, UNIT_KINDS } from "../types";
 
 /**
  * JSON schema for the structured `ReviewPlan` output. Shared by every
@@ -15,23 +15,33 @@ export const REVIEW_PLAN_JSON_SCHEMA = {
     units: {
       type: "array",
       description:
-        "Review units in the order the human should walk through them: model/schema changes first, then the logic that changes because of them, then consumers/call-sites, then tests and generated/config files last.",
+        "Review units in walk order. For each feature: change unit(s) first, then the matching tests unit. Never mix production and test files in one unit.",
       items: {
         type: "object",
         properties: {
-          id: { type: "string", description: "Stable slug id, e.g. 'add-retry-policy-field'." },
-          title: {
+          id: {
             type: "string",
             description:
-              "Short human title for this review unit, e.g. 'Add retryPolicy field to Job model'.",
+              "Unique kebab-case slug (e.g. 'add-retry-policy'). Tests units end with '-tests'.",
+          },
+          kind: {
+            type: "string",
+            enum: UNIT_KINDS,
+            description:
+              "'change' = production and optional config only. 'tests' = test files only. Never mix.",
+          },
+          title: {
+            type: "string",
+            description: "Short human title for this review unit.",
           },
           context: {
             type: "string",
             description:
-              "Why this change was made, inferred from the PR description and the diff. Assume the reviewer already understands the code; convey the intent and context behind the change rather than telling them what to check or verify. 2-5 sentences.",
+              "Why this change was made (intent from PR description and diff). Not a verify/check list. 2-5 sentences.",
           },
           files: {
             type: "array",
+            description: "Files for this unit only.",
             items: {
               type: "object",
               properties: {
@@ -43,11 +53,13 @@ export const REVIEW_PLAN_JSON_SCHEMA = {
                   type: "array",
                   items: { type: "string" },
                   description:
-                    "IDs of the specific hunks in this file relevant to this unit, formatted 'path#index'. Empty array means the whole file.",
+                    "Hunk ids for this unit ('path#index'). Empty array = whole file (only when every hunk belongs here).",
                 },
                 role: {
                   type: "string",
                   enum: FILE_ROLES,
+                  description:
+                    "schema_or_model | core_logic | consumer_or_call_site | test | config_or_generated",
                 },
               },
               required: ["fileId", "hunkIds", "role"],
@@ -55,7 +67,7 @@ export const REVIEW_PLAN_JSON_SCHEMA = {
             },
           },
         },
-        required: ["id", "title", "context", "files"],
+        required: ["id", "kind", "title", "context", "files"],
         additionalProperties: false,
       },
     },

--- a/apps/extension/src/lib/review/streamPlanParser.test.ts
+++ b/apps/extension/src/lib/review/streamPlanParser.test.ts
@@ -4,6 +4,7 @@ import { StreamPlanParser } from "./streamPlanParser";
 const UNIT_A = {
   id: "u1",
   title: "First unit",
+  kind: "change",
   context: "Why first",
   files: [{ fileId: "src/a.ts", hunkIds: ["src/a.ts#0"], role: "core_logic" }],
 };
@@ -11,6 +12,7 @@ const UNIT_A = {
 const UNIT_B = {
   id: "u2",
   title: "Second unit",
+  kind: "tests",
   context: "Why second",
   files: [{ fileId: "src/b.ts", hunkIds: [], role: "test" }],
 };
@@ -61,6 +63,7 @@ describe("StreamPlanParser", () => {
     const unit = {
       id: "u1",
       title: 'Say "hello"',
+      kind: "change",
       context: "path: C:\\foo\\bar",
       files: [{ fileId: "src/a.ts", hunkIds: [], role: "core_logic" }],
     };
@@ -119,6 +122,7 @@ describe("StreamPlanParser", () => {
     const unit = {
       id: "u1",
       title: "Uses {braces}",
+      kind: "change",
       context: "also } here { and }",
       files: [{ fileId: "src/a.ts", hunkIds: [], role: "core_logic" }],
     };

--- a/apps/extension/src/lib/types.ts
+++ b/apps/extension/src/lib/types.ts
@@ -76,6 +76,18 @@ export type FileRole = (typeof FILE_ROLES)[number];
 export const DEFAULT_FILE_ROLE: FileRole = "core_logic";
 
 /**
+ * Whether a review unit is production code or tests. Tests are always a
+ * separate unit (never mixed with production files). Single source of truth
+ * for the JSON schema enum and runtime validation.
+ */
+export const UNIT_KINDS = ["change", "tests"] as const;
+
+export type UnitKind = (typeof UNIT_KINDS)[number];
+
+/** Kind assigned when the model omits one or returns something unrecognized. */
+export const DEFAULT_UNIT_KIND: UnitKind = "change";
+
+/**
  * Shown when a review that requires a summary is submitted without one. The
  * overlay checks this before calling the background worker so the user gets
  * the error without a round-trip; `submitReview.ts` enforces it again because
@@ -96,6 +108,11 @@ export interface ReviewUnitFileRef {
 export interface ReviewUnit {
   id: string;
   title: string;
+  /**
+   * `change` = production (and optional config); `tests` = test files only.
+   * Never mixed — validation splits impure units.
+   */
+  kind: UnitKind;
   /** Why the change was made (inferred). */
   context: string;
   files: ReviewUnitFileRef[];

--- a/apps/web/content/help/how-it-works.mdx
+++ b/apps/web/content/help/how-it-works.mdx
@@ -24,7 +24,9 @@ If annotation fails mid-stream, see [Troubleshooting → Plan generation fails](
 
 ## Review units
 
-A **review unit** is a logical step in the plan: a title, guidance text, and one or more hunk references. Units are ordered so reviewers typically see foundational pieces (schema, types, core logic) before call-sites and tests.
+A **review unit** is a logical step in the plan: a title, intent context, and one or more hunk references. Production changes and tests are **separate** units — never mixed in one step. After each feature’s production unit(s), the matching tests unit follows immediately (not a single dump of all tests at the end). Tests steps show a flask icon next to the unit name in the sidebar and diff pane.
+
+Units aim for a consistent structure on the same diff: same hunk partition, order, and change-vs-tests kind. Titles and wording may still vary slightly across models.
 
 The first display step is a synthetic **PR description** unit built from page context, then the model’s units. You step through them with the footer or [keyboard shortcuts](/docs/keyboard-shortcuts).
 


### PR DESCRIPTION
## Summary

- Introduce first-class `kind: "change" | "tests"` on review units so production and tests never share a step; the sidebar/diff pane show a flask icon on tests units.
- Teach the LLM (system prompt + schema) a short, rule-driven structure: model-first change units, tests immediately after the feature they cover, pure kinds, explicit hunk ownership, intent-only context.
- Harden validation: force test paths to role `test`, split mixed units, strip duplicate hunk claims, sort files by role rank; post-processing remains the consistency backstop when the model drifts.
- Docs: how-it-works notes separate tests units and walk order.

Stacks on #47 (`diff-search`).

## Test plan

- [ ] `npm test` / `npm run typecheck` in the extension package
- [ ] Load extension from `apps/extension/dist`, run Guided Review on a PR with both prod + tests
- [ ] Confirm change units have no test files; tests units follow their feature and show the flask icon
- [ ] Same-file multi-hunk PR: units list explicit hunk ids without duplicates
- [ ] Mixed model output is still cleaned (split / drop hallucinations) if the plan is imperfect