### PR TITLE
feat(extension): mark review units as viewed with e

### DIFF
--- a/apps/extension/src/content/index.test.tsx
+++ b/apps/extension/src/content/index.test.tsx
@@ -102,6 +102,7 @@ describe("content script review orchestration", () => {
       currentUnitIndex: 0,
       sessionKey: null,
       draftComments: [],
+      viewedUnitIds: [],
     });
     stubDiffResponse({ ok: true, diff: diffFixture() });
   });

--- a/apps/extension/src/content/overlay/Overlay.test.tsx
+++ b/apps/extension/src/content/overlay/Overlay.test.tsx
@@ -104,6 +104,7 @@ function resetStore(): void {
     lineSelection: null,
     composerOpen: false,
     draftComments: [],
+    viewedUnitIds: [],
   });
 }
 
@@ -272,6 +273,7 @@ describe("Overlay", () => {
     expect(screen.getByLabelText(/keyboard shortcuts/i)).toBeInTheDocument();
     expect(screen.getByText(/previous \/ next step/i)).toBeInTheDocument();
     expect(screen.getByText(/scroll the code pane/i)).toBeInTheDocument();
+    expect(screen.getByText(/mark unit viewed/i)).toBeInTheDocument();
     expect(screen.getByText(/^unified view$/i)).toBeInTheDocument();
     expect(screen.getByText(/^split view$/i)).toBeInTheDocument();
     expect(screen.getByText(/^enter comment mode$/i)).toBeInTheDocument();
@@ -1077,6 +1079,35 @@ describe("Overlay", () => {
         "data-event",
         "APPROVE",
       );
+    });
+  });
+
+  describe("mark unit viewed (e)", () => {
+    it("toggles the current unit as viewed and updates the sidebar", () => {
+      seedReadyReview(1);
+      render(<Overlay />);
+
+      expect(useReviewStore.getState().viewedUnitIds).toEqual([]);
+      fireEvent.keyDown(window, { key: "e" });
+      expect(useReviewStore.getState().viewedUnitIds).toEqual(["u1"]);
+      expect(screen.getByTestId("unit-viewed-icon")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /2\. Update foo, viewed/i })).toBeInTheDocument();
+
+      fireEvent.keyDown(window, { key: "e" });
+      expect(useReviewStore.getState().viewedUnitIds).toEqual([]);
+      expect(screen.queryByTestId("unit-viewed-icon")).not.toBeInTheDocument();
+    });
+
+    it("does not toggle while the comment composer is open", () => {
+      seedReadyReview(1);
+      render(<Overlay />);
+
+      fireEvent.keyDown(window, { key: "c" });
+      fireEvent.keyDown(window, { key: "Enter" });
+      expect(useReviewStore.getState().composerOpen).toBe(true);
+
+      fireEvent.keyDown(window, { key: "e" });
+      expect(useReviewStore.getState().viewedUnitIds).toEqual([]);
     });
   });
 

--- a/apps/extension/src/content/overlay/Overlay.tsx
+++ b/apps/extension/src/content/overlay/Overlay.tsx
@@ -44,6 +44,7 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
   const goNext = useReviewStore((s) => s.goNext);
   const goPrev = useReviewStore((s) => s.goPrev);
   const draftComments = useReviewStore((s) => s.draftComments);
+  const viewedUnitIds = useReviewStore((s) => s.viewedUnitIds);
   const clearDraftComments = useReviewStore((s) => s.clearDraftComments);
   const overlayRef = useRef<HTMLDivElement>(null);
   const submitModalDialogRef = useRef<HTMLDivElement>(null);
