### PR TITLE
feat(overlay): clickable ellipsis for omitted lines between hunks

### DIFF
--- a/apps/extension/src/content/overlay/components/DiffPane.test.tsx
+++ b/apps/extension/src/content/overlay/components/DiffPane.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { buildPRFileDiffUrl } from "@extension/lib/github/prUrls";
+import { buildFileLineUrl, buildPRFileDiffUrl } from "@extension/lib/github/prUrls";
 import type { DiffFile, DiffHunk, PRContext } from "@extension/lib/types";
 import { buildSelectableLines } from "@extension/content/overlay/buildSelectableLines";
 import { DEFAULT_DIFF_VIEW_MODE } from "@extension/lib/preferences";
@@ -266,5 +266,52 @@ describe("DiffPane", () => {
       const stored = await chrome.storage.local.get("guidedReview.diffViewMode");
       expect(stored["guidedReview.diffViewMode"]).toBe("unified");
     });
+  });
+
+  it("does not show a gap placeholder for a single-hunk file", () => {
+    renderPane();
+    expect(screen.queryByTestId("hunk-gap-placeholder")).not.toBeInTheDocument();
+  });
+
+  it("shows a clickable gap ellipsis between non-adjacent hunks", async () => {
+    const first = hunkFixture({
+      id: "src/foo.ts#0",
+      header: "@@ -1,2 +1,2 @@",
+      oldStart: 1,
+      oldLines: 2,
+      newStart: 1,
+      newLines: 2,
+      lines: [
+        { type: "context", content: "a", oldLine: 1, newLine: 1 },
+        { type: "add", content: "b", newLine: 2 },
+      ],
+    });
+    const second = hunkFixture({
+      id: "src/foo.ts#1",
+      header: "@@ -20,2 +20,2 @@",
+      oldStart: 20,
+      oldLines: 2,
+      newStart: 20,
+      newLines: 2,
+      lines: [
+        { type: "context", content: "c", oldLine: 20, newLine: 20 },
+        { type: "add", content: "d", newLine: 21 },
+      ],
+    });
+    const file = fileFixture({ hunks: [first, second] });
+    useReviewStore.setState({ prContext: prContextFixture() });
+
+    const expectedHref = await buildFileLineUrl(
+      { owner: "acme", repo: "widgets", number: 42 },
+      { filePath: "src/foo.ts", line: 2, headRef: "feature" },
+    );
+
+    renderPane([{ file, hunks: [first, second] }]);
+
+    // URL is built async via buildFileLineUrl — wait until the div becomes a link.
+    const gap = await screen.findByRole("link", { name: "Open file at line 2" });
+    expect(gap).toHaveAttribute("data-testid", "hunk-gap-placeholder");
+    expect(gap).toHaveAttribute("href", expectedHref);
+    expect(gap).toHaveAttribute("target", "_blank");
   });
 });

--- a/apps/extension/src/content/overlay/components/DiffPane.test.tsx
+++ b/apps/extension/src/content/overlay/components/DiffPane.test.tsx
@@ -309,9 +309,10 @@ describe("DiffPane", () => {
     renderPane([{ file, hunks: [first, second] }]);
 
     // URL is built async via buildFileLineUrl — wait until the div becomes a link.
-    const gap = await screen.findByRole("link", { name: "Open file at line 2" });
+    const gap = await screen.findByRole("link", { name: /View Collapsed Lines/i });
     expect(gap).toHaveAttribute("data-testid", "hunk-gap-placeholder");
     expect(gap).toHaveAttribute("href", expectedHref);
     expect(gap).toHaveAttribute("target", "_blank");
+    expect(gap).toHaveTextContent("View Collapsed Lines");
   });
 });

--- a/apps/extension/src/content/overlay/components/DiffPane.tsx
+++ b/apps/extension/src/content/overlay/components/DiffPane.tsx
@@ -9,9 +9,11 @@ import {
   type SelectableLine,
 } from "@extension/content/overlay/commentTypes";
 import type { SearchScrollTarget } from "@extension/content/overlay/diffSearch";
