### PR TITLE
style(overlay): polish review unit UI, path-aware labels, and progressive build status

### DIFF
--- a/apps/extension/e2e/overlay.spec.ts
+++ b/apps/extension/e2e/overlay.spec.ts
@@ -247,17 +247,17 @@ test.describe("Guided review overlay", () => {
     await page.getByRole("button", { name: "Start Guided Review" }).click();
 
     await expect(page.getByText("PR Description").first()).toBeVisible();
-    await expect(page.getByTestId("footer-step-status")).toHaveText(/Step 1 of/i);
+    await expect(page.getByTestId("footer-step-status")).toHaveText(/Review unit 1 of/i);
 
     // Wait for the streamed AI unit before navigating past the description.
     await expect(page.getByText(CANNED_PLAN.units[0].title)).toBeVisible();
 
     await page.getByRole("button", { name: /next/i }).click();
     await expect(page.getByText(CANNED_PLAN.units[0].context)).toBeVisible();
-    await expect(page.getByTestId("footer-step-status")).toHaveText(/Step 2 of/i);
+    await expect(page.getByTestId("footer-step-status")).toHaveText(/Review unit 2 of/i);
 
     await page.getByRole("button", { name: /previous/i }).click();
-    await expect(page.getByTestId("footer-step-status")).toHaveText(/Step 1 of/i);
+    await expect(page.getByTestId("footer-step-status")).toHaveText(/Review unit 1 of/i);
 
     // Esc opens the exit confirmation; confirm to tear the overlay down.
     await page.keyboard.press("Escape");

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@guided-review/extension",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/apps/extension/src/background/index.test.ts
+++ b/apps/extension/src/background/index.test.ts
@@ -325,6 +325,23 @@ describe("ANNOTATE_REVIEW stream", () => {
     expect(donePlan(events)?.map((u) => u.id)).toEqual(["c0-shared", "c1-shared"]);
   });
 
+  it("posts waiting_for_tokens then tokens_streaming STATUS before units", async () => {
+    provider.deltasByFirstFilePath.set("a.ts", [planJson([unitJson("u1", "a.ts")])]);
+
+    const { events } = await runStream({ files: [oversizedFile("a.ts")] });
+
+    const statusPhases = events
+      .filter(
+        (e): e is Extract<AnnotateReviewStreamEvent, { type: "STATUS" }> => e.type === "STATUS",
+      )
+      .map((e) => e.phase);
+    expect(statusPhases).toEqual(["waiting_for_tokens", "tokens_streaming"]);
+    // STATUS events precede the first unit.
+    const firstUnitIdx = events.findIndex((e) => e.type === "UNIT");
+    const lastStatusIdx = events.map((e) => e.type).lastIndexOf("STATUS");
+    expect(lastStatusIdx).toBeLessThan(firstUnitIdx);
+  });
+
   it("drops units referencing a file the model was not given", async () => {
     provider.deltasByFirstFilePath.set("a.ts", [
       planJson([unitJson("real", "a.ts"), unitJson("ghost", "not-in-the-diff.ts")]),

--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -264,14 +264,26 @@ async function handleAnnotateReviewStream(
   const allUnits: ReviewUnit[] = [];
   /** First unit that claims a hunk id wins; later duplicates are stripped. */
   const seenHunkIds = new Set<string>();
+  /** Emit waiting / first-token STATUS once across all chunks. */
+  const streamStatus = { postedWaiting: false, postedStreaming: false };
 
   for (const [chunkIndex, chunk] of chunks.entries()) {
     if (signal.aborted) return;
+
+    if (!streamStatus.postedWaiting) {
+      streamStatus.postedWaiting = true;
+      postEvent(port, { type: "STATUS", phase: "waiting_for_tokens" });
+    }
 
     for await (const unit of streamChunkUnits(client, chunk, request.prContext, settings, {
       chunkIndex,
       seenHunkIds,
       signal,
+      onFirstToken: () => {
+        if (streamStatus.postedStreaming) return;
+        streamStatus.postedStreaming = true;
+        postEvent(port, { type: "STATUS", phase: "tokens_streaming" });
+      },
     })) {
       if (signal.aborted) return;
       allUnits.push(unit);
@@ -299,19 +311,31 @@ async function* streamChunkUnits(
     chunkIndex,
     seenHunkIds,
     signal,
-  }: { chunkIndex: number; seenHunkIds: Set<string>; signal: AbortSignal },
+    onFirstToken,
+  }: {
+    chunkIndex: number;
+    seenHunkIds: Set<string>;
+    signal: AbortSignal;
+    onFirstToken?: () => void;
+  },
 ): AsyncGenerator<ReviewUnit, void, unknown> {
   const parser = new StreamPlanParser();
   // Keyed by path because the schema defines `fileId` as "the file path exactly
   // as it appears in the diff" (see REVIEW_PLAN_JSON_SCHEMA) — the same
   // assumption `resolveUnitFiles` makes when rendering.
   const knownFiles = new Map(chunk.files.map((file) => [file.path, file]));
+  let sawToken = false;
 
   for await (const event of client.annotateReviewStream(
     { diff: chunk, prContext, settings },
     { signal },
   )) {
     if (signal.aborted) return;
+
+    if (event.type === "text_delta" && !sawToken) {
+      sawToken = true;
+      onFirstToken?.();
+    }
 
     const raw =
       event.type === "text_delta"

--- a/apps/extension/src/content/index.tsx
+++ b/apps/extension/src/content/index.tsx
@@ -4,6 +4,7 @@ import { parsePRUrl, type PRIdentity } from "../lib/github/diffFetch";
 import { isIgnoredPrPath } from "../lib/github/ignoredPrPaths";
 import { fetchConversationDescription, scrapePRContext } from "../lib/github/prContext";
 import { requestPRDiff, streamReviewPlan } from "../lib/messaging";
+import { getProvider } from "../lib/providers/catalog";
 import { getProviderSettings, onProviderSettingsChanged } from "../lib/settings";
 import type { ContentRequest, ParsedDiff, PRContext } from "../lib/types";
 import { ensureFallbackHost, FALLBACK_HOST_ID, findButtonAnchor } from "./buttonAnchor";
@@ -225,7 +226,11 @@ function startAnnotationStream(
   prContext: PRContext,
   streamGeneration: number,
 ): void {
+  // Request is on the wire — show "Sent it to …" until the worker reports waiting/tokens.
+  useReviewStore.getState().setBuildPhase("sent_to_provider", streamGeneration);
+
   const { cancel } = streamReviewPlan(diff, prContext, {
+    onStatus: (phase) => useReviewStore.getState().setBuildPhase(phase, streamGeneration),
     onUnit: (unit) => useReviewStore.getState().appendUnit(unit, streamGeneration),
     onDone: (plan) => {
       activeStreamCancel = null;
@@ -315,6 +320,7 @@ async function onStartReview(): Promise<void> {
       return;
     }
 
+    useReviewStore.getState().setProviderLabel(getProvider(settings.provider).displayName);
     useReviewStore.getState().beginStreaming(streamGeneration);
 
     const latestContext = useReviewStore.getState().prContext ?? prContext;

--- a/apps/extension/src/content/index.tsx
+++ b/apps/extension/src/content/index.tsx
@@ -15,8 +15,9 @@ import { useReviewStore, restoreSession, buildSessionKey } from "./overlay/store
 const BUTTON_ID = "guided-review-start-btn";
 const BUTTON_STYLE_ID = "guided-review-start-btn-styles";
 const HOST_ID = "guided-review-overlay-host";
-/** Brand accent hover — keep in sync with `--color-primary-hover` in theme.css. */
-const ACCENT_HOVER = "#b6e64e";
+/** Brand accent — keep in sync with `--color-primary` / `--color-primary-hover` in theme.css. */
+const ACCENT = "#CAFF57";
+const ACCENT_HOVER = "#a8d448";
 
 let currentPR: PRIdentity | null = null;
 /** Active stream cancel handle so restart / close can abort the worker. */
@@ -37,9 +38,12 @@ function ensureButtonStyles(): void {
   if (document.getElementById(BUTTON_STYLE_ID)) return;
   const style = document.createElement("style");
   style.id = BUTTON_STYLE_ID;
+  // Base fill/border live here (not inline) so :hover can override them —
+  // style attributes beat normal stylesheet rules, including #id:hover.
   style.textContent = [
+    `#${BUTTON_ID}{border:1px solid ${ACCENT};background:${ACCENT}}`,
     `#${BUTTON_ID}:hover{background:${ACCENT_HOVER};border-color:${ACCENT_HOVER}}`,
-    `#${BUTTON_ID}:focus-visible{outline:2px solid #CAFF57;outline-offset:2px}`,
+    `#${BUTTON_ID}:focus-visible{outline:2px solid ${ACCENT};outline-offset:2px}`,
     `@media (prefers-reduced-motion:reduce){#${BUTTON_ID}{transition:none}}`,
   ].join("");
   document.documentElement.appendChild(style);
@@ -165,8 +169,7 @@ function tryInjectButton(): void {
       "margin-left: 8px",
       "padding: 0 12px",
       "border-radius: 6px",
-      "border: 1px solid #CAFF57",
-      "background: #CAFF57",
+      // border + background come from ensureButtonStyles() so :hover can apply
       "color: #0D0806",
       "font-size: 14px",
       "font-weight: 600",

--- a/apps/extension/src/content/overlay/Overlay.test.tsx
+++ b/apps/extension/src/content/overlay/Overlay.test.tsx
@@ -90,6 +90,8 @@ function resetStore(): void {
     status: "idle",
     error: null,
     needsProvider: false,
+    buildPhase: null,
+    providerLabel: null,
     diff: null,
     plan: null,
     prContext: null,
@@ -151,6 +153,7 @@ describe("Overlay", () => {
     useReviewStore.setState({
       isOpen: true,
       status: "loading",
+      buildPhase: "extracting_diff",
       prContext: prContextFixture(),
       currentUnitIndex: 0,
     });
@@ -159,8 +162,12 @@ describe("Overlay", () => {
     // Title in left pane + entry in the unit list.
     expect(screen.getAllByText("PR Description").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("This PR adds a feature.")).toBeInTheDocument();
-    expect(screen.getByText(/building remaining units/i)).toBeInTheDocument();
-    expect(screen.getByRole("status", { name: /building remaining units/i })).toBeInTheDocument();
+    const loading = screen.getByTestId("context-panel-loading");
+    expect(loading).toHaveTextContent(/building a review plan/i);
+    expect(screen.getByTestId("context-panel-loading-detail")).toHaveTextContent(
+      /extracting the diff/i,
+    );
+    expect(screen.getByRole("status", { name: /building a review plan/i })).toBeInTheDocument();
     // Skeleton placeholders are present (non-interactive bars in the unit list).
     expect(screen.getAllByTestId("unit-skeleton").length).toBeGreaterThan(0);
     // Shortcuts are reserved for the ready state; spinner occupies that slot while loading.
@@ -175,6 +182,7 @@ describe("Overlay", () => {
     useReviewStore.setState({
       isOpen: true,
       status: "loading",
+      buildPhase: "processing_diff",
       diff: diffFixture(),
       prContext: prContextFixture(),
       currentUnitIndex: 0,
@@ -184,7 +192,12 @@ describe("Overlay", () => {
     expect(screen.getByLabelText(/diff summary/i)).toBeInTheDocument();
     expect(screen.getByText("src/foo.ts")).toBeInTheDocument();
     // Plan still loading — skeleton + status copy remain.
-    expect(screen.getByText(/building remaining units/i)).toBeInTheDocument();
+    expect(screen.getByTestId("context-panel-loading")).toHaveTextContent(
+      /building a review plan/i,
+    );
+    expect(screen.getByTestId("context-panel-loading-detail")).toHaveTextContent(
+      /processing the diff/i,
+    );
     expect(screen.getAllByTestId("unit-skeleton").length).toBeGreaterThan(0);
   });
 
@@ -192,6 +205,7 @@ describe("Overlay", () => {
     useReviewStore.setState({
       isOpen: true,
       status: "streaming",
+      buildPhase: "tokens_streaming",
       diff: diffFixture(),
       plan: planFixture(),
       prContext: prContextFixture(),
@@ -201,13 +215,37 @@ describe("Overlay", () => {
 
     expect(screen.getByText("Update foo")).toBeInTheDocument();
     expect(screen.getAllByTestId("unit-skeleton").length).toBeGreaterThan(0);
-    expect(screen.getByText(/building remaining units/i)).toBeInTheDocument();
+    expect(screen.getByTestId("context-panel-loading")).toHaveTextContent(
+      /building a review plan/i,
+    );
+    expect(screen.getByTestId("context-panel-loading-detail")).toHaveTextContent(
+      /tokens are streaming/i,
+    );
+  });
+
+  it("names the configured provider in the loading detail when the request is sent", () => {
+    useReviewStore.setState({
+      isOpen: true,
+      status: "streaming",
+      buildPhase: "sent_to_provider",
+      providerLabel: "Claude (Anthropic)",
+      diff: diffFixture(),
+      plan: { units: [] },
+      prContext: prContextFixture(),
+      currentUnitIndex: 0,
+    });
+    render(<Overlay />);
+
+    expect(screen.getByTestId("context-panel-loading-detail")).toHaveTextContent(
+      /sent it to claude \(anthropic\)/i,
+    );
   });
 
   it("shows unit context without the building spinner when viewing a streamed unit", () => {
     useReviewStore.setState({
       isOpen: true,
       status: "streaming",
+      buildPhase: "tokens_streaming",
       diff: diffFixture(),
       plan: planFixture(),
       prContext: prContextFixture(),
@@ -216,13 +254,14 @@ describe("Overlay", () => {
     render(<Overlay />);
 
     expect(screen.getByText("because it needed updating")).toBeInTheDocument();
-    expect(screen.queryByText(/building remaining units/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("context-panel-loading")).not.toBeInTheDocument();
   });
 
   it("shows keyboard shortcuts on the description unit once the review plan is ready", () => {
     useReviewStore.setState({
       isOpen: true,
       status: "ready",
+      buildPhase: null,
       diff: diffFixture(),
       plan: planFixture(),
       prContext: prContextFixture(),
@@ -237,7 +276,7 @@ describe("Overlay", () => {
     expect(screen.getByText(/^split view$/i)).toBeInTheDocument();
     expect(screen.getByText(/^enter comment mode$/i)).toBeInTheDocument();
     expect(screen.getByText(/exit comment mode \/ exit review/i)).toBeInTheDocument();
-    expect(screen.queryByText(/building remaining units/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("context-panel-loading")).not.toBeInTheDocument();
   });
 
   it("shows the error in the context panel without collapsing the layout", () => {

--- a/apps/extension/src/content/overlay/Overlay.tsx
+++ b/apps/extension/src/content/overlay/Overlay.tsx
@@ -316,7 +316,10 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
           ) : (
             <DiffPane
               files={resolvedFiles}
-              unitTitle={currentReviewUnit?.title ?? ""}
+              unitTitle={
+                currentReviewUnit ? (currentReviewUnit.displayTitle ?? currentReviewUnit.title) : ""
+              }
+              unitTitleTooltip={currentReviewUnit?.title}
               isTestsUnit={currentReviewUnit?.kind === "tests"}
               unitId={currentReviewUnit?.id}
               selectableForUnit={selectableForUnit}

--- a/apps/extension/src/content/overlay/Overlay.tsx
+++ b/apps/extension/src/content/overlay/Overlay.tsx
@@ -19,6 +19,7 @@ import { ConnectGitHubModal } from "./components/ConnectGitHubModal";
 import { confirm, ConfirmationHost, useConfirmationOpen } from "./components/confirmation";
 import { SubmitReviewModal } from "./components/SubmitReviewModal";
 import { ReviewSubmittedModal } from "./components/ReviewSubmittedModal";
+import { BUILD_PLAN_PRIMARY, buildPhaseDetail } from "./buildPhaseCopy";
 
 interface OverlayProps {
   /** Invoked when the user exits so any in-flight stream can be cancelled. */
@@ -32,6 +33,8 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
   const status = useReviewStore((s) => s.status);
   const error = useReviewStore((s) => s.error);
   const needsProvider = useReviewStore((s) => s.needsProvider);
+  const buildPhase = useReviewStore((s) => s.buildPhase);
+  const providerLabel = useReviewStore((s) => s.providerLabel);
   const diff = useReviewStore((s) => s.diff);
   const plan = useReviewStore((s) => s.plan);
   const prContext = useReviewStore((s) => s.prContext);
@@ -193,6 +196,7 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
   const planStillBuilding = status === "loading" || status === "streaming";
   // Spinner on the description unit only while the plan is still being built.
   const showBuildingSpinner = planStillBuilding && (!plan || currentUnitIndex === 0);
+  const loadingDetail = buildPhase != null ? buildPhaseDetail(buildPhase, providerLabel) : null;
   const displayUnits = buildDisplayUnits(plan);
   const total = displayUnitCount(plan);
   const currentDisplay = displayUnits[currentUnitIndex] ?? displayUnits[0];
@@ -253,20 +257,19 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
     if (needsProvider) {
       return "Connect an AI provider to enable the AI features.";
     }
-    if (status === "loading") {
-      return "Loading pull request diff…";
-    }
-    if (status === "streaming") {
+    if (status === "loading" || status === "streaming") {
+      const detail = buildPhase != null ? buildPhaseDetail(buildPhase, providerLabel) : null;
       const n = plan?.units.length ?? 0;
-      return n > 0
-        ? `Building review plan. ${n} review unit${n === 1 ? "" : "s"} ready.`
-        : "Building review plan…";
+      if (status === "streaming" && n > 0) {
+        return `${BUILD_PLAN_PRIMARY}. ${n} review unit${n === 1 ? "" : "s"} ready.${detail ? ` ${detail}` : ""}`;
+      }
+      return detail ? `${BUILD_PLAN_PRIMARY}. ${detail}` : `${BUILD_PLAN_PRIMARY}…`;
     }
     if (status === "ready" && plan) {
       return `Review plan ready. ${displayUnitCount(plan)} steps.`;
     }
     return "";
-  }, [status, error, plan, needsProvider]);
+  }, [status, error, plan, needsProvider, buildPhase, providerLabel]);
 
   if (!isOpen) return null;
 
@@ -348,6 +351,7 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
                 error={status === "error" ? error : null}
                 needsProvider={needsProvider}
                 loading={showBuildingSpinner && isDescriptionUnit}
+                loadingDetail={showBuildingSpinner && isDescriptionUnit ? loadingDetail : null}
                 onRetry={status === "error" ? onRetry : undefined}
               />
             </div>

--- a/apps/extension/src/content/overlay/buildPhaseCopy.test.ts
+++ b/apps/extension/src/content/overlay/buildPhaseCopy.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { BUILD_PLAN_PRIMARY, buildPhaseDetail } from "./buildPhaseCopy";
+
+describe("buildPhaseCopy", () => {
+  it("exposes the primary loading line", () => {
+    expect(BUILD_PLAN_PRIMARY).toBe("Building a review plan");
+  });
+
+  it("maps each phase to user-facing detail copy", () => {
+    expect(buildPhaseDetail("extracting_diff", null)).toBe("Extracting the diff…");
+    expect(buildPhaseDetail("processing_diff", null)).toBe("Processing the diff…");
+    expect(buildPhaseDetail("sent_to_provider", "Claude (Anthropic)")).toBe(
+      "Sent it to Claude (Anthropic)…",
+    );
+    expect(buildPhaseDetail("sent_to_provider", null)).toBe("Sent it to your AI provider…");
+    expect(buildPhaseDetail("waiting_for_tokens", null)).toBe("Waiting for tokens…");
+    expect(buildPhaseDetail("tokens_streaming", null)).toBe("Tokens are streaming…");
+  });
+});

--- a/apps/extension/src/content/overlay/buildPhaseCopy.ts
+++ b/apps/extension/src/content/overlay/buildPhaseCopy.ts
@@ -1,0 +1,20 @@
+import type { BuildPhase } from "./store";
+
+/** Primary loading line while the review plan is being built. */
+export const BUILD_PLAN_PRIMARY = "Building a review plan";
+
+/** Subtext for the active pipeline phase. */
+export function buildPhaseDetail(phase: BuildPhase, providerLabel: string | null): string {
+  switch (phase) {
+    case "extracting_diff":
+      return "Extracting the diff…";
+    case "processing_diff":
+      return "Processing the diff…";
+    case "sent_to_provider":
+      return `Sent it to ${providerLabel ?? "your AI provider"}…`;
+    case "waiting_for_tokens":
+      return "Waiting for tokens…";
+    case "tokens_streaming":
+      return "Tokens are streaming…";
+  }
+}

--- a/apps/extension/src/content/overlay/components/ContextPanel.test.tsx
+++ b/apps/extension/src/content/overlay/components/ContextPanel.test.tsx
@@ -37,6 +37,27 @@ describe("ContextPanel error state", () => {
   });
 });
 
+describe("ContextPanel loading state", () => {
+  it("shows primary copy and phase detail under the spinner", () => {
+    render(
+      <ContextPanel
+        unit={null}
+        loading
+        loadingDetail="Extracting the diff…"
+        hasTitle
+        hasDescription
+      />,
+    );
+
+    expect(screen.getByTestId("context-panel-loading")).toBeInTheDocument();
+    expect(screen.getByText("Building a review plan")).toBeInTheDocument();
+    expect(screen.getByTestId("context-panel-loading-detail")).toHaveTextContent(
+      "Extracting the diff…",
+    );
+    expect(screen.getByRole("status", { name: /building a review plan/i })).toBeInTheDocument();
+  });
+});
+
 describe("ContextPanel needs-provider state", () => {
   it("renders the connect-provider prompt with its illustration", () => {
     render(<ContextPanel unit={null} needsProvider />);

--- a/apps/extension/src/content/overlay/components/ContextPanel.tsx
+++ b/apps/extension/src/content/overlay/components/ContextPanel.tsx
@@ -2,6 +2,7 @@ import type { ReviewErrorInfo, ReviewUnit } from "../../../lib/types";
 import { ConnectProviderPrompt } from "./ConnectProviderPrompt";
 import { KeyboardShortcuts } from "./KeyboardShortcuts";
 import { Button, Spinner } from "@guided-review/ui";
+import { BUILD_PLAN_PRIMARY } from "../buildPhaseCopy";
 import { missingMetadataHint, PR_DESCRIPTION_HINT } from "../missingMetadata";
 
 interface ContextPanelProps {
@@ -15,6 +16,8 @@ interface ContextPanelProps {
   /** No AI provider configured — prompt to connect one instead of erroring. */
   needsProvider?: boolean;
   loading?: boolean;
+  /** Pipeline phase detail shown under the primary loading line. */
+  loadingDetail?: string | null;
   /** Retry the failed API / review build step. */
   onRetry?: () => void;
 }
@@ -26,6 +29,7 @@ export function ContextPanel({
   error,
   needsProvider,
   loading,
+  loadingDetail,
   onRetry,
 }: ContextPanelProps) {
   // Takes precedence over `error`: a missing key is a setup step, not a failure.
@@ -94,9 +98,24 @@ export function ContextPanel({
           {hint}
         </div>
         {loading ? (
-          <div className="mt-4 flex items-center gap-2.5 border-t border-border-strong pt-3">
-            <Spinner label="Building remaining units" />
-            <p className="m-0 text-base text-muted">Building remaining units…</p>
+          <div
+            className="mt-4 flex items-start gap-2.5 border-t border-border-strong pt-3"
+            data-testid="context-panel-loading"
+          >
+            <Spinner
+              label={loadingDetail ? `${BUILD_PLAN_PRIMARY}. ${loadingDetail}` : BUILD_PLAN_PRIMARY}
+            />
+            <div className="min-w-0">
+              <p className="m-0 text-base text-muted">{BUILD_PLAN_PRIMARY}</p>
+              {loadingDetail ? (
+                <p
+                  className="m-0 mt-0.5 text-sm text-muted"
+                  data-testid="context-panel-loading-detail"
+                >
+                  {loadingDetail}
+                </p>
+              ) : null}
+            </div>
           </div>
         ) : (
           <KeyboardShortcuts />

--- a/apps/extension/src/content/overlay/components/DescriptionPane.tsx
+++ b/apps/extension/src/content/overlay/components/DescriptionPane.tsx
@@ -1,11 +1,8 @@
 import type { FileChangeStatus, ParsedDiff, PRContext } from "../../../lib/types";
 import { summarizeDiff, type FileDiffSummary } from "../../../lib/github/diffSummary";
-import { middleTruncate } from "../../../lib/middleTruncate";
 import { cn } from "@guided-review/ui";
 import { missingMetadataHint } from "../missingMetadata";
-
-/** Character budget for path labels in the narrow Changes column. */
-const DIFF_SUMMARY_PATH_MAX = 48;
+import { MiddleEllipsisText } from "./MiddleEllipsisText";
 
 interface DescriptionPaneProps {
   prContext: PRContext | null;
@@ -118,9 +115,7 @@ function DiffSummaryFileRow({ file }: { file: FileDiffSummary }) {
       >
         {badge.letter}
       </span>
-      <span className="min-w-0 truncate text-foreground" title={pathLabel}>
-        {middleTruncate(pathLabel, DIFF_SUMMARY_PATH_MAX)}
-      </span>
+      <MiddleEllipsisText text={pathLabel} maxWidth="100%" className="min-w-0 text-foreground" />
       <span className="inline-flex min-w-[4.5rem] shrink-0 items-center justify-end gap-1.5 text-right tabular-nums">
         {file.isBinaryOrElided ? (
           <span className="text-[0.8125rem] text-faint">binary</span>

--- a/apps/extension/src/content/overlay/components/DiffPane.tsx
+++ b/apps/extension/src/content/overlay/components/DiffPane.tsx
@@ -11,22 +11,21 @@ import { BinaryElidedEmptyState } from "./diff/BinaryElidedEmptyState";
 import { SplitHunk } from "./diff/SplitHunk";
 import { UnifiedHunk } from "./diff/UnifiedHunk";
 import { useSelectionDerived } from "./diff/useSelectionDerived";
+import { MiddleEllipsisText } from "./MiddleEllipsisText";
 import { TestsUnitIcon } from "./TestsUnitIcon";
-import { middleTruncate } from "../../../lib/middleTruncate";
 
 /** How long the search-match flash highlight stays on the target line/file. */
 const SEARCH_HIGHLIGHT_MS = 1600;
 
-/** Character budget for file-header path labels in the diff viewer. */
-const DIFF_FILE_PATH_MAX = 80;
-
-/** Character budget for the unit title (often a file path without AI). */
-const UNIT_TITLE_MAX = 64;
-
 interface DiffPaneProps {
   files: ResolvedUnitFile[];
-  /** Title of the currently active review unit. */
+  /**
+   * Title of the currently active review unit (`displayTitle ?? title`).
+   * Already display-ready — path plans pre-truncate in buildFileReviewPlan.
+   */
   unitTitle: string;
+  /** Full untruncated title for the native tooltip (falls back to unitTitle). */
+  unitTitleTooltip?: string;
   /** When true, show the flask icon (tests review unit). */
   isTestsUnit?: boolean;
   /** Review unit id for associating saved drafts. */
@@ -45,6 +44,7 @@ interface DiffPaneProps {
 export function DiffPane({
   files,
   unitTitle,
+  unitTitleTooltip,
   isTestsUnit = false,
   unitId,
   selectableForUnit,
@@ -162,11 +162,9 @@ export function DiffPane({
         <h2
           className="flex min-w-0 items-center gap-1.5 text-lg font-semibold text-foreground"
           data-testid="diff-unit-title"
-          title={unitTitle}
+          title={unitTitleTooltip ?? unitTitle}
         >
-          <span className="min-w-0 truncate" title={unitTitle}>
-            {middleTruncate(unitTitle, UNIT_TITLE_MAX)}
-          </span>
+          <span className="min-w-0 break-words">{unitTitle}</span>
           {isTestsUnit && <TestsUnitIcon className="shrink-0 text-muted" size={16} />}
         </h2>
         <div className="flex shrink-0 items-center gap-2">
@@ -207,9 +205,7 @@ export function DiffPane({
             data-testid={fileSearchHit ? "diff-file-search-highlight" : undefined}
           >
             <div className="flex min-w-0 items-baseline gap-2.5 border-b border-border bg-background px-3 py-2 font-mono text-sm">
-              <span className="min-w-0 flex-1 truncate" title={pathLabel}>
-                {middleTruncate(pathLabel, DIFF_FILE_PATH_MAX)}
-              </span>
+              <MiddleEllipsisText text={pathLabel} maxWidth="100%" className="min-w-0 flex-1" />
               {!language && !file.isBinaryOrElided && (
                 <span className="shrink-0 font-normal text-muted italic">
                   {extension

--- a/apps/extension/src/content/overlay/components/DiffPane.tsx
+++ b/apps/extension/src/content/overlay/components/DiffPane.tsx
@@ -164,10 +164,10 @@ export function DiffPane({
           data-testid="diff-unit-title"
           title={unitTitle}
         >
-          {isTestsUnit && <TestsUnitIcon className="shrink-0 text-muted" size={16} />}
           <span className="min-w-0 truncate" title={unitTitle}>
             {middleTruncate(unitTitle, UNIT_TITLE_MAX)}
           </span>
+          {isTestsUnit && <TestsUnitIcon className="shrink-0 text-muted" size={16} />}
         </h2>
         <div className="flex shrink-0 items-center gap-2">
           {commentModeActive ? (

--- a/apps/extension/src/content/overlay/components/FooterNav.tsx
+++ b/apps/extension/src/content/overlay/components/FooterNav.tsx
@@ -11,7 +11,8 @@ const navBtnBase =
   "inline-flex cursor-pointer items-center gap-2 rounded-md border px-4 py-[7px] text-base font-medium disabled:cursor-default disabled:opacity-40";
 
 export function FooterNav({ currentIndex, total, onPrev, onNext }: FooterNavProps) {
-  const stepLabel = total > 0 ? `Step ${currentIndex + 1} of ${total}` : "No steps yet";
+  const stepLabel =
+    total > 0 ? `Review unit ${currentIndex + 1} of ${total}` : "No review units yet";
 
   return (
     <footer
@@ -23,7 +24,7 @@ export function FooterNav({ currentIndex, total, onPrev, onNext }: FooterNavProp
         className={cn(navBtnBase, "border-border bg-surface text-foreground")}
         onClick={onPrev}
         disabled={currentIndex === 0 || total === 0}
-        aria-label="Previous step"
+        aria-label="Previous review unit"
       >
         Previous
         <Kbd>←</Kbd>
@@ -49,7 +50,7 @@ export function FooterNav({ currentIndex, total, onPrev, onNext }: FooterNavProp
         )}
         onClick={onNext}
         disabled={total === 0 || currentIndex >= total - 1}
-        aria-label="Next step"
+        aria-label="Next review unit"
       >
         Next
         <Kbd>→</Kbd>

--- a/apps/extension/src/content/overlay/components/MiddleEllipsisText.test.tsx
+++ b/apps/extension/src/content/overlay/components/MiddleEllipsisText.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MiddleEllipsisText } from "./MiddleEllipsisText";
+
+describe("MiddleEllipsisText", () => {
+  it("renders the full text when width cannot be measured", () => {
+    // jsdom typically reports clientWidth 0, so the component falls back to full text.
+    render(<MiddleEllipsisText text="src/very/long/path/to/file.ts" maxWidth="100%" />);
+
+    expect(screen.getByTitle("src/very/long/path/to/file.ts")).toHaveTextContent(
+      "src/very/long/path/to/file.ts",
+    );
+  });
+
+  it("exposes the full path via title for tooltips", () => {
+    render(<MiddleEllipsisText text="apps/extension/src/lib/types.ts" maxWidth={120} />);
+
+    expect(screen.getByTitle("apps/extension/src/lib/types.ts")).toBeInTheDocument();
+  });
+
+  it("applies maxWidth as a CSS style", () => {
+    render(<MiddleEllipsisText text="a/b.ts" maxWidth={80} />);
+
+    expect(screen.getByTitle("a/b.ts")).toHaveStyle({ maxWidth: "80px" });
+  });
+});

--- a/apps/extension/src/content/overlay/components/MiddleEllipsisText.tsx
+++ b/apps/extension/src/content/overlay/components/MiddleEllipsisText.tsx
@@ -1,0 +1,116 @@
+import { useLayoutEffect, useRef, useState } from "react";
+import { cn } from "@guided-review/ui";
+
+import { middleTruncate } from "../../../lib/middleTruncate";
+
+interface MiddleEllipsisTextProps {
+  /** Full text to display; truncated in the middle when it overflows. */
+  text: string;
+  /**
+   * CSS max-width from the parent layout. Required — width-aware middle
+   * truncation only runs when the parent constrains width via CSS.
+   */
+  maxWidth: string | number;
+  className?: string;
+}
+
+/**
+ * Single-line path label that middle-truncates to fit a CSS max-width so both
+ * the start and end stay visible. Full string is always available via `title`.
+ *
+ * Path labels only — do not use for prose review unit titles (those wrap).
+ */
+export function MiddleEllipsisText({ text, maxWidth, className }: MiddleEllipsisTextProps) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const [display, setDisplay] = useState(text);
+  const maxWidthStyle = typeof maxWidth === "number" ? `${maxWidth}px` : maxWidth;
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const update = () => {
+      const width = el.clientWidth;
+      if (width <= 0) {
+        setDisplay(text);
+        return;
+      }
+
+      const maxChars = maxCharsForWidth(text, width, el);
+      setDisplay(middleTruncate(text, maxChars));
+    };
+
+    update();
+
+    // jsdom has no ResizeObserver; fall back to window resize only.
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", update);
+      return () => window.removeEventListener("resize", update);
+    }
+
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [text, maxWidthStyle]);
+
+  return (
+    <span
+      ref={ref}
+      className={cn("block min-w-0 overflow-hidden whitespace-nowrap", className)}
+      style={{ maxWidth: maxWidthStyle }}
+      title={text}
+    >
+      {display}
+    </span>
+  );
+}
+
+/** Shared canvas for measureText; recreated only if document is unavailable. */
+let measureCanvas: HTMLCanvasElement | null = null;
+
+function getMeasureContext(el: HTMLElement): CanvasRenderingContext2D | null {
+  if (typeof document === "undefined") return null;
+  if (!measureCanvas) measureCanvas = document.createElement("canvas");
+  const ctx = measureCanvas.getContext("2d");
+  if (!ctx) return null;
+  const style = getComputedStyle(el);
+  // Match the rendered font so char widths track mono/proportional fonts.
+  ctx.font = style.font || `${style.fontSize} ${style.fontFamily}`;
+  return ctx;
+}
+
+/**
+ * Largest character count whose rendered width fits in `width` px.
+ * Binary-searches with canvas measureText; falls back to a mono estimate.
+ */
+function maxCharsForWidth(text: string, width: number, el: HTMLElement): number {
+  if (text.length === 0) return 0;
+
+  const ctx = getMeasureContext(el);
+  if (!ctx) {
+    // jsdom / no canvas: rough mono estimate (~0.6em per char is typical).
+    const fontSize = parseFloat(getComputedStyle(el).fontSize) || 13;
+    return Math.max(1, Math.floor(width / (fontSize * 0.6)));
+  }
+
+  if (ctx.measureText(text).width <= width) {
+    return text.length;
+  }
+
+  let lo = 1;
+  let hi = text.length;
+  let best = 1;
+
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    const candidate = middleTruncate(text, mid);
+    if (ctx.measureText(candidate).width <= width) {
+      best = mid;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+
+  return best;
+}

--- a/apps/extension/src/content/overlay/components/Sidebar.tsx
+++ b/apps/extension/src/content/overlay/components/Sidebar.tsx
@@ -53,21 +53,22 @@ export function Sidebar({ plan, currentUnitIndex, stillBuilding, onSelectUnit }:
               aria-current={isActive ? "true" : undefined}
               className={cn(
                 "mb-0.5 flex w-full cursor-pointer items-start rounded-md border-none bg-transparent p-2 text-left text-base leading-snug text-foreground",
-                isActive && "bg-primary-muted text-primary! hover:bg-primary-muted",
+                "hover:bg-primary-muted",
+                isActive && "bg-primary-muted text-primary!",
               )}
               onClick={() => onSelectUnit(displayIndex)}
             >
               <span className={cn("mr-1.5 shrink-0", isActive ? "text-primary" : "text-muted")}>
                 {displayIndex + 1}.
               </span>
-              {isTestsUnit && (
-                <TestsUnitIcon
-                  className={cn("mr-1.5 mt-0.5 shrink-0", isActive ? "text-primary" : "text-muted")}
-                />
-              )}
               <span className="min-w-0 truncate" title={unit.title}>
                 {middleTruncate(unit.title, UNIT_TITLE_MAX)}
               </span>
+              {isTestsUnit && (
+                <TestsUnitIcon
+                  className={cn("ml-1.5 mt-0.5 shrink-0", isActive ? "text-primary" : "text-muted")}
+                />
+              )}
             </button>
           );
         })}

--- a/apps/extension/src/content/overlay/components/Sidebar.tsx
+++ b/apps/extension/src/content/overlay/components/Sidebar.tsx
@@ -1,14 +1,10 @@
 import { useEffect, useRef } from "react";
 import type { ReviewPlan } from "../../../lib/types";
-import { middleTruncate } from "../../../lib/middleTruncate";
 import { cn } from "@guided-review/ui";
 import { buildDisplayUnits } from "../displayUnits";
 import { TestsUnitIcon } from "./TestsUnitIcon";
 
 const SKELETON_COUNT = 4;
-
-/** Character budget for unit titles (often file paths when no AI is configured). */
-const UNIT_TITLE_MAX = 40;
 
 interface SidebarProps {
   plan: ReviewPlan | null;
@@ -45,12 +41,18 @@ export function Sidebar({ plan, currentUnitIndex, stillBuilding, onSelectUnit }:
         {displayUnits.map((unit, displayIndex) => {
           const isActive = displayIndex === currentUnitIndex;
           const isTestsUnit = unit.kind === "review" && unit.unit.kind === "tests";
+          // displayTitle is pre-truncated in buildFileReviewPlan for path labels;
+          // AI units omit it and show title. Render as plain text either way.
+          const label =
+            unit.kind === "review" ? (unit.unit.displayTitle ?? unit.unit.title) : unit.title;
+          const tooltip = unit.kind === "review" ? unit.unit.title : unit.title;
           return (
             <button
               key={unit.id}
               type="button"
               ref={isActive ? activeItemRef : undefined}
               aria-current={isActive ? "true" : undefined}
+              title={tooltip}
               className={cn(
                 "mb-0.5 flex w-full cursor-pointer items-start rounded-md border-none bg-transparent p-2 text-left text-base leading-snug text-foreground",
                 "hover:bg-primary-muted",
@@ -61,9 +63,7 @@ export function Sidebar({ plan, currentUnitIndex, stillBuilding, onSelectUnit }:
               <span className={cn("mr-1.5 shrink-0", isActive ? "text-primary" : "text-muted")}>
                 {displayIndex + 1}.
               </span>
-              <span className="min-w-0 truncate" title={unit.title}>
-                {middleTruncate(unit.title, UNIT_TITLE_MAX)}
-              </span>
+              <span className="min-w-0 break-words">{label}</span>
               {isTestsUnit && (
                 <TestsUnitIcon
                   className={cn("ml-1.5 mt-0.5 shrink-0", isActive ? "text-primary" : "text-muted")}

--- a/apps/extension/src/content/overlay/components/TestsUnitIcon.tsx
+++ b/apps/extension/src/content/overlay/components/TestsUnitIcon.tsx
@@ -1,4 +1,4 @@
-/** Flask mark for `kind: "tests"` review units — filled via currentColor. */
+/** Lab flask mark for `kind: "tests"` review units — stroke via currentColor. */
 export function TestsUnitIcon({
   className,
   size = 14,
@@ -14,13 +14,20 @@ export function TestsUnitIcon({
       width={size}
       height={size}
       viewBox="0 0 16 16"
-      fill="currentColor"
+      fill="none"
       xmlns="http://www.w3.org/2000/svg"
       aria-hidden="true"
       data-testid={testId}
     >
-      {/* Simple flask: neck + bulb */}
-      <path d="M6.25 1.5a.75.75 0 0 0 0 1.5h.5v3.38L3.22 12.1A2 2 0 0 0 4.9 15h6.2a2 2 0 0 0 1.68-2.9L9.25 6.38V3h.5a.75.75 0 0 0 0-1.5h-3.5ZM7.75 6.9l3.35 5.58a.5.5 0 0 1-.42.72H5.32a.5.5 0 0 1-.42-.72L8.25 6.9V3h-.5v3.9Z" />
+      {/* Outline lab flask: neck, bulb, liquid line */}
+      <path
+        d="M6 1.75h4M7 1.75v3.1L3.35 11.2A2.25 2.25 0 0 0 5.28 14.5h5.44a2.25 2.25 0 0 0 1.93-3.3L9 4.85V1.75"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path d="M4.2 9.75h7.6" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" />
     </svg>
   );
 }

--- a/apps/extension/src/content/overlay/store.test.ts
+++ b/apps/extension/src/content/overlay/store.test.ts
@@ -43,6 +43,8 @@ function resetStore(): void {
     status: "idle",
     error: null,
     needsProvider: false,
+    buildPhase: null,
+    providerLabel: null,
     diff: null,
     plan: null,
     prContext: null,
@@ -103,6 +105,8 @@ describe("useReviewStore", () => {
       plan: planFixture(1),
       diff: diffFixture(),
       currentUnitIndex: 2,
+      buildPhase: "tokens_streaming",
+      providerLabel: "OpenAI",
     });
     useReviewStore.getState().startLoading(SESSION_KEY);
     const state = useReviewStore.getState();
@@ -112,9 +116,11 @@ describe("useReviewStore", () => {
     expect(state.diff).toBeNull();
     expect(state.currentUnitIndex).toBe(0);
     expect(state.sessionKey).toBe(SESSION_KEY);
+    expect(state.buildPhase).toBe("extracting_diff");
+    expect(state.providerLabel).toBeNull();
   });
 
-  it("setDiff stores the diff without changing status or plan", () => {
+  it("setDiff stores the diff and advances buildPhase to processing", () => {
     resetStore();
     useReviewStore.getState().startLoading(SESSION_KEY);
     const diff = diffFixture();
@@ -124,6 +130,7 @@ describe("useReviewStore", () => {
     expect(state.status).toBe("loading");
     expect(state.diff).toBe(diff);
     expect(state.plan).toBeNull();
+    expect(state.buildPhase).toBe("processing_diff");
   });
 
   it("beginStreaming and appendUnit grow the plan while streaming", () => {
@@ -139,6 +146,7 @@ describe("useReviewStore", () => {
     useReviewStore.getState().appendUnit(unit, gen);
     expect(useReviewStore.getState().plan?.units).toHaveLength(1);
     expect(useReviewStore.getState().status).toBe("streaming");
+    expect(useReviewStore.getState().buildPhase).toBe("tokens_streaming");
 
     // Duplicate id is ignored.
     useReviewStore.getState().appendUnit(unit, gen);
@@ -147,6 +155,40 @@ describe("useReviewStore", () => {
     // Stale generation is ignored.
     useReviewStore.getState().appendUnit({ ...unit, id: "stale" }, gen - 1);
     expect(useReviewStore.getState().plan?.units).toHaveLength(1);
+  });
+
+  it("setBuildPhase respects stream generation", () => {
+    resetStore();
+    useReviewStore.getState().startLoading(SESSION_KEY);
+    const gen = useReviewStore.getState().streamGeneration;
+    useReviewStore.getState().setBuildPhase("sent_to_provider", gen);
+    expect(useReviewStore.getState().buildPhase).toBe("sent_to_provider");
+    useReviewStore.getState().setBuildPhase("waiting_for_tokens", gen - 1);
+    expect(useReviewStore.getState().buildPhase).toBe("sent_to_provider");
+  });
+
+  it("beginRetry with a cached diff starts at processing_diff", () => {
+    resetStore();
+    useReviewStore.getState().startLoading(SESSION_KEY);
+    useReviewStore.getState().setDiff(diffFixture());
+    useReviewStore.getState().setProviderLabel("Claude (Anthropic)");
+    const gen = useReviewStore.getState().beginRetry();
+    const state = useReviewStore.getState();
+    expect(gen).toBe(state.streamGeneration);
+    expect(state.status).toBe("streaming");
+    expect(state.buildPhase).toBe("processing_diff");
+    expect(state.providerLabel).toBe("Claude (Anthropic)");
+  });
+
+  it("setReady and setError clear buildPhase", () => {
+    resetStore();
+    useReviewStore.setState({ buildPhase: "tokens_streaming" });
+    useReviewStore.getState().setReady(diffFixture(), planFixture(1));
+    expect(useReviewStore.getState().buildPhase).toBeNull();
+
+    useReviewStore.setState({ buildPhase: "waiting_for_tokens" });
+    useReviewStore.getState().setError("boom");
+    expect(useReviewStore.getState().buildPhase).toBeNull();
   });
 
   it("goNext works mid-stream once units have been appended", () => {

--- a/apps/extension/src/content/overlay/store.ts
+++ b/apps/extension/src/content/overlay/store.ts
@@ -27,6 +27,18 @@ import {
 } from "./diffViewMode";
 
 export type ReviewStatus = "idle" | "loading" | "streaming" | "ready" | "error";
+
+/**
+ * Fine-grained progress while the review plan is being built (diff fetch →
+ * provider stream). Orthogonal to coarse `status`; cleared when ready/error.
+ */
+export type BuildPhase =
+  | "extracting_diff"
+  | "processing_diff"
+  | "sent_to_provider"
+  | "waiting_for_tokens"
+  | "tokens_streaming";
+
 export type { DiffViewMode };
 
 interface PersistedSession {
@@ -56,6 +68,10 @@ interface ReviewState {
    * the user to connect a provider for ordering and commentary.
    */
   needsProvider: boolean;
+  /** Pipeline sub-status while loading/streaming; null when idle/ready/error. */
+  buildPhase: BuildPhase | null;
+  /** Catalog display name of the configured provider (for "Sent it to …" copy). */
+  providerLabel: string | null;
   diff: ParsedDiff | null;
   plan: ReviewPlan | null;
   prContext: PRContext | null;
@@ -87,6 +103,8 @@ interface ReviewState {
   startLoading: (sessionKey: string) => void;
   setPRContext: (prContext: PRContext) => void;
   setDiff: (diff: ParsedDiff) => void;
+  setBuildPhase: (phase: BuildPhase, generation?: number) => void;
+  setProviderLabel: (label: string | null) => void;
   beginStreaming: (generation: number) => void;
   /**
    * Start a retry of the annotation stream without clearing the already-fetched
@@ -147,6 +165,8 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   status: "idle",
   error: null,
   needsProvider: false,
+  buildPhase: null,
+  providerLabel: null,
   diff: null,
   plan: null,
   prContext: null,
@@ -168,6 +188,8 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
       status: "loading",
       error: null,
       needsProvider: false,
+      buildPhase: "extracting_diff",
+      providerLabel: null,
       currentUnitIndex: 0,
       plan: null,
       diff: null,
@@ -179,7 +201,19 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
 
   setPRContext: (prContext) => set({ prContext }),
 
-  setDiff: (diff) => set({ diff }),
+  setDiff: (diff) =>
+    set({
+      diff,
+      // Diff just landed — move past "extracting" into local/provider prep.
+      buildPhase: "processing_diff",
+    }),
+
+  setBuildPhase: (phase, generation) => {
+    if (generation !== undefined && get().streamGeneration !== generation) return;
+    set({ buildPhase: phase });
+  },
+
+  setProviderLabel: (label) => set({ providerLabel: label }),
 
   beginStreaming: (generation) => {
     if (get().streamGeneration !== generation) return;
@@ -197,6 +231,9 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
       // prompt must not survive into the new attempt.
       needsProvider: false,
       plan: hasDiff ? { units: [] } : null,
+      // Cached-diff retry skips extract; full restart goes through startLoading.
+      buildPhase: hasDiff ? "processing_diff" : "extracting_diff",
+      providerLabel: hasDiff ? get().providerLabel : null,
       ...COMMENT_UI_RESET,
     });
     return nextGeneration;
@@ -213,6 +250,8 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
         status: "streaming",
         plan: { units: [...existing, unit] },
         error: null,
+        // Units imply tokens already arrived (STATUS may have set this earlier).
+        buildPhase: "tokens_streaming",
       };
     });
   },
@@ -228,6 +267,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
         plan,
         currentUnitIndex: index,
         error: null,
+        buildPhase: null,
       };
     });
   },
@@ -241,13 +281,13 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
       get().setNeedsProvider();
       return;
     }
-    set({ status: "error", error: normalized });
+    set({ status: "error", error: normalized, buildPhase: null });
   },
 
   setNeedsProvider: () => {
     const { diff } = get();
     if (!diff) {
-      set({ needsProvider: true, error: null });
+      set({ needsProvider: true, error: null, buildPhase: null });
       return;
     }
     // Diff already fetched (or the background backstop fired mid-stream):
@@ -258,6 +298,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
       status: "ready",
       plan: buildFileReviewPlan(diff),
       currentUnitIndex: 0,
+      buildPhase: null,
       ...COMMENT_UI_RESET,
     });
   },
@@ -531,6 +572,8 @@ export async function restoreSession(sessionKey: string): Promise<boolean> {
     currentUnitIndex,
     sessionKey,
     error: null,
+    buildPhase: null,
+    providerLabel: null,
     draftComments: saved.draftComments ?? [],
     ...COMMENT_UI_RESET,
   });

--- a/apps/extension/src/lib/messaging.test.ts
+++ b/apps/extension/src/lib/messaging.test.ts
@@ -79,6 +79,23 @@ describe("messaging", () => {
     expect(port.disconnect).toHaveBeenCalled();
   });
 
+  it("streamReviewPlan delivers STATUS events to onStatus", () => {
+    const onStatus = vi.fn();
+    streamReviewPlan({ files: [] }, { title: "t" } as PRContext, {
+      onUnit: vi.fn(),
+      onDone: vi.fn(),
+      onError: vi.fn(),
+      onStatus,
+    });
+    const port = vi.mocked(chrome.runtime.connect).mock.results[0].value as MockPort;
+
+    port.__emitMessage({ type: "STATUS", phase: "waiting_for_tokens" });
+    port.__emitMessage({ type: "STATUS", phase: "tokens_streaming" });
+
+    expect(onStatus).toHaveBeenNthCalledWith(1, "waiting_for_tokens");
+    expect(onStatus).toHaveBeenNthCalledWith(2, "tokens_streaming");
+  });
+
   it("streamReviewPlan delivers ERROR events", () => {
     const onUnit = vi.fn();
     const onDone = vi.fn();

--- a/apps/extension/src/lib/messaging.ts
+++ b/apps/extension/src/lib/messaging.ts
@@ -45,6 +45,8 @@ export interface StreamReviewPlanHandlers {
   onUnit: (unit: ReviewUnit) => void;
   onDone: (plan: ReviewPlan) => void;
   onError: (error: ReviewErrorInfo) => void;
+  /** Optional: waiting_for_tokens / tokens_streaming from the worker. */
+  onStatus?: (phase: "waiting_for_tokens" | "tokens_streaming") => void;
 }
 
 /**
@@ -71,6 +73,9 @@ export function streamReviewPlan(
     if (!message || typeof message !== "object" || !("type" in message)) return;
 
     switch (message.type) {
+      case "STATUS":
+        handlers.onStatus?.(message.phase);
+        return;
       case "UNIT":
         handlers.onUnit(message.unit);
         return;

--- a/apps/extension/src/lib/middleTruncate.test.ts
+++ b/apps/extension/src/lib/middleTruncate.test.ts
@@ -7,19 +7,27 @@ describe("middleTruncate", () => {
     expect(middleTruncate("short", 5)).toBe("short");
   });
 
-  it("places the ellipsis in the middle when truncating", () => {
+  it("keeps the basename intact and truncates only the path prefix", () => {
     const path = "apps/extension/src/content/overlay/components/DescriptionPane.tsx";
     const result = middleTruncate(path, 40);
     expect(result.length).toBe(40);
     expect(result).toContain("…");
-    expect(result.startsWith("apps/extension")).toBe(true);
-    expect(result.endsWith("DescriptionPane.tsx")).toBe(true);
-    // Not end-truncated: last char of full path must still appear.
-    expect(result.at(-1)).toBe("x");
+    // Basename always fully visible after the final /.
+    expect(result.endsWith("/DescriptionPane.tsx")).toBe(true);
+    expect(result).toMatch(/^apps\//);
+    // Not end-truncated: full basename must appear.
     expect(result).not.toMatch(/Descripti…$/);
   });
 
-  it("handles even and odd character budgets", () => {
+  it("never chops the final path segment when there is room for it", () => {
+    const path = "src/very/long/path/to/file.ts";
+    const result = middleTruncate(path, 20);
+    expect(result.endsWith("/file.ts")).toBe(true);
+    expect(result).toContain("…");
+    expect(result.length).toBe(20);
+  });
+
+  it("handles even and odd character budgets for non-path strings", () => {
     const text = "abcdefghij"; // 10
     // max 7 → budget 6 for content + 1 ellipsis → start 3, end 3
     expect(middleTruncate(text, 7)).toBe("abc…hij");
@@ -27,12 +35,11 @@ describe("middleTruncate", () => {
     expect(middleTruncate(text, 8)).toBe("abc…ghij");
   });
 
-  it("handles rename labels", () => {
+  it("handles rename labels by keeping the final basename", () => {
     const label = "src/very/long/old-name.ts → src/very/long/new-name.ts";
     const result = middleTruncate(label, 30);
     expect(result.length).toBe(30);
-    expect(result.startsWith("src/")).toBe(true);
-    expect(result.endsWith(".ts")).toBe(true);
+    expect(result.endsWith("/new-name.ts")).toBe(true);
     expect(result).toContain("…");
   });
 
@@ -45,12 +52,26 @@ describe("middleTruncate", () => {
     expect(middleTruncate("long-path/file.ts", 1)).toBe("…");
   });
 
-  it("keeps only the end when there is no room for a start segment", () => {
+  it("falls back to basename with leading ellipsis when prefix cannot fit", () => {
+    // basename "file.ts" is 7; with ellipsis fits in 8, no room for prefix chars.
+    expect(middleTruncate("long-path/file.ts", 8)).toBe("…file.ts");
+  });
+
+  it("keeps only the end when there is no room for a start segment (non-path)", () => {
     // maxLength 2 → ellipsis + 1 end char
     expect(middleTruncate("abcdef", 2)).toBe("…f");
   });
 
   it("accepts a custom ellipsis", () => {
     expect(middleTruncate("abcdefghij", 7, "...")).toBe("ab...ij");
+  });
+
+  it("middle-truncates a long basename when it alone exceeds the budget", () => {
+    const path = "dir/verylongfilenamewithoutspaces.ts";
+    const result = middleTruncate(path, 12);
+    expect(result.length).toBe(12);
+    expect(result).toContain("…");
+    // Path prefix dropped; basename itself middle-truncated.
+    expect(result).not.toContain("/");
   });
 });

--- a/apps/extension/src/lib/middleTruncate.ts
+++ b/apps/extension/src/lib/middleTruncate.ts
@@ -3,10 +3,56 @@
  * remain visible. Prefer this for file paths over end-ellipsis (CSS
  * `text-overflow: ellipsis`), which hides the basename.
  *
+ * Path-aware: when `text` contains `/`, the final segment after the last `/`
+ * is always kept intact and truncation is applied only to characters before
+ * it. Non-path strings fall back to character-wise middle truncation.
+ *
  * `maxLength` is a character budget for the *result* (including the ellipsis).
  * When `text` already fits, it is returned unchanged.
  */
 export function middleTruncate(text: string, maxLength: number, ellipsis = "…"): string {
+  if (maxLength <= 0) return "";
+  if (text.length <= maxLength) return text;
+
+  if (maxLength <= ellipsis.length) {
+    return ellipsis.slice(0, maxLength);
+  }
+
+  const lastSlash = text.lastIndexOf("/");
+  if (lastSlash === -1) {
+    return middleTruncateChars(text, maxLength, ellipsis);
+  }
+
+  const basename = text.slice(lastSlash + 1);
+  // "/" + basename must stay; truncate only the directory prefix.
+  const reserved = 1 + basename.length;
+  const prefixBudget = maxLength - reserved;
+
+  if (prefixBudget <= 0) {
+    // No room for any directory prefix — keep as much of the basename as fits,
+    // with a leading ellipsis when we have to drop the path.
+    if (basename.length <= maxLength) {
+      // Prefer "…basename" when it fits so the path loss is obvious.
+      if (ellipsis.length + basename.length <= maxLength) {
+        return ellipsis + basename;
+      }
+      return basename;
+    }
+    // Basename alone exceeds the budget: end-bias so the extension stays.
+    return middleTruncateChars(basename, maxLength, ellipsis);
+  }
+
+  const prefix = text.slice(0, lastSlash);
+  if (prefix.length <= prefixBudget) {
+    // Prefix fits without truncation (only possible if basename grew somehow).
+    return prefix + "/" + basename;
+  }
+
+  return middleTruncateChars(prefix, prefixBudget, ellipsis) + "/" + basename;
+}
+
+/** Character-wise middle truncation (no path awareness). */
+function middleTruncateChars(text: string, maxLength: number, ellipsis: string): string {
   if (maxLength <= 0) return "";
   if (text.length <= maxLength) return text;
 

--- a/apps/extension/src/lib/review/fileReviewPlan.test.ts
+++ b/apps/extension/src/lib/review/fileReviewPlan.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { buildFileReviewPlan } from "./fileReviewPlan";
+import { buildFileReviewPlan, FILE_UNIT_TITLE_MAX } from "./fileReviewPlan";
 import { resolveUnitFiles } from "../../content/overlay/selectors";
+import { middleTruncate } from "../middleTruncate";
 import type { ParsedDiff } from "../types";
 
 function diffFixture(): ParsedDiff {
@@ -46,7 +47,27 @@ describe("buildFileReviewPlan", () => {
       "src/core.test.ts",
       "package.json",
     ]);
+    // Short paths fit the budget — displayTitle equals the full path.
+    expect(plan.units.map((u) => u.displayTitle)).toEqual([
+      "src/core.ts",
+      "src/core.test.ts",
+      "package.json",
+    ]);
     expect(new Set(plan.units.map((u) => u.id)).size).toBe(3);
+  });
+
+  it("middle-truncates long path labels into displayTitle, keeps full path on title", () => {
+    const longPath =
+      "apps/extension/src/content/overlay/components/VeryLongFileNameForTruncation.tsx";
+    const diff: ParsedDiff = {
+      files: [{ path: longPath, status: "modified", isBinaryOrElided: false, hunks: [] }],
+    };
+
+    const plan = buildFileReviewPlan(diff);
+    expect(plan.units[0].title).toBe(longPath);
+    expect(plan.units[0].displayTitle).toBe(middleTruncate(longPath, FILE_UNIT_TITLE_MAX));
+    expect(plan.units[0].displayTitle!.length).toBe(FILE_UNIT_TITLE_MAX);
+    expect(plan.units[0].displayTitle).toContain("…");
   });
 
   it("leaves context empty rather than inventing commentary", () => {

--- a/apps/extension/src/lib/review/fileReviewPlan.ts
+++ b/apps/extension/src/lib/review/fileReviewPlan.ts
@@ -1,5 +1,13 @@
+import { middleTruncate } from "../middleTruncate";
 import type { ParsedDiff, ReviewPlan, ReviewUnit } from "../types";
 import { roleForPath } from "./pathClass";
+
+/**
+ * Character budget for path titles in the no-AI one-unit-per-file plan.
+ * Matches the sidebar-width budget used when paths were truncated at render.
+ * Full path stays on `title` for tooltips; truncated form is `displayTitle`.
+ */
+export const FILE_UNIT_TITLE_MAX = 40;
 
 /**
  * Fallback plan for when no AI provider is configured: one review unit per
@@ -12,7 +20,10 @@ export function buildFileReviewPlan(diff: ParsedDiff): ReviewPlan {
     const role = roleForPath(file.path);
     return {
       id: `file-${index}-${file.path}`,
+      // Full path — tooltips, identity. Truncated label is displayTitle.
       title: file.path,
+      // Pre-truncated so the overlay can render the unit label as plain text.
+      displayTitle: middleTruncate(file.path, FILE_UNIT_TITLE_MAX),
       kind: role === "test" ? "tests" : "change",
       // Deliberately empty: the context panel shows the connect-a-provider
       // prompt instead of inventing commentary we have no model to write.

--- a/apps/extension/src/lib/review/reviewPlan.test.ts
+++ b/apps/extension/src/lib/review/reviewPlan.test.ts
@@ -72,6 +72,8 @@ describe("parseReviewUnit", () => {
     expect(cleaned).toHaveLength(1);
     expect(cleaned[0].files[0].hunkIds).toEqual(["src/foo.ts#0"]);
     expect(cleaned[0].kind).toBe("change");
+    // AI units show prose titles as-is — no pre-truncated displayTitle.
+    expect(cleaned[0].displayTitle).toBeUndefined();
   });
 
   it("drops hallucinated hunk ids but keeps the file ref if the file is real", () => {

--- a/apps/extension/src/lib/types.ts
+++ b/apps/extension/src/lib/types.ts
@@ -194,8 +194,12 @@ export const NO_API_KEY_ERROR_CODE = "no_api_key";
  * Progressive events on the `annotate-review` port from background → content.
  * Complete, validated units are pushed as they become available; DONE carries
  * the final merged plan; ERROR ends the stream with structured error details.
+ * STATUS updates the overlay's build-phase subtext (waiting / first token).
  */
+export type AnnotateStreamStatusPhase = "waiting_for_tokens" | "tokens_streaming";
+
 export type AnnotateReviewStreamEvent =
+  | { type: "STATUS"; phase: AnnotateStreamStatusPhase }
   | { type: "UNIT"; unit: ReviewUnit }
   | { type: "DONE"; plan: ReviewPlan }
   | { type: "ERROR"; error: ReviewErrorInfo };

--- a/apps/extension/src/lib/types.ts
+++ b/apps/extension/src/lib/types.ts
@@ -109,6 +109,13 @@ export interface ReviewUnit {
   id: string;
   title: string;
   /**
+   * When set, the overlay shows this instead of `title`. The no-AI
+   * one-unit-per-file plan sets this to a middle-truncated path so the UI
+   * renders the label as plain text (no path-aware truncation at render).
+   * AI units omit it and show `title`. Not model output (not in the LLM schema).
+   */
+  displayTitle?: string;
+  /**
    * `change` = production (and optional config); `tests` = test files only.
    * Never mixed — validation splits impure units.
    */

--- a/apps/extension/src/test/chromeMock.ts
+++ b/apps/extension/src/test/chromeMock.ts
@@ -138,7 +138,7 @@ export function createChromeMock() {
       getManifest: vi.fn(() => ({
         manifest_version: 3,
         name: "Guided Review",
-        version: "0.1.0",
+        version: "0.2.0",
       })),
       openOptionsPage: vi.fn(),
       lastError: undefined as { message?: string } | undefined,

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
     },
     "apps/extension": {
       "name": "@guided-review/extension",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource/victor-mono": "^5.3.0",

--- a/packages/ui/src/components/Button.test.tsx
+++ b/packages/ui/src/components/Button.test.tsx
@@ -30,6 +30,15 @@ describe("Button", () => {
     expect(primary).not.toContain("enabled:hover:");
   });
 
+  it("tints nested kbd chips on destructive to a darker danger shade", () => {
+    const destructive = buttonClassName({ variant: "destructive" });
+    expect(destructive).toContain(
+      "[&_[data-slot=kbd]]:bg-[color-mix(in_srgb,black_25%,var(--color-danger-muted))]",
+    );
+    expect(destructive).toContain("[&_[data-slot=kbd]]:text-inherit");
+    expect(destructive).toContain("[&_[data-slot=kbd]]:border-transparent");
+  });
+
   it("includes transition-colors for hover feedback", () => {
     expect(buttonClassName()).toContain("transition-colors");
   });

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -39,6 +39,10 @@ const variants: Record<ButtonVariant, string> = {
     "border-danger bg-danger-muted font-semibold text-danger",
     "not-disabled:hover:bg-[color-mix(in_srgb,var(--color-danger)_20%,var(--color-danger-muted))]",
     "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-danger",
+    // Nested keyboard keys: darker shade of the danger fill, not neutral surface.
+    "[&_[data-slot=kbd]]:border-transparent",
+    "[&_[data-slot=kbd]]:bg-[color-mix(in_srgb,black_25%,var(--color-danger-muted))]",
+    "[&_[data-slot=kbd]]:text-inherit",
   ),
   ghost: cn(
     "border-transparent bg-transparent font-medium text-muted",

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -28,7 +28,7 @@
 
   /* Brand (lime) */
   --color-primary: #caff57;
-  --color-primary-hover: #b6e64e;
+  --color-primary-hover: #a8d448;
   --color-primary-foreground: #0d0806;
   --color-primary-muted: #1a2408;
 


### PR DESCRIPTION
## Summary
- Polish overlay review-unit UI: rename footer “step” labels to “review unit”, fix Start Guided Review hover fill, strengthen primary hover contrast, place tests flask icon after the unit title, and always show sidebar unit hover.
- Path-aware middle ellipsis for long file labels: keep the basename visible, middle-truncate only the directory prefix, and add `MiddleEllipsisText` for width-aware truncation in DiffPane and DescriptionPane.
- Optional `displayTitle` on review units so file plans can pre-truncate long paths for the sidebar while keeping the full path as a tooltip.
- Progressive loading status while the plan is built: primary **Building a review plan** with phase subtext (extracting the diff → processing → sent to configured provider → waiting for tokens → tokens streaming). Driven by store `buildPhase` plus annotate-stream `STATUS` events for first wait and first token.

## Test plan
- [ ] Load unpacked extension from `apps/extension/dist` after `npm run build:extension`
- [ ] Open a PR with deep nested file paths; confirm basename stays visible and directory middle-ellipsizes in DiffPane/DescriptionPane headers
- [ ] Confirm sidebar unit titles use truncated display titles with full path on hover (tooltip)
- [ ] Walk footer nav: labels say “review unit” (not “step”); tests flask icon appears after the unit title
- [ ] Hover Start Guided Review and primary buttons — fill/border and stronger brand contrast
- [ ] Hover sidebar units — hover state always visible; destructive button kbd chips tint correctly
- [ ] Start a guided review with a provider configured; on the description unit, confirm loading shows **Building a review plan** and advances subtext through extract → process → sent to provider → waiting → streaming
- [ ] Retry annotate after a failure (diff already loaded); confirm status does not flash “Extracting the diff…”
- [ ] Run extension unit tests for overlay loading phase / `MiddleEllipsisText` / `middleTruncate` if not already covered in CI