@@ -138,7 +139,7 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
 
   useEffect(() => {
     if (status === "ready") void persistSession();
-  }, [status, currentUnitIndex, sessionKey, draftComments]);
+  }, [status, currentUnitIndex, sessionKey, draftComments, viewedUnitIds]);
 
   // Drop search UI when the overlay closes so the next open starts clean.
   useEffect(() => {
@@ -356,6 +357,7 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
           <Sidebar
             plan={plan}
             currentUnitIndex={currentUnitIndex}
+            viewedUnitIds={viewedUnitIds}
             stillBuilding={planStillBuilding}
             onSelectUnit={goToUnit}
           />

--- a/apps/extension/src/content/overlay/components/KeyboardShortcuts.tsx
+++ b/apps/extension/src/content/overlay/components/KeyboardShortcuts.tsx
@@ -23,6 +23,7 @@ type ShortcutRow =
 const SHORTCUTS: readonly ShortcutRow[] = [
   { keys: ["←", "→"], join: "none", description: "Previous / next step" },
   { keys: ["↑", "↓"], join: "none", description: "Scroll the code pane" },
+  { keys: ["e"], join: "none", description: "Mark unit viewed" },
   { keys: ["v", "u"], join: "sequence", description: "Unified view" },
   { keys: ["v", "s"], join: "sequence", description: "Split view" },
   {

--- a/apps/extension/src/content/overlay/components/Sidebar.test.tsx
+++ b/apps/extension/src/content/overlay/components/Sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReviewPlan } from "@extension/lib/types";
 import { Sidebar } from "./Sidebar";
@@ -76,6 +76,31 @@ describe("Sidebar", () => {
     expect(screen.getByText("Unit 1")).toBeInTheDocument();
     expect(screen.getByText("Unit 2")).toBeInTheDocument();
     expect(screen.getAllByTestId("unit-skeleton")).toHaveLength(4);
+  });
+
+  it("shows a checkmark and strikethrough for viewed units and keeps them selectable", () => {
+    const onSelectUnit = vi.fn();
+    render(
+      <Sidebar
+        plan={planWithUnits(2)}
+        currentUnitIndex={0}
+        viewedUnitIds={["u1"]}
+        stillBuilding={false}
+        onSelectUnit={onSelectUnit}
+      />,
+    );
+
+    expect(screen.getByTestId("unit-viewed-icon")).toBeInTheDocument();
+    // Display index 1 → "2. Unit 1" (0 is PR description).
+    const viewedButton = screen.getByRole("button", { name: /2\. Unit 1, viewed/i });
+    expect(viewedButton.querySelector(".line-through")).not.toBeNull();
+
+    // Unviewed plan unit has no checkmark.
+    expect(screen.getByRole("button", { name: /3\. Unit 2$/i })).toBeInTheDocument();
+    expect(screen.getAllByTestId("unit-viewed-icon")).toHaveLength(1);
+
+    fireEvent.click(viewedButton);
+    expect(onSelectUnit).toHaveBeenCalledWith(1);
   });
 
   it("hides skeletons when not still building", () => {

--- a/apps/extension/src/content/overlay/components/Sidebar.tsx
+++ b/apps/extension/src/content/overlay/components/Sidebar.tsx
@@ -1,22 +1,32 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import type { ReviewPlan } from "@extension/lib/types";
 import { cn } from "@guided-review/ui";
 import { buildDisplayUnits } from "@extension/content/overlay/store";
 import { TestsUnitIcon } from "./TestsUnitIcon";
+import { ViewedUnitIcon } from "./ViewedUnitIcon";
 
 const SKELETON_COUNT = 4;
 
 interface SidebarProps {
   plan: ReviewPlan | null;
   currentUnitIndex: number;
+  /** Display unit ids marked viewed (visual memory aid only). */
+  viewedUnitIds?: readonly string[];
   /** When true, show trailing skeleton rows after any completed units. */
   stillBuilding: boolean;
   onSelectUnit: (index: number) => void;
 }
 
-export function Sidebar({ plan, currentUnitIndex, stillBuilding, onSelectUnit }: SidebarProps) {
+export function Sidebar({
+  plan,
+  currentUnitIndex,
+  viewedUnitIds = [],
+  stillBuilding,
+  onSelectUnit,
+}: SidebarProps) {
   const displayUnits = buildDisplayUnits(plan);
   const activeItemRef = useRef<HTMLButtonElement>(null);
+  const viewedSet = useMemo(() => new Set(viewedUnitIds), [viewedUnitIds]);
 
   // Keep the active unit visible when navigating via keyboard (←/→) or footer
   // buttons — the sidebar is independently scrollable and can leave the
@@ -40,18 +50,21 @@ export function Sidebar({ plan, currentUnitIndex, stillBuilding, onSelectUnit }:
 
         {displayUnits.map((unit, displayIndex) => {
           const isActive = displayIndex === currentUnitIndex;
+          const isViewed = viewedSet.has(unit.id);
           const isTestsUnit = unit.kind === "review" && unit.unit.kind === "tests";
           // displayTitle is pre-truncated in buildFileReviewPlan for path labels;
           // AI units omit it and show title. Render as plain text either way.
           const label =
             unit.kind === "review" ? (unit.unit.displayTitle ?? unit.unit.title) : unit.title;
           const tooltip = unit.kind === "review" ? unit.unit.title : unit.title;
+          const accessibleName = `${displayIndex + 1}. ${label}${isViewed ? ", viewed" : ""}`;
           return (
             <button
               key={unit.id}
               type="button"
               ref={isActive ? activeItemRef : undefined}
               aria-current={isActive ? "true" : undefined}
+              aria-label={accessibleName}
               title={tooltip}
               className={cn(
                 "mb-0.5 flex w-full cursor-pointer items-start rounded-md border-none bg-transparent p-2 text-left text-base leading-snug text-foreground",
@@ -63,7 +76,13 @@ export function Sidebar({ plan, currentUnitIndex, stillBuilding, onSelectUnit }:
               <span className={cn("mr-1.5 shrink-0", isActive ? "text-primary" : "text-muted")}>
                 {displayIndex + 1}.
               </span>
-              <span className="min-w-0 break-words">
+              <span
+                className={cn(
+                  "min-w-0 flex-1 break-words",
+                  isViewed && "text-muted line-through",
+                  isViewed && isActive && "text-primary/70!",
+                )}
+              >
                 {isTestsUnit && (
                   <TestsUnitIcon
                     className={cn(
@@ -74,6 +93,14 @@ export function Sidebar({ plan, currentUnitIndex, stillBuilding, onSelectUnit }:
                 )}
                 {label}
               </span>
+              {isViewed && (
+                <ViewedUnitIcon
+                  className={cn(
+                    "ml-1.5 shrink-0 self-start",
+                    isActive ? "text-primary" : "text-muted",
+                  )}
+                />
+              )}
             </button>
           );
         })}

--- a/apps/extension/src/content/overlay/components/ViewedUnitIcon.tsx
+++ b/apps/extension/src/content/overlay/components/ViewedUnitIcon.tsx
@@ -1,0 +1,32 @@
+/** Checkmark for units the reviewer marked viewed — stroke via currentColor. */
+export function ViewedUnitIcon({
+  className,
+  /** Defaults to `1em` so the mark tracks surrounding text size. */
+  size = "1em",
+  "data-testid": testId = "unit-viewed-icon",
+}: {
+  className?: string;
+  size?: number | string;
+  "data-testid"?: string;
+}) {
+  return (
+    <svg
+      className={className}
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      data-testid={testId}
+    >
+      <path
+        d="M3.25 8.25 6.5 11.5 12.75 4.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/apps/extension/src/content/overlay/store.test.ts
+++ b/apps/extension/src/content/overlay/store.test.ts
@@ -57,6 +57,7 @@ function resetStore(): void {
     lineSelection: null,
     composerOpen: false,
     draftComments: [],
+    viewedUnitIds: [],
   });
 }
 
@@ -486,6 +487,49 @@ describe("useReviewStore", () => {
       expect(drafts).toHaveLength(1);
       expect(drafts[0].body).toBe("Looks good");
       expect(useReviewStore.getState().uiMode).toBe("navigate");
+    });
+
+    it("persistSession / restoreSession round-trips viewed unit ids", async () => {
+      resetStore();
+      useReviewStore.getState().startLoading(SESSION_KEY);
+      useReviewStore.getState().setReady(diffFixture(), planFixture(2));
+      // Index 0 is PR description; mark it, then a plan unit.
+      useReviewStore.getState().toggleCurrentUnitViewed();
+      useReviewStore.getState().goToUnit(1);
+      useReviewStore.getState().toggleCurrentUnitViewed();
+
+      await persistSession();
+      resetStore();
+      await restoreSession(SESSION_KEY);
+
+      expect(useReviewStore.getState().viewedUnitIds).toEqual(["__pr_description", "u0"]);
+    });
+  });
+
+  describe("toggleCurrentUnitViewed", () => {
+    it("toggles the current display unit id on and off", () => {
+      resetStore();
+      useReviewStore.getState().setReady(diffFixture(), planFixture(2));
+      // Description unit at index 0.
+      useReviewStore.getState().toggleCurrentUnitViewed();
+      expect(useReviewStore.getState().viewedUnitIds).toEqual(["__pr_description"]);
+
+      useReviewStore.getState().goToUnit(1);
+      useReviewStore.getState().toggleCurrentUnitViewed();
+      expect(useReviewStore.getState().viewedUnitIds).toEqual(["__pr_description", "u0"]);
+
+      useReviewStore.getState().toggleCurrentUnitViewed();
+      expect(useReviewStore.getState().viewedUnitIds).toEqual(["__pr_description"]);
+    });
+
+    it("startLoading clears viewed unit ids", () => {
+      resetStore();
+      useReviewStore.getState().setReady(diffFixture(), planFixture(1));
+      useReviewStore.getState().toggleCurrentUnitViewed();
+      expect(useReviewStore.getState().viewedUnitIds).toHaveLength(1);
+
+      useReviewStore.getState().startLoading(SESSION_KEY);
+      expect(useReviewStore.getState().viewedUnitIds).toEqual([]);
     });
   });
 

--- a/apps/extension/src/content/overlay/store.ts
+++ b/apps/extension/src/content/overlay/store.ts
@@ -78,6 +78,8 @@ interface PersistedSession {
   currentUnitIndex: number;
   /** Local draft comments (session-scoped; not posted to GitHub). */
   draftComments?: DraftComment[];
+  /** Display unit ids the reviewer marked viewed (session-scoped memory aid). */
+  viewedUnitIds?: string[];
 }
 
 const COMMENT_UI_RESET = {
@@ -126,6 +128,11 @@ interface ReviewState {
   lineSelection: LineSelection | null;
   composerOpen: boolean;
   draftComments: DraftComment[];
+  /**
+   * Display unit ids the reviewer marked as viewed (`e` toggle). Visual only —
+   * navigation is unchanged. Session-scoped; not posted to GitHub.
+   */
+  viewedUnitIds: string[];
 
   open: () => void;
   close: () => void;
@@ -168,6 +175,8 @@ interface ReviewState {
   updateDraftComment: (id: string, body: string) => void;
   removeDraftComment: (id: string) => void;
   clearDraftComments: () => void;
+  /** Toggle viewed mark for the current display unit (navigate/comment mode). */
+  toggleCurrentUnitViewed: () => void;
 }
 
 /**
@@ -208,6 +217,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   lineSelection: null,
   composerOpen: false,
   draftComments: [],
+  viewedUnitIds: [],
 
   open: () => set({ isOpen: true }),
   close: () => set({ isOpen: false, ...COMMENT_UI_RESET }),
@@ -225,6 +235,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
       sessionKey,
       streamGeneration: state.streamGeneration + 1,
       draftComments: [],
+      viewedUnitIds: [],
       ...COMMENT_UI_RESET,
     })),
 
@@ -499,6 +510,19 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   },
 
   clearDraftComments: () => set({ draftComments: [] }),
+
+  toggleCurrentUnitViewed: () => {
+    const { plan, currentUnitIndex, viewedUnitIds } = get();
+    const unit = buildDisplayUnits(plan)[currentUnitIndex];
+    if (!unit) return;
+    const id = unit.id;
+    const already = viewedUnitIds.includes(id);
+    set({
+      viewedUnitIds: already
+        ? viewedUnitIds.filter((existing) => existing !== id)
+        : [...viewedUnitIds, id],
+    });
+  },
 }));
 
 /** Bumped when the user sets a mode so pending storage reads are dropped. */
@@ -553,6 +577,7 @@ export async function persistSession(): Promise<void> {
     currentUnitIndex,
     sessionKey,
     draftComments,
+    viewedUnitIds,
   } = useReviewStore.getState();
   if (status !== "ready" || !diff || !plan || !sessionKey) return;
   // The file-per-unit fallback is cheap to rebuild and would otherwise be
@@ -565,6 +590,7 @@ export async function persistSession(): Promise<void> {
     prContext,
     currentUnitIndex,
     draftComments,
+    viewedUnitIds,
   };
   try {
     await writeSession(storageKey(sessionKey), payload);
@@ -604,6 +630,7 @@ export async function restoreSession(sessionKey: string): Promise<boolean> {
     buildPhase: null,
     providerLabel: null,
     draftComments: saved.draftComments ?? [],
+    viewedUnitIds: saved.viewedUnitIds ?? [],
     ...COMMENT_UI_RESET,
   });
   return true;

--- a/apps/extension/src/content/overlay/useOverlayKeyboard.ts
+++ b/apps/extension/src/content/overlay/useOverlayKeyboard.ts
@@ -326,6 +326,12 @@ export function useOverlayKeyboard({
           event.preventDefault();
           store.goPrev();
           return;
+        case "e":
+        case "E":
+          if (event.metaKey || event.ctrlKey || event.altKey) return;
+          event.preventDefault();
+          store.toggleCurrentUnitViewed();
+          return;
         default:
           return;
       }
@@ -368,6 +374,12 @@ export function useOverlayKeyboard({
           if (selectableForUnit.length > 0) {
             store.enterCommentMode(selectableForUnit);
           }
+          return;
+        case "e":
+        case "E":
+          if (event.metaKey || event.ctrlKey || event.altKey) return;
+          event.preventDefault();
+          store.toggleCurrentUnitViewed();
           return;
         default:
           return;

--- a/apps/web/content/help/first-review.mdx
+++ b/apps/web/content/help/first-review.mdx
@@ -45,6 +45,7 @@ For each unit you can:
 - Read the unit’s title and guidance (take summaries with a grain of salt — see the [FAQ](/docs/faq#does-the-ai-approve-prs))
 - See the linked hunks from the real diff (default **split** view; switch with `v u` / `v s`, or the toolbar — choice is remembered)
 - Move next / previous with the footer or [keyboard shortcuts](/docs/keyboard-shortcuts)
+- Press `e` to mark the unit viewed (strikethrough + checkmark in the list). Visual memory only — viewed units stay fully navigable; press `e` again to clear
 
 With AI, the model chooses order and commentary; it does **not** supply the code lines you see. Hunk ids that don’t match the parsed diff are dropped. Without AI, order is file order and commentary is empty until you connect a provider.
 
@@ -63,6 +64,6 @@ Submit needs [GitHub connected](/docs/connect-github). Walking the plan and draf
 
 ## Resume later
 
-Sessions (diff, plan, PR context, current step, drafts) are stored in `chrome.storage.session`, keyed by **owner/repo#number** — not the full URL — so you can switch between Conversation and Files changed tabs and resume the same plan until the browser session ends. Limits and clears: [Troubleshooting](/docs/troubleshooting#session-and-resume).
+Sessions (diff, plan, PR context, current step, drafts, viewed unit marks) are stored in `chrome.storage.session`, keyed by **owner/repo#number** — not the full URL — so you can switch between Conversation and Files changed tabs and resume the same plan until the browser session ends. Limits and clears: [Troubleshooting](/docs/troubleshooting#session-and-resume).
 
 If something fails mid-flight, see [Troubleshooting](/docs/troubleshooting).

--- a/apps/web/content/help/keyboard-shortcuts.mdx
+++ b/apps/web/content/help/keyboard-shortcuts.mdx
@@ -22,6 +22,7 @@ The Guided Review sidebar always lists the same shortcuts as this page. Hands-on
 | `→`                | Next unit                                                                                       |
 | `←`                | Previous unit                                                                                   |
 | `↑` / `↓`          | Scroll the code pane                                                                            |
+| `e`                | Toggle current unit as viewed (strikethrough + checkmark in the list; still navigable)          |
 | `Esc`              | Exit Guided Review (when not in comment mode or a modal)                                        |
 | `c`                | Enter [comment mode](/docs/leave-comments) (if the unit has selectable lines)                   |
 | `⌘/Ctrl` + `F`     | Open [diff search](#diff-search)                                                                |

--- a/apps/web/content/help/privacy-and-data.mdx
+++ b/apps/web/content/help/privacy-and-data.mdx
@@ -24,7 +24,7 @@ The background service worker is the only context that holds the API key and per
 ## What stays local
 
 - Provider choice, model, and API key (`chrome.storage.local`) — [Configure AI provider](/docs/configure-provider#where-settings-live)
-- Active review session: diff, plan, step index (`chrome.storage.session`, keyed by `owner/repo#number`) — [Resume later](/docs/first-review#resume-later)
+- Active review session: diff, plan, step index, viewed unit marks (`chrome.storage.session`, keyed by `owner/repo#number`) — [Resume later](/docs/first-review#resume-later)
 - [Draft comments](/docs/leave-comments) in Guided Review until you submit
 - GitHub tokens after [Connect GitHub](/docs/connect-github), until you disconnect
 


### PR DESCRIPTION
## Summary

- Press **e** to toggle the current display unit as viewed (navigate or comment mode).
- Viewed units show a checkmark and strikethrough title in the sidebar list, but stay fully navigable.
- Marks are session-scoped (same storage as drafts) and documented in the keyboard shortcuts help.

## Test plan

- [ ] Load unpacked extension from `apps/extension/dist` after `build:extension`
- [ ] Open Guided Review on a PR; press `e` on a unit → checkmark + strikethrough in the list
- [ ] Press `e` again → mark clears
- [ ] Navigate with ←/→ and sidebar click on a viewed unit (still works)
- [ ] Confirm `e` does not toggle while the comment composer is open
- [ ] Close and reopen the overlay in the same browser session → viewed marks persist
- [ ] `npm test` / typecheck green