+import { withHunkGaps } from "@extension/content/overlay/hunkGaps";
 import { hydrateDiffViewMode, useReviewStore } from "@extension/content/overlay/store";
 import type { ResolvedUnitFile } from "@extension/content/overlay/buildSelectableLines";
 import { AddCommentButton, CommentModeChip, DiffViewToggle } from "./diff/DiffToolbar";
+import { HunkGapPlaceholder } from "./diff/HunkGapPlaceholder";
 import { SplitHunk } from "./diff/SplitHunk";
 import { UnifiedHunk } from "./diff/UnifiedHunk";
 import { useSelectionDerived } from "./diff/useSelectionDerived";
@@ -270,8 +272,18 @@ export function DiffPane({
             {file.isBinaryOrElided ? (
               <BinaryElidedEmptyState filePath={file.path} />
             ) : (
-              hunks.map((hunk) =>
-                diffViewMode === "split" ? (
+              withHunkGaps(hunks).map((item) => {
+                if (item.kind === "gap") {
+                  return (
+                    <HunkGapPlaceholder
+                      key={item.key}
+                      filePath={file.path}
+                      afterLine={item.afterLine}
+                    />
+                  );
+                }
+                const { hunk } = item;
+                return diffViewMode === "split" ? (
                   <SplitHunk
                     hunk={hunk}
                     language={language}
@@ -295,8 +307,8 @@ export function DiffPane({
                     composerRange={composerRange}
                     unitId={unitId}
                   />
-                ),
-              )
+                );
+              })
             )}
           </div>
         );

--- a/apps/extension/src/content/overlay/components/diff/HunkGapPlaceholder.tsx
+++ b/apps/extension/src/content/overlay/components/diff/HunkGapPlaceholder.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+import { cn } from "@guided-review/ui";
+import { buildFileLineUrl } from "@extension/lib/github/prUrls";
+import { useReviewStore } from "@extension/content/overlay/store";
+
+interface HunkGapPlaceholderProps {
+  filePath: string;
+  /** Line number immediately above the omitted range. */
+  afterLine: number;
+}
+
+/**
+ * Clickable ellipsis between hunks when the patch omits lines.
+ * Opens the file on GitHub at `afterLine` (new tab).
+ */
+export function HunkGapPlaceholder({ filePath, afterLine }: HunkGapPlaceholderProps) {
+  const prContext = useReviewStore((s) => s.prContext);
+  const [href, setHref] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!prContext) {
+      setHref(null);
+      return;
+    }
+    let cancelled = false;
+    void buildFileLineUrl(
+      { owner: prContext.owner, repo: prContext.repo, number: prContext.number },
+      { filePath, line: afterLine, headRef: prContext.headRef },
+    ).then((url) => {
+      if (!cancelled) setHref(url);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [prContext, filePath, afterLine]);
+
+  const label = `Open file at line ${afterLine}`;
+  const className = cn(
+    "flex w-full items-center justify-center border-y border-border bg-background",
+    "py-1.5 font-mono text-sm text-faint",
+    href && "cursor-pointer hover:bg-surface-muted hover:text-muted",
+  );
+
+  if (href) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={className}
+        aria-label={label}
+        title={label}
+        data-testid="hunk-gap-placeholder"
+      >
+        ⋯
+      </a>
+    );
+  }
+
+  return (
+    <div className={className} role="presentation" title={label} data-testid="hunk-gap-placeholder">
+      ⋯
+    </div>
+  );
+}

--- a/apps/extension/src/content/overlay/components/diff/HunkGapPlaceholder.tsx
+++ b/apps/extension/src/content/overlay/components/diff/HunkGapPlaceholder.tsx
@@ -34,11 +34,21 @@ export function HunkGapPlaceholder({ filePath, afterLine }: HunkGapPlaceholderPr
     };
   }, [prContext, filePath, afterLine]);
 
-  const label = `Open file at line ${afterLine}`;
+  const label = `View Collapsed Lines (line ${afterLine})`;
   const className = cn(
-    "flex w-full items-center justify-center border-y border-border bg-background",
+    // Match the surrounding hunk surface (parent is bg-surface-raised); no
+    // separate wash so it reads as part of the diff, not a chrome bar.
+    "flex w-full items-center justify-center gap-2 border-y border-border",
     "py-1.5 font-mono text-sm text-faint",
     href && "cursor-pointer hover:bg-surface-muted hover:text-muted",
+  );
+
+  const content = (
+    <>
+      <span aria-hidden="true">⋯</span>
+      <span>View Collapsed Lines</span>
+      <span aria-hidden="true">⋯</span>
+    </>
   );
 
   if (href) {
@@ -52,14 +62,14 @@ export function HunkGapPlaceholder({ filePath, afterLine }: HunkGapPlaceholderPr
         title={label}
         data-testid="hunk-gap-placeholder"
       >
-        ⋯
+        {content}
       </a>
     );
   }
 
   return (
     <div className={className} role="presentation" title={label} data-testid="hunk-gap-placeholder">
-      ⋯
+      {content}
     </div>
   );
 }

--- a/apps/extension/src/content/overlay/hunkGaps.test.ts
+++ b/apps/extension/src/content/overlay/hunkGaps.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import type { DiffHunk } from "@extension/lib/types";
+import { hasLineGapBetween, hunkEndLine, withHunkGaps } from "./hunkGaps";
+
+function hunk(overrides: Partial<DiffHunk> & Pick<DiffHunk, "id">): DiffHunk {
+  return {
+    header: "@@ -1,1 +1,1 @@",
+    oldStart: 1,
+    oldLines: 1,
+    newStart: 1,
+    newLines: 1,
+    lines: [],
+    ...overrides,
+  };
+}
+
+describe("hunkEndLine", () => {
+  it("prefers the new side end line", () => {
+    expect(
+      hunkEndLine(
+        hunk({
+          id: "f#0",
+          oldStart: 10,
+          oldLines: 5,
+          newStart: 12,
+          newLines: 8,
+        }),
+      ),
+    ).toBe(19);
+  });
+
+  it("falls back to the old side when the new side is empty", () => {
+    expect(
+      hunkEndLine(
+        hunk({
+          id: "f#0",
+          oldStart: 10,
+          oldLines: 5,
+          newStart: 0,
+          newLines: 0,
+        }),
+      ),
+    ).toBe(14);
+  });
+
+  it("returns undefined when both sides are empty", () => {
+    expect(
+      hunkEndLine(
+        hunk({
+          id: "f#0",
+          oldStart: 0,
+          oldLines: 0,
+          newStart: 0,
+          newLines: 0,
+        }),
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("hasLineGapBetween", () => {
+  it("detects a gap on the new side", () => {
+    const prev = hunk({ id: "f#0", newStart: 1, newLines: 4, oldStart: 1, oldLines: 3 });
+    const next = hunk({ id: "f#1", newStart: 20, newLines: 2, oldStart: 18, oldLines: 2 });
+    expect(hasLineGapBetween(prev, next)).toBe(true);
+  });
+
+  it("returns false when hunks are adjacent on the new side", () => {
+    const prev = hunk({ id: "f#0", newStart: 1, newLines: 4, oldStart: 1, oldLines: 3 });
+    const next = hunk({ id: "f#1", newStart: 5, newLines: 2, oldStart: 4, oldLines: 2 });
+    expect(hasLineGapBetween(prev, next)).toBe(false);
+  });
+
+  it("detects a gap on the old side when new sides are empty", () => {
+    const prev = hunk({ id: "f#0", newStart: 0, newLines: 0, oldStart: 1, oldLines: 4 });
+    const next = hunk({ id: "f#1", newStart: 0, newLines: 0, oldStart: 10, oldLines: 2 });
+    expect(hasLineGapBetween(prev, next)).toBe(true);
+  });
+});
+
+describe("withHunkGaps", () => {
+  it("returns a single hunk unchanged", () => {
+    const only = hunk({ id: "f#0", newStart: 1, newLines: 3 });
+    expect(withHunkGaps([only])).toEqual([{ kind: "hunk", hunk: only }]);
+  });
+
+  it("inserts a gap between non-adjacent hunks", () => {
+    const a = hunk({ id: "f#0", newStart: 1, newLines: 4, oldStart: 1, oldLines: 3 });
+    const b = hunk({ id: "f#1", newStart: 20, newLines: 2, oldStart: 18, oldLines: 2 });
+    expect(withHunkGaps([a, b])).toEqual([
+      { kind: "hunk", hunk: a },
+      { kind: "gap", afterLine: 4, key: "gap-f#0-f#1" },
+      { kind: "hunk", hunk: b },
+    ]);
+  });
+
+  it("does not insert a gap when hunks are adjacent", () => {
+    const a = hunk({ id: "f#0", newStart: 1, newLines: 4, oldStart: 1, oldLines: 3 });
+    const b = hunk({ id: "f#1", newStart: 5, newLines: 2, oldStart: 4, oldLines: 2 });
+    expect(withHunkGaps([a, b])).toEqual([
+      { kind: "hunk", hunk: a },
+      { kind: "hunk", hunk: b },
+    ]);
+  });
+
+  it("inserts a gap when a unit skips an intermediate hunk", () => {
+    const first = hunk({ id: "f#0", newStart: 1, newLines: 3, oldStart: 1, oldLines: 3 });
+    const third = hunk({ id: "f#2", newStart: 40, newLines: 5, oldStart: 38, oldLines: 5 });
+    const seq = withHunkGaps([first, third]);
+    expect(seq).toHaveLength(3);
+    expect(seq[1]).toEqual({ kind: "gap", afterLine: 3, key: "gap-f#0-f#2" });
+  });
+});

--- a/apps/extension/src/content/overlay/hunkGaps.ts
+++ b/apps/extension/src/content/overlay/hunkGaps.ts
@@ -1,0 +1,51 @@
+import type { DiffHunk } from "@extension/lib/types";
+
+/** Last file line number of a hunk (prefer new side). */
+export function hunkEndLine(hunk: DiffHunk): number | undefined {
+  if (hunk.newLines > 0) return hunk.newStart + hunk.newLines - 1;
+  if (hunk.oldLines > 0) return hunk.oldStart + hunk.oldLines - 1;
+  return undefined;
+}
+
+/**
+ * True when the next hunk starts after the previous ends with at least one
+ * omitted line on the new side (preferred) or old side.
+ */
+export function hasLineGapBetween(prev: DiffHunk, next: DiffHunk): boolean {
+  if (prev.newLines > 0 && next.newLines > 0) {
+    return next.newStart > prev.newStart + prev.newLines;
+  }
+  if (prev.oldLines > 0 && next.oldLines > 0) {
+    return next.oldStart > prev.oldStart + prev.oldLines;
+  }
+  return false;
+}
+
+export type HunkSequenceItem =
+  { kind: "hunk"; hunk: DiffHunk } | { kind: "gap"; afterLine: number; key: string };
+
+/**
+ * Interleave displayed hunks with gap markers for rendering.
+ * Only inserts a gap between consecutive items in the displayed list.
+ */
+export function withHunkGaps(hunks: DiffHunk[]): HunkSequenceItem[] {
+  const out: HunkSequenceItem[] = [];
+  for (let i = 0; i < hunks.length; i++) {
+    const hunk = hunks[i];
+    if (i > 0) {
+      const prev = hunks[i - 1];
+      if (hasLineGapBetween(prev, hunk)) {
+        const afterLine = hunkEndLine(prev);
+        if (afterLine != null) {
+          out.push({
+            kind: "gap",
+            afterLine,
+            key: `gap-${prev.id}-${hunk.id}`,
+          });
+        }
+      }
+    }
+    out.push({ kind: "hunk", hunk });
+  }
+  return out;
+}

--- a/apps/extension/src/lib/github/prUrls.test.ts
+++ b/apps/extension/src/lib/github/prUrls.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  buildFileLineUrl,
   buildPRFileDiffUrl,
   isIgnoredPrPath,
   isPrFilesChangedPath,
@@ -83,6 +84,49 @@ describe("buildPRFileDiffUrl", () => {
     );
     expect(url).toBe(
       "https://github.com/acme/widgets/pull/42/files#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556",
+    );
+  });
+
+  it("appends a right-side line anchor when line is provided", async () => {
+    const url = await buildPRFileDiffUrl(
+      { owner: "acme", repo: "widgets", number: 42 },
+      "src/index.js",
+      17,
+    );
+    expect(url).toBe(
+      "https://github.com/acme/widgets/pull/42/files#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R17",
+    );
+  });
+});
+
+describe("buildFileLineUrl", () => {
+  const pr = { owner: "acme", repo: "widgets", number: 42 };
+
+  it("builds a head-branch blob URL when headRef is set", async () => {
+    const url = await buildFileLineUrl(pr, {
+      filePath: "src/foo.ts",
+      line: 12,
+      headRef: "feature-x",
+    });
+    expect(url).toBe("https://github.com/acme/widgets/blob/feature-x/src/foo.ts#L12");
+  });
+
+  it("encodes path segments and head ref", async () => {
+    const url = await buildFileLineUrl(pr, {
+      filePath: "src/my file.ts",
+      line: 3,
+      headRef: "feat/branch",
+    });
+    expect(url).toBe("https://github.com/acme/widgets/blob/feat%2Fbranch/src/my%20file.ts#L3");
+  });
+
+  it("falls back to the PR Files deep link when headRef is missing", async () => {
+    const url = await buildFileLineUrl(pr, {
+      filePath: "src/index.js",
+      line: 9,
+    });
+    expect(url).toBe(
+      "https://github.com/acme/widgets/pull/42/files#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R9",
     );
   });
 });

--- a/apps/extension/src/lib/github/prUrls.ts
+++ b/apps/extension/src/lib/github/prUrls.ts
@@ -55,14 +55,38 @@ export function navigateToPrConversation(pr: {
  * URL that opens the PR Files tab scrolled to `filePath`.
  * GitHub anchors each file with `#diff-{sha256Hex(path)}` (lowercase hex of
  * the UTF-8 path). Use the file's current path (new path after renames).
+ * When `line` is set, append `R{line}` so GitHub highlights that new-side line.
  */
 export async function buildPRFileDiffUrl(
   pr: { owner: string; repo: string; number: number },
   filePath: string,
+  line?: number,
 ): Promise<string> {
   const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(filePath));
   const hex = Array.from(new Uint8Array(digest))
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");
-  return `https://github.com/${pr.owner}/${pr.repo}/pull/${pr.number}/files#diff-${hex}`;
+  const fragment = line != null && line > 0 ? `diff-${hex}R${line}` : `diff-${hex}`;
+  return `https://github.com/${pr.owner}/${pr.repo}/pull/${pr.number}/files#${fragment}`;
+}
+
+/**
+ * Deep link to a file at a specific line. Prefers the head-branch blob view
+ * (full file, including lines omitted from the patch). Falls back to the PR
+ * Files tab when `headRef` is missing.
+ */
+export async function buildFileLineUrl(
+  pr: { owner: string; repo: string; number: number },
+  opts: { filePath: string; line: number; headRef?: string },
+): Promise<string> {
+  const headRef = opts.headRef?.trim();
+  if (headRef) {
+    // Encode path segments so spaces/special chars survive; keep slashes.
+    const encodedPath = opts.filePath
+      .split("/")
+      .map((seg) => encodeURIComponent(seg))
+      .join("/");
+    return `https://github.com/${pr.owner}/${pr.repo}/blob/${encodeURIComponent(headRef)}/${encodedPath}#L${opts.line}`;
+  }
+  return buildPRFileDiffUrl(pr, opts.filePath, opts.line);
 }


### PR DESCRIPTION
## Summary

- Detect line gaps between consecutive hunks in a review unit’s file view and insert a clickable `⋯` placeholder between them.
- Clicking the placeholder opens the file on GitHub at the line immediately above the gap (head-branch blob when available; PR Files tab fallback).
- Shared gap math in `hunkGaps.ts` and deep-link helper `buildFileLineUrl` keep DiffPane / URL construction thin and testable.

## Test plan

- [x] Unit tests for gap detection (`hunkGaps.test.ts`)
- [x] URL builder tests (blob + PR Files fallback)
- [x] DiffPane tests for single-hunk (no placeholder) and multi-hunk gap link
- [x] Extension typecheck
- [ ] Manual: `npm run build:extension`, reload unpacked extension, open a multi-hunk PR unit — confirm ellipsis between hunks, click opens file at line above; check split and unified views