### PR TITLE
refactor(overlay): introduce ReviewHost so the walkthrough is chrome-free

### DIFF
--- a/apps/extension/src/content/githubHost.ts
+++ b/apps/extension/src/content/githubHost.ts
@@ -1,0 +1,77 @@
+/**
+ * Chrome/GitHub implementation of ReviewHost. The only overlay-adjacent
+ * module allowed to touch chrome messaging, storage, and GitHub URLs.
+ */
+
+import type { ReviewContext } from "@guided-review/core";
+import {
+  getGitHubAuthStatus,
+  openOptionsPage,
+  requestSubmitReview,
+  streamReviewPlan,
+} from "@extension/lib/messaging";
+import { getStoredDiffViewMode, setStoredDiffViewMode } from "@extension/lib/preferences";
+import { readSession, writeSession } from "@extension/lib/storage";
+import {
+  buildFileLineUrl,
+  buildPRFileDiffUrl,
+  navigateToPrConversation,
+} from "@extension/lib/github/prUrls";
+import type { ReviewHost } from "./overlay/host";
+
+function sessionStorageKey(sessionKey: string): string {
+  return `guidedReview.session.${sessionKey}`;
+}
+
+function githubIdentity(context: ReviewContext): {
+  owner: string;
+  repo: string;
+  number: number;
+} | null {
+  if (
+    typeof context.owner !== "string" ||
+    typeof context.repo !== "string" ||
+    typeof context.number !== "number"
+  ) {
+    return null;
+  }
+  return { owner: context.owner, repo: context.repo, number: context.number };
+}
+
+export function createGitHubReviewHost(): ReviewHost {
+  return {
+    kind: "github",
+    assetUrl: (path) => chrome.runtime.getURL(path),
+    persistSession: async (key, data) => {
+      await writeSession(sessionStorageKey(key), data);
+    },
+    restoreSession: async (key) => {
+      return readSession(sessionStorageKey(key), (raw) => (raw ?? null) as unknown);
+    },
+    streamPlan: (diff, context, handlers) =>
+      streamReviewPlan(diff, context as import("@extension/lib/types").PRContext, handlers),
+    connectProvider: () => {
+      void openOptionsPage();
+    },
+    persistDiffViewMode: setStoredDiffViewMode,
+    readDiffViewMode: getStoredDiffViewMode,
+    fileDiffUrl: async (filePath, context) => {
+      const pr = githubIdentity(context);
+      if (!pr) return null;
+      return buildPRFileDiffUrl(pr, filePath);
+    },
+    fileLineUrl: async (filePath, line, context) => {
+      const pr = githubIdentity(context);
+      if (!pr) return null;
+      return buildFileLineUrl(pr, { filePath, line, headRef: context.headRef });
+    },
+    submit: {
+      getAuthStatus: getGitHubAuthStatus,
+      submitReview: requestSubmitReview,
+      afterSubmit: (context) => {
+        const pr = githubIdentity(context);
+        if (pr) navigateToPrConversation(pr);
+      },
+    },
+  };
+}

--- a/apps/extension/src/content/index.tsx
+++ b/apps/extension/src/content/index.tsx
@@ -3,15 +3,20 @@ import { getAutoOpenOnFilesTab, onAutoOpenOnFilesTabChanged } from "@extension/l
 import { parsePRUrl, type PRIdentity } from "@extension/lib/github/diffFetch";
 import { isIgnoredPrPath } from "@extension/lib/github/prUrls";
 import { fetchConversationDescription, scrapePRContext } from "@extension/lib/github/prContext";
-import { requestPRDiff, streamReviewPlan } from "@extension/lib/messaging";
+import { requestPRDiff } from "@extension/lib/messaging";
 import { getProvider } from "@guided-review/core";
 import { getProviderSettings, onProviderSettingsChanged } from "@extension/lib/settings";
 import type { ContentRequest, ParsedDiff, PRContext } from "@extension/lib/types";
 import { ensureFallbackHost, FALLBACK_HOST_ID, findButtonAnchor } from "./buttonAnchor";
+import { createGitHubReviewHost } from "./githubHost";
 import { Overlay } from "./overlay/Overlay";
+import { ReviewHostProvider, setActiveReviewHost } from "./overlay/host";
 import { isPrFilesChangedPath } from "@extension/lib/github/prUrls";
 import overlayStyles from "./overlay/styles/overlay.css?inline";
 import { useReviewStore, restoreSession, buildSessionKey } from "./overlay/store";
+
+const reviewHost = createGitHubReviewHost();
+setActiveReviewHost(reviewHost);
 
 const BUTTON_ID = "guided-review-start-btn";
 const BUTTON_STYLE_ID = "guided-review-start-btn-styles";
@@ -229,7 +234,7 @@ function startAnnotationStream(
   // Request is on the wire — show "Sent it to …" until the worker reports waiting/tokens.
   useReviewStore.getState().setBuildPhase("sent_to_provider", streamGeneration);
 
-  const { cancel } = streamReviewPlan(diff, prContext, {
+  const { cancel } = reviewHost.streamPlan(diff, prContext, {
     onStatus: (phase) => useReviewStore.getState().setBuildPhase(phase, streamGeneration),
     onUnit: (unit) => useReviewStore.getState().appendUnit(unit, streamGeneration),
     onDone: (plan) => {
@@ -353,6 +358,8 @@ function ensureOverlayMounted(): void {
   // Overlay reads the active session key from the store, so SPA navigation to
   // another PR never leaves a stale prUrl prop from the first mount.
   createRoot(appRoot).render(
-    <Overlay onRequestClose={cancelActiveStream} onRetry={retryAnnotation} />,
+    <ReviewHostProvider host={reviewHost}>
+      <Overlay onRequestClose={cancelActiveStream} onRetry={retryAnnotation} />
+    </ReviewHostProvider>,
   );
 }

--- a/apps/extension/src/content/index.tsx
+++ b/apps/extension/src/content/index.tsx
@@ -6,7 +6,8 @@ import { fetchConversationDescription, scrapePRContext } from "@extension/lib/gi
 import { requestPRDiff } from "@extension/lib/messaging";
 import { getProvider } from "@guided-review/core";
 import { getProviderSettings, onProviderSettingsChanged } from "@extension/lib/settings";
-import type { ContentRequest, ParsedDiff, PRContext } from "@extension/lib/types";
+import type { ContentRequest, ParsedDiff } from "@extension/lib/types";
+import type { ReviewContext } from "@guided-review/core";
 import { ensureFallbackHost, FALLBACK_HOST_ID, findButtonAnchor } from "./buttonAnchor";
 import { createGitHubReviewHost } from "./githubHost";
 import { Overlay } from "./overlay/Overlay";
@@ -228,7 +229,7 @@ function cancelActiveStream(): void {
 
 function startAnnotationStream(
   diff: ParsedDiff,
-  prContext: PRContext,
+  prContext: ReviewContext,
   streamGeneration: number,
 ): void {
   // Request is on the wire — show "Sent it to …" until the worker reports waiting/tokens.

--- a/apps/extension/src/content/overlay/Overlay.test.tsx
+++ b/apps/extension/src/content/overlay/Overlay.test.tsx
@@ -9,6 +9,8 @@ import { buildFileReviewPlan } from "@guided-review/core";
 import type { ParsedDiff, PRContext, ReviewPlan } from "@extension/lib/types";
 import * as messaging from "@extension/lib/messaging";
 import * as oauthConfig from "@extension/lib/github/oauthConfig";
+import { createGitHubReviewHost } from "@extension/content/githubHost";
+import { createMemoryReviewHost, setActiveReviewHost } from "./host";
 
 const sampleAuth = {
   accessToken: "gho_test",
@@ -120,6 +122,7 @@ function seedReadyReview(unitIndex = 1): void {
 
 describe("Overlay", () => {
   beforeEach(() => {
+    setActiveReviewHost(createGitHubReviewHost());
     resetStore();
     resetConfirmationQueueForTests();
     Element.prototype.scrollIntoView = vi.fn();
@@ -147,6 +150,23 @@ describe("Overlay", () => {
   it("renders nothing when the review isn't open", () => {
     const { container } = render(<Overlay />);
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it("uses Copy notes and Change summary for a local host", () => {
+    setActiveReviewHost(
+      createMemoryReviewHost({
+        kind: "local",
+        exportNotes: vi.fn(),
+        submit: undefined,
+      }),
+    );
+    seedReadyReview(0);
+    render(<Overlay />);
+
+    expect(screen.getByTestId("submit-review-button")).toHaveTextContent("Copy notes");
+    expect(screen.getByTestId("submit-review-button")).toBeDisabled();
+    expect(screen.getAllByText("Change summary").length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText("#1")).not.toBeInTheDocument();
   });
 
   it("shows the full layout with the PR description unit while loading", () => {

--- a/apps/extension/src/content/overlay/Overlay.test.tsx
+++ b/apps/extension/src/content/overlay/Overlay.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Overlay } from "./Overlay";
 import { resetConfirmationQueueForTests } from "@extension/lib/confirmation";
-import { DEFAULT_DIFF_VIEW_MODE } from "@extension/lib/preferences";
+import { DEFAULT_DIFF_VIEW_MODE } from "./diffView";
 import { useReviewStore } from "./store";
 import { VIEW_CHORD_WINDOW_MS } from "./useOverlayKeyboard";
 import { buildFileReviewPlan } from "@guided-review/core";

--- a/apps/extension/src/content/overlay/Overlay.tsx
+++ b/apps/extension/src/content/overlay/Overlay.tsx
@@ -25,6 +25,7 @@ import { confirm, ConfirmationHost, useConfirmationOpen } from "@extension/lib/c
 import { SubmitReviewModal } from "./components/SubmitReviewModal";
 import { ReviewSubmittedModal } from "./components/ReviewSubmittedModal";
 import { BUILD_PLAN_PRIMARY, buildPhaseDetail } from "./overlayCopy";
+import { useReviewHost } from "./host";
 
 interface OverlayProps {
   /** Invoked when the user exits so any in-flight stream can be cancelled. */
@@ -66,6 +67,7 @@ function statusAnnouncementText(
 }
 
 export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
+  const host = useReviewHost();
   const isOpen = useReviewStore((s) => s.isOpen);
   const status = useReviewStore((s) => s.status);
   const error = useReviewStore((s) => s.error);
@@ -140,7 +142,10 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
   function requestExit() {
     confirm({
       title: "Exit review?",
-      body: "You can reopen on this PR later. Draft comments stay for this browser session.",
+      body:
+        host.kind === "local"
+          ? "Draft notes stay for this session. Re-run the command to start again."
+          : "You can reopen on this PR later. Draft comments stay for this browser session.",
       variant: "destructive",
       okButtonText: "Exit",
       cancelButtonText: "Stay",
@@ -231,7 +236,7 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
   // Spinner on the description unit only while the plan is still being built.
   const showBuildingSpinner = planStillBuilding && (!plan || currentUnitIndex === 0);
   const loadingDetail = buildPhase != null ? buildPhaseDetail(buildPhase, providerLabel) : null;
-  const displayUnits = buildDisplayUnits(plan);
+  const displayUnits = buildDisplayUnits(plan, host.kind);
   const total = displayUnitCount(plan);
   const currentDisplay = displayUnits[currentUnitIndex] ?? displayUnits[0];
   const isDescriptionUnit = !currentDisplay || currentDisplay.kind === "pr_description";
@@ -320,7 +325,12 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
         titleId={titleId}
         title={dialogTitle}
         onExit={requestExit}
+        notesCount={draftComments.length}
         onSubmitReview={() => {
+          if (host.exportNotes) {
+            void host.exportNotes(draftComments);
+            return;
+          }
           void requestOpenSubmitReview();
         }}
       />

--- a/apps/extension/src/content/overlay/buildSelectableLines.ts
+++ b/apps/extension/src/content/overlay/buildSelectableLines.ts
@@ -1,7 +1,7 @@
 import type { DiffLine } from "@extension/lib/types";
 import { type ResolvedUnitFile } from "@guided-review/core";
 import { buildSplitRows } from "./buildSplitRows";
-import type { DiffViewMode } from "@extension/lib/preferences";
+import type { DiffViewMode } from "./diffView";
 import { lineIdFor, sideForLine, type DiffSide, type SelectableLine } from "./commentTypes";
 
 export { resolveUnitFiles } from "@guided-review/core";

--- a/apps/extension/src/content/overlay/components/ConnectProviderPrompt.tsx
+++ b/apps/extension/src/content/overlay/components/ConnectProviderPrompt.tsx
@@ -1,5 +1,5 @@
 import { Button, buttonClassName } from "@guided-review/ui";
-import { openOptionsPage } from "@extension/lib/messaging";
+import { useReviewHost } from "../host";
 
 /** Docs: configure Anthropic / OpenAI / Grok and paste an API key. */
 const CONFIGURE_PROVIDER_DOCS_URL = "https://guidedreview.dev/docs/configure-provider";
@@ -110,6 +110,7 @@ function DisconnectedProviderArt() {
  * sends the user to Settings.
  */
 export function ConnectProviderPrompt() {
+  const host = useReviewHost();
   return (
     // No live region here — the overlay's own status region already announces
     // this state, and two would double-announce it.
@@ -129,7 +130,7 @@ export function ConnectProviderPrompt() {
       <div className="flex flex-col items-center gap-2">
         <Button
           size="sm"
-          onClick={() => void openOptionsPage()}
+          onClick={() => host.connectProvider()}
           data-testid="connect-provider-open-settings"
         >
           Connect AI Provider

--- a/apps/extension/src/content/overlay/components/ContextPanel.test.tsx
+++ b/apps/extension/src/content/overlay/components/ContextPanel.test.tsx
@@ -1,6 +1,12 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createGitHubReviewHost } from "@extension/content/githubHost";
+import { setActiveReviewHost } from "../host";
 import { ContextPanel } from "./ContextPanel";
+
+beforeEach(() => {
+  setActiveReviewHost(createGitHubReviewHost());
+});
 
 describe("ContextPanel error state", () => {
   it("renders status code, error code, message, and retry", () => {

--- a/apps/extension/src/content/overlay/components/ContextPanel.tsx
+++ b/apps/extension/src/content/overlay/components/ContextPanel.tsx
@@ -7,6 +7,7 @@ import {
   missingMetadataHint,
   PR_DESCRIPTION_HINT,
 } from "@extension/content/overlay/overlayCopy";
+import { useReviewHost } from "../host";
 
 interface ContextPanelProps {
   /** When null, the synthetic PR-description unit is active. */
@@ -39,6 +40,7 @@ export function ContextPanel({
   loadingDetail,
   onRetry,
 }: ContextPanelProps) {
+  const host = useReviewHost();
   // Takes precedence over `error`: a missing key is a setup step, not a failure.
   // Units built locally have no context to show; a restored AI unit still does,
   // so never cover real commentary with the prompt.
@@ -95,9 +97,9 @@ export function ContextPanel({
 
   if (!unit) {
     const hint =
-      hasTitle && hasDescription
+      hasTitle && hasDescription && host.kind === "github"
         ? PR_DESCRIPTION_HINT
-        : missingMetadataHint(hasTitle, hasDescription);
+        : missingMetadataHint(hasTitle, hasDescription, host.kind);
 
     return (
       <div className="rounded-none border-0 bg-transparent px-0 py-0.5 pb-1">

--- a/apps/extension/src/content/overlay/components/DescriptionPane.test.tsx
+++ b/apps/extension/src/content/overlay/components/DescriptionPane.test.tsx
@@ -1,7 +1,13 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import type { ParsedDiff, PRContext } from "@extension/lib/types";
+import { createGitHubReviewHost } from "@extension/content/githubHost";
+import { setActiveReviewHost } from "../host";
 import { DescriptionPane } from "./DescriptionPane";
+
+beforeEach(() => {
+  setActiveReviewHost(createGitHubReviewHost());
+});
 
 function prContext(overrides: Partial<PRContext> = {}): PRContext {
   return {

--- a/apps/extension/src/content/overlay/components/DescriptionPane.tsx
+++ b/apps/extension/src/content/overlay/components/DescriptionPane.tsx
@@ -2,6 +2,8 @@ import type { FileChangeStatus, ParsedDiff, PRContext } from "@extension/lib/typ
 import { summarizeDiff, type FileDiffSummary } from "@guided-review/core";
 import { cn } from "@guided-review/ui";
 import { missingMetadataHint } from "@extension/content/overlay/overlayCopy";
+import { summaryUnitTitle } from "@extension/content/overlay/store";
+import { useReviewHost } from "@extension/content/overlay/host";
 import { MiddleEllipsisText } from "./MiddleEllipsisText";
 
 interface DescriptionPaneProps {
@@ -34,6 +36,7 @@ const STATUS_BADGE_CLASS: Record<FileChangeStatus, string> = {
  * When a parsed diff is available, also shows a summary of file changes.
  */
 export function DescriptionPane({ prContext, diff }: DescriptionPaneProps) {
+  const host = useReviewHost();
   const description = prContext?.description ?? "";
   const descriptionHtml = prContext?.descriptionHtml ?? "";
   const hasTitle = hasNonEmpty(prContext?.title);
@@ -51,7 +54,7 @@ export function DescriptionPane({ prContext, diff }: DescriptionPaneProps) {
     >
       <div className="min-w-0 max-w-[720px] flex-1">
         <h2 className="mb-5 text-[1.375rem] font-semibold leading-snug tracking-[-0.01em] text-foreground">
-          PR Description
+          {summaryUnitTitle(host.kind)}
         </h2>
         {descriptionHtml ? (
           <div
@@ -67,7 +70,7 @@ export function DescriptionPane({ prContext, diff }: DescriptionPaneProps) {
             className="m-0 text-[0.9375rem] leading-relaxed text-muted"
             data-testid="description-pane-empty"
           >
-            {missingMetadataHint(hasTitle, false)}
+            {missingMetadataHint(hasTitle, false, host.kind)}
           </p>
         )}
       </div>

--- a/apps/extension/src/content/overlay/components/DescriptionPane.tsx
+++ b/apps/extension/src/content/overlay/components/DescriptionPane.tsx
@@ -1,4 +1,5 @@
-import type { FileChangeStatus, ParsedDiff, PRContext } from "@extension/lib/types";
+import type { FileChangeStatus, ParsedDiff } from "@extension/lib/types";
+import type { ReviewContext } from "@guided-review/core";
 import { summarizeDiff, type FileDiffSummary } from "@guided-review/core";
 import { cn } from "@guided-review/ui";
 import { missingMetadataHint } from "@extension/content/overlay/overlayCopy";
@@ -7,7 +8,7 @@ import { useReviewHost } from "@extension/content/overlay/host";
 import { MiddleEllipsisText } from "./MiddleEllipsisText";
 
 interface DescriptionPaneProps {
-  prContext: PRContext | null;
+  prContext: ReviewContext | null;
   diff: ParsedDiff | null;
 }
 

--- a/apps/extension/src/content/overlay/components/DiffPane.test.tsx
+++ b/apps/extension/src/content/overlay/components/DiffPane.test.tsx
@@ -4,6 +4,8 @@ import { buildFileLineUrl, buildPRFileDiffUrl } from "@extension/lib/github/prUr
 import type { DiffFile, DiffHunk, PRContext } from "@extension/lib/types";
 import { buildSelectableLines } from "@extension/content/overlay/buildSelectableLines";
 import { DEFAULT_DIFF_VIEW_MODE } from "@extension/lib/preferences";
+import { createGitHubReviewHost } from "@extension/content/githubHost";
+import { setActiveReviewHost } from "../host";
 import {
   resetDiffViewModeHydrationForTests,
   useReviewStore,
@@ -84,6 +86,7 @@ function resetStore(): void {
 
 describe("DiffPane", () => {
   beforeEach(async () => {
+    setActiveReviewHost(createGitHubReviewHost());
     await chrome.storage.local.clear();
     resetStore();
   });

--- a/apps/extension/src/content/overlay/components/DiffPane.test.tsx
+++ b/apps/extension/src/content/overlay/components/DiffPane.test.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildFileLineUrl, buildPRFileDiffUrl } from "@extension/lib/github/prUrls";
 import type { DiffFile, DiffHunk, PRContext } from "@extension/lib/types";
 import { buildSelectableLines } from "@extension/content/overlay/buildSelectableLines";
-import { DEFAULT_DIFF_VIEW_MODE } from "@extension/lib/preferences";
+import { DEFAULT_DIFF_VIEW_MODE } from "@extension/content/overlay/diffView";
 import { createGitHubReviewHost } from "@extension/content/githubHost";
 import { setActiveReviewHost } from "../host";
 import {

--- a/apps/extension/src/content/overlay/components/DiffPane.tsx
+++ b/apps/extension/src/content/overlay/components/DiffPane.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@guided-review/ui";
 
-import { buildPRFileDiffUrl } from "@extension/lib/github/prUrls";
 import { languageForPath } from "@extension/lib/highlight";
+import { useReviewHost } from "@extension/content/overlay/host";
 import {
   displayLineNumber,
   linesInSelection,
@@ -53,25 +53,23 @@ interface DiffPaneProps {
 
 /** Empty body for binary/LFS/elided files; optional deep link to GitHub Files tab. */
 function BinaryElidedEmptyState({ filePath }: { filePath: string }) {
+  const host = useReviewHost();
   const prContext = useReviewStore((s) => s.prContext);
   const [githubUrl, setGithubUrl] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!prContext) {
+    if (!prContext || !host.fileDiffUrl) {
       setGithubUrl(null);
       return;
     }
     let cancelled = false;
-    void buildPRFileDiffUrl(
-      { owner: prContext.owner, repo: prContext.repo, number: prContext.number },
-      filePath,
-    ).then((url) => {
+    void host.fileDiffUrl(filePath, prContext).then((url) => {
       if (!cancelled) setGithubUrl(url);
     });
     return () => {
       cancelled = true;
     };
-  }, [prContext, filePath]);
+  }, [host, prContext, filePath]);
 
   return (
     <div

--- a/apps/extension/src/content/overlay/components/DiffPane.tsx
+++ b/apps/extension/src/content/overlay/components/DiffPane.tsx
@@ -14,7 +14,7 @@ import type { SearchScrollTarget } from "@extension/content/overlay/diffSearch";
 import { withHunkGaps } from "@extension/content/overlay/hunkGaps";
 import { hydrateDiffViewMode, useReviewStore } from "@extension/content/overlay/store";
 import type { ResolvedUnitFile } from "@extension/content/overlay/buildSelectableLines";
-import type { DiffViewMode } from "@extension/lib/preferences";
+import type { DiffViewMode } from "@extension/content/overlay/diffView";
 import type { ComposerRange } from "./diff/hunkShared";
 import { AddCommentButton, CommentModeChip, DiffViewToggle } from "./diff/DiffToolbar";
 import { HunkGapPlaceholder } from "./diff/HunkGapPlaceholder";

--- a/apps/extension/src/content/overlay/components/ProgressHeader.tsx
+++ b/apps/extension/src/content/overlay/components/ProgressHeader.tsx
@@ -1,6 +1,7 @@
 import type { ParsedDiff, PRContext } from "@extension/lib/types";
 import { summarizeDiff } from "@guided-review/core";
 import { Kbd } from "@guided-review/ui";
+import { useReviewHost } from "../host";
 import { ModEnterChord } from "./ShortcutKeys";
 
 interface ProgressHeaderProps {
@@ -11,8 +12,10 @@ interface ProgressHeaderProps {
   /** Accessible / visible title text. */
   title: string;
   onExit: () => void;
-  /** Opens the Submit Review modal. */
+  /** Opens the Submit Review modal or copies local notes. */
   onSubmitReview: () => void;
+  /** When set, the primary action is copy-notes (no GitHub submit). */
+  notesCount?: number;
 }
 
 const headerBtn =
@@ -25,9 +28,14 @@ export function ProgressHeader({
   title,
   onExit,
   onSubmitReview,
+  notesCount,
 }: ProgressHeaderProps) {
+  const host = useReviewHost();
   const stats = diff ? summarizeDiff(diff) : null;
-  const logomarkUrl = chrome.runtime.getURL("logomark.svg");
+  const logomarkUrl = host.assetUrl("logomark.svg");
+  const showPrNumber = host.kind === "github" && prContext?.number != null;
+  const primaryIsExport = !host.submit && Boolean(host.exportNotes);
+  const primaryDisabled = primaryIsExport && (notesCount ?? 0) === 0;
 
   return (
     <header className="flex shrink-0 flex-col gap-1.5 border-b border-border bg-background px-5 py-3.5">
@@ -46,8 +54,8 @@ export function ProgressHeader({
               <h1 id={titleId} className="m-0 truncate text-lg font-semibold leading-snug">
                 {title}
               </h1>
-              {prContext && (
-                <span className="shrink-0 text-base text-muted">#{prContext.number}</span>
+              {showPrNumber && (
+                <span className="shrink-0 text-base text-muted">#{prContext!.number}</span>
               )}
             </div>
             {prContext && (prContext.author || prContext.baseRef || prContext.headRef || stats) && (
@@ -72,11 +80,12 @@ export function ProgressHeader({
         <div className="flex shrink-0 items-center gap-3">
           <button
             type="button"
-            className={`${headerBtn} border-primary bg-primary text-primary-foreground hover:border-primary-hover hover:bg-primary-hover [&_[data-slot=kbd]]:bg-[rgba(13,8,6,0.12)] [&_[data-slot=kbd]]:text-inherit`}
+            className={`${headerBtn} border-primary bg-primary text-primary-foreground hover:border-primary-hover hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-50 [&_[data-slot=kbd]]:bg-[rgba(13,8,6,0.12)] [&_[data-slot=kbd]]:text-inherit`}
             onClick={onSubmitReview}
+            disabled={primaryDisabled}
             data-testid="submit-review-button"
           >
-            Submit Review
+            {primaryIsExport ? "Copy notes" : "Submit Review"}
             <ModEnterChord />
           </button>
           <button

--- a/apps/extension/src/content/overlay/components/ProgressHeader.tsx
+++ b/apps/extension/src/content/overlay/components/ProgressHeader.tsx
@@ -1,11 +1,12 @@
-import type { ParsedDiff, PRContext } from "@extension/lib/types";
+import type { ParsedDiff } from "@extension/lib/types";
+import type { ReviewContext } from "@guided-review/core";
 import { summarizeDiff } from "@guided-review/core";
 import { Kbd } from "@guided-review/ui";
 import { useReviewHost } from "../host";
 import { ModEnterChord } from "./ShortcutKeys";
 
 interface ProgressHeaderProps {
-  prContext: PRContext | null;
+  prContext: ReviewContext | null;
   diff: ParsedDiff | null;
   /** Id for the dialog title (overlay aria-labelledby). */
   titleId: string;

--- a/apps/extension/src/content/overlay/components/Sidebar.test.tsx
+++ b/apps/extension/src/content/overlay/components/Sidebar.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReviewPlan } from "@extension/lib/types";
+import { createGitHubReviewHost } from "@extension/content/githubHost";
+import { setActiveReviewHost } from "../host";
 import { Sidebar } from "./Sidebar";
 
 function planWithUnits(count: number): ReviewPlan {
@@ -17,6 +19,7 @@ function planWithUnits(count: number): ReviewPlan {
 
 describe("Sidebar", () => {
   beforeEach(() => {
+    setActiveReviewHost(createGitHubReviewHost());
     // jsdom doesn't implement layout/scroll; stub scrollIntoView so we can
     // assert the active unit is kept in view on navigation.
     Element.prototype.scrollIntoView = vi.fn();

--- a/apps/extension/src/content/overlay/components/Sidebar.tsx
+++ b/apps/extension/src/content/overlay/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import type { ReviewPlan } from "@extension/lib/types";
 import { cn } from "@guided-review/ui";
 import { buildDisplayUnits } from "@extension/content/overlay/store";
+import { useReviewHost } from "../host";
 import { TestsUnitIcon } from "./TestsUnitIcon";
 
 const SKELETON_COUNT = 4;
@@ -15,7 +16,8 @@ interface SidebarProps {
 }
 
 export function Sidebar({ plan, currentUnitIndex, stillBuilding, onSelectUnit }: SidebarProps) {
-  const displayUnits = buildDisplayUnits(plan);
+  const host = useReviewHost();
+  const displayUnits = buildDisplayUnits(plan, host.kind);
   const activeItemRef = useRef<HTMLButtonElement>(null);
 
   // Keep the active unit visible when navigating via keyboard (←/→) or footer

--- a/apps/extension/src/content/overlay/components/diff/DiffToolbar.tsx
+++ b/apps/extension/src/content/overlay/components/diff/DiffToolbar.tsx
@@ -1,5 +1,5 @@
 import { cn, Kbd } from "@guided-review/ui";
-import type { DiffViewMode } from "@extension/lib/preferences";
+import type { DiffViewMode } from "@extension/content/overlay/diffView";
 import { ShortcutKeys } from "@extension/content/overlay/components/ShortcutKeys";
 
 export function DiffViewToggle({

--- a/apps/extension/src/content/overlay/components/diff/HunkGapPlaceholder.tsx
+++ b/apps/extension/src/content/overlay/components/diff/HunkGapPlaceholder.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { cn } from "@guided-review/ui";
-import { buildFileLineUrl } from "@extension/lib/github/prUrls";
+import { useReviewHost } from "@extension/content/overlay/host";
 import { useReviewStore } from "@extension/content/overlay/store";
 
 interface HunkGapPlaceholderProps {
@@ -14,25 +14,23 @@ interface HunkGapPlaceholderProps {
  * Opens the file on GitHub at `afterLine` (new tab).
  */
 export function HunkGapPlaceholder({ filePath, afterLine }: HunkGapPlaceholderProps) {
+  const host = useReviewHost();
   const prContext = useReviewStore((s) => s.prContext);
   const [href, setHref] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!prContext) {
+    if (!prContext || !host.fileLineUrl) {
       setHref(null);
       return;
     }
     let cancelled = false;
-    void buildFileLineUrl(
-      { owner: prContext.owner, repo: prContext.repo, number: prContext.number },
-      { filePath, line: afterLine, headRef: prContext.headRef },
-    ).then((url) => {
+    void host.fileLineUrl(filePath, afterLine, prContext).then((url) => {
       if (!cancelled) setHref(url);
     });
     return () => {
       cancelled = true;
     };
-  }, [prContext, filePath, afterLine]);
+  }, [host, prContext, filePath, afterLine]);
 
   const label = `View Collapsed Lines (line ${afterLine})`;
   const className = cn(

--- a/apps/extension/src/content/overlay/diffView.ts
+++ b/apps/extension/src/content/overlay/diffView.ts
@@ -1,0 +1,4 @@
+/** Unified vs side-by-side. Chrome-free so any host can import it. */
+export type DiffViewMode = "unified" | "split";
+
+export const DEFAULT_DIFF_VIEW_MODE: DiffViewMode = "split";

--- a/apps/extension/src/content/overlay/host.ts
+++ b/apps/extension/src/content/overlay/host.ts
@@ -13,7 +13,7 @@ import type {
   SubmitReviewResponse,
 } from "@extension/lib/types";
 import type { ReviewCommentInput, ReviewEvent } from "@extension/lib/types";
-import type { DiffViewMode } from "@extension/lib/preferences";
+import type { DiffViewMode } from "./diffView";
 import type { DraftComment } from "./commentTypes";
 
 export interface StreamPlanHandlers {

--- a/apps/extension/src/content/overlay/host.ts
+++ b/apps/extension/src/content/overlay/host.ts
@@ -1,0 +1,107 @@
+/**
+ * Host adapter for the review overlay. Chrome/GitHub (and later the CLI)
+ * implement this; overlay components must not import `chrome.*`.
+ */
+
+import { createContext, createElement, useContext, type ReactNode } from "react";
+import type {
+  ParsedDiff,
+  ReviewContext,
+  ReviewErrorInfo,
+  ReviewPlan,
+  ReviewUnit,
+  SubmitReviewResponse,
+} from "@extension/lib/types";
+import type { ReviewCommentInput, ReviewEvent } from "@extension/lib/types";
+import type { DiffViewMode } from "@extension/lib/preferences";
+import type { DraftComment } from "./commentTypes";
+
+export interface StreamPlanHandlers {
+  onUnit: (unit: ReviewUnit) => void;
+  onDone: (plan: ReviewPlan) => void;
+  onError: (error: ReviewErrorInfo) => void;
+  onStatus?: (phase: "waiting_for_tokens" | "tokens_streaming") => void;
+}
+
+export interface ReviewSubmitAuth {
+  login: string;
+  avatarUrl?: string;
+  name?: string;
+}
+
+export interface ReviewHostSubmit {
+  getAuthStatus(): Promise<{ ok: true; auth: ReviewSubmitAuth | null }>;
+  submitReview(
+    pr: { owner: string; repo: string; number: number },
+    body: string,
+    event: ReviewEvent,
+    comments: ReviewCommentInput[],
+  ): Promise<SubmitReviewResponse>;
+  afterSubmit?(context: ReviewContext): void;
+}
+
+export interface ReviewHost {
+  kind: "github" | "local";
+  assetUrl(path: string): string;
+  persistSession(key: string, data: unknown): Promise<void>;
+  restoreSession(key: string): Promise<unknown | null>;
+  streamPlan(
+    diff: ParsedDiff,
+    context: ReviewContext,
+    handlers: StreamPlanHandlers,
+  ): { cancel(): void };
+  connectProvider(): void;
+  persistDiffViewMode?(mode: DiffViewMode): Promise<void>;
+  readDiffViewMode?(): Promise<DiffViewMode>;
+  fileDiffUrl?(filePath: string, context: ReviewContext): Promise<string | null>;
+  fileLineUrl?(filePath: string, line: number, context: ReviewContext): Promise<string | null>;
+  submit?: ReviewHostSubmit;
+  exportNotes?: (drafts: DraftComment[]) => void | Promise<void>;
+}
+
+const ReviewHostContext = createContext<ReviewHost | null>(null);
+
+let activeHost: ReviewHost | null = null;
+
+export function setActiveReviewHost(host: ReviewHost | null): void {
+  activeHost = host;
+}
+
+export function getActiveReviewHost(): ReviewHost | null {
+  return activeHost;
+}
+
+export function ReviewHostProvider({ host, children }: { host: ReviewHost; children: ReactNode }) {
+  setActiveReviewHost(host);
+  return createElement(ReviewHostContext.Provider, { value: host }, children);
+}
+
+export function useReviewHost(): ReviewHost {
+  const fromContext = useContext(ReviewHostContext);
+  const host = fromContext ?? activeHost;
+  if (!host) {
+    throw new Error("ReviewHost is not set. Wrap the overlay in ReviewHostProvider.");
+  }
+  return host;
+}
+
+/** In-memory host for unit tests. */
+export function createMemoryReviewHost(overrides: Partial<ReviewHost> = {}): ReviewHost {
+  const sessions = new Map<string, unknown>();
+  let diffViewMode: DiffViewMode = "split";
+  return {
+    kind: "github",
+    assetUrl: (path) => path,
+    persistSession: async (key, data) => {
+      sessions.set(key, data);
+    },
+    restoreSession: async (key) => sessions.get(key) ?? null,
+    streamPlan: () => ({ cancel() {} }),
+    connectProvider: () => {},
+    persistDiffViewMode: async (mode) => {
+      diffViewMode = mode;
+    },
+    readDiffViewMode: async () => diffViewMode,
+    ...overrides,
+  };
+}

--- a/apps/extension/src/content/overlay/overlayCopy.ts
+++ b/apps/extension/src/content/overlay/overlayCopy.ts
@@ -28,7 +28,23 @@ export function buildPhaseDetail(phase: BuildPhase, providerLabel: string | null
  * Shared by the left description pane and the right context panel so wording
  * stays consistent.
  */
-export function missingMetadataHint(hasTitle: boolean, hasDescription: boolean): string {
+export function missingMetadataHint(
+  hasTitle: boolean,
+  hasDescription: boolean,
+  kind: "github" | "local" = "github",
+): string {
+  if (kind === "local") {
+    if (!hasTitle && !hasDescription) {
+      return "No branch summary. Intent will be inferred from the diff.";
+    }
+    if (!hasDescription) {
+      return "No commit log. Intent will be inferred from the branch name and diff.";
+    }
+    if (!hasTitle) {
+      return "No branch name. Intent will be inferred from the commit log and diff.";
+    }
+    return "Commit log and dirty-tree notes. Start here, then step through the planned units.";
+  }
   if (!hasTitle && !hasDescription) {
     return "No PR title or description. Intent will be inferred from the diff.";
   }

--- a/apps/extension/src/content/overlay/store.displayUnits.test.ts
+++ b/apps/extension/src/content/overlay/store.displayUnits.test.ts
@@ -14,6 +14,7 @@ describe("displayUnits", () => {
     expect(buildDisplayUnits(null)).toEqual([
       { kind: "pr_description", id: "__pr_description", title: "PR Description" },
     ]);
+    expect(buildDisplayUnits(null, "local")[0].title).toBe("Change summary");
   });
 
   it("appends plan units after the description", () => {

--- a/apps/extension/src/content/overlay/store.test.ts
+++ b/apps/extension/src/content/overlay/store.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import { DEFAULT_DIFF_VIEW_MODE } from "@extension/lib/preferences";
 import { useReviewStore, persistSession, restoreSession, buildSessionKey } from "./store";
 import type { ParsedDiff, PRContext, ReviewPlan } from "@extension/lib/types";
+import { createGitHubReviewHost } from "@extension/content/githubHost";
+import { setActiveReviewHost } from "./host";
 
 function diffFixture(): ParsedDiff {
   return { files: [] };
@@ -81,6 +83,10 @@ describe("buildSessionKey", () => {
 });
 
 describe("useReviewStore", () => {
+  beforeEach(() => {
+    setActiveReviewHost(createGitHubReviewHost());
+  });
+
   it("open/close toggle isOpen", () => {
     resetStore();
     useReviewStore.getState().open();

--- a/apps/extension/src/content/overlay/store.test.ts
+++ b/apps/extension/src/content/overlay/store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { DEFAULT_DIFF_VIEW_MODE } from "@extension/lib/preferences";
+import { DEFAULT_DIFF_VIEW_MODE } from "./diffView";
 import { useReviewStore, persistSession, restoreSession, buildSessionKey } from "./store";
 import type { ParsedDiff, PRContext, ReviewPlan } from "@extension/lib/types";
 import { createGitHubReviewHost } from "@extension/content/githubHost";

--- a/apps/extension/src/content/overlay/store.ts
+++ b/apps/extension/src/content/overlay/store.ts
@@ -17,13 +17,8 @@ import {
   type SelectableLine,
   type UiMode,
 } from "./commentTypes";
-import { readSession, writeSession } from "@extension/lib/storage";
-import {
-  DEFAULT_DIFF_VIEW_MODE,
-  getStoredDiffViewMode,
-  setStoredDiffViewMode,
-  type DiffViewMode,
-} from "@extension/lib/preferences";
+import { DEFAULT_DIFF_VIEW_MODE, type DiffViewMode } from "@extension/lib/preferences";
+import { getActiveReviewHost } from "./host";
 
 export type ReviewStatus = "idle" | "loading" | "streaming" | "ready" | "error";
 
@@ -40,17 +35,24 @@ export type BuildPhase =
 
 export type { DiffViewMode };
 
-/** Display list unit: synthetic PR description first, then plan units. */
+/** Display list unit: synthetic change summary first, then plan units. */
 export type DisplayUnit =
-  | { kind: "pr_description"; id: "__pr_description"; title: "PR Description" }
+  | { kind: "pr_description"; id: "__pr_description"; title: string }
   | { kind: "review"; id: string; title: string; unit: ReviewUnit; planIndex: number };
 
+export function summaryUnitTitle(kind: "github" | "local" = "github"): string {
+  return kind === "local" ? "Change summary" : "PR Description";
+}
+
 /** Ordered units shown in the overlay (description is UI-only, not model output). */
-export function buildDisplayUnits(plan: ReviewPlan | null): DisplayUnit[] {
+export function buildDisplayUnits(
+  plan: ReviewPlan | null,
+  hostKind: "github" | "local" = "github",
+): DisplayUnit[] {
   const description: DisplayUnit = {
     kind: "pr_description",
     id: "__pr_description",
-    title: "PR Description",
+    title: summaryUnitTitle(hostKind),
   };
   if (!plan) return [description];
   return [
@@ -176,10 +178,6 @@ interface ReviewState {
  */
 export function buildSessionKey(pr: PRIdentity): string {
   return `${pr.owner}/${pr.repo}#${pr.number}`;
-}
-
-function storageKey(sessionKey: string): string {
-  return `guidedReview.session.${sessionKey}`;
 }
 
 function newDraftId(): string {
@@ -358,7 +356,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
     diffViewModeHydrateEpoch += 1;
     diffViewModeHydrated = true;
     set({ diffViewMode: mode });
-    void setStoredDiffViewMode(mode);
+    void getActiveReviewHost()?.persistDiffViewMode?.(mode);
   },
 
   enterCommentMode: (lines) => {
@@ -518,7 +516,7 @@ export async function hydrateDiffViewMode(): Promise<void> {
   const epoch = diffViewModeHydrateEpoch;
   diffViewModeHydrateInFlight = (async () => {
     try {
-      const mode = await getStoredDiffViewMode();
+      const mode = (await getActiveReviewHost()?.readDiffViewMode?.()) ?? DEFAULT_DIFF_VIEW_MODE;
       if (epoch !== diffViewModeHydrateEpoch) return;
       useReviewStore.setState({ diffViewMode: mode });
       diffViewModeHydrated = true;
@@ -559,6 +557,9 @@ export async function persistSession(): Promise<void> {
   // resumed in place of the AI plan once a provider is configured.
   if (needsProvider) return;
 
+  const host = getActiveReviewHost();
+  if (!host) return;
+
   const payload: PersistedSession = {
     diff,
     plan,
@@ -567,7 +568,7 @@ export async function persistSession(): Promise<void> {
     draftComments,
   };
   try {
-    await writeSession(storageKey(sessionKey), payload);
+    await host.persistSession(sessionKey, payload);
   } catch (error) {
     console.warn("Guided Review: failed to persist session", error);
   }
@@ -579,9 +580,12 @@ export async function persistSession(): Promise<void> {
  * to starting a fresh review in either case.
  */
 export async function restoreSession(sessionKey: string): Promise<boolean> {
+  const host = getActiveReviewHost();
+  if (!host) return false;
+
   let saved: PersistedSession | undefined;
   try {
-    saved = await readSession(storageKey(sessionKey), (raw) => raw as PersistedSession | undefined);
+    saved = (await host.restoreSession(sessionKey)) as PersistedSession | undefined;
   } catch (error) {
     console.warn("Guided Review: failed to restore session", error);
     return false;

--- a/apps/extension/src/content/overlay/store.ts
+++ b/apps/extension/src/content/overlay/store.ts
@@ -1,11 +1,6 @@
 import { create } from "zustand";
-import type {
-  ParsedDiff,
-  PRContext,
-  ReviewErrorInfo,
-  ReviewPlan,
-  ReviewUnit,
-} from "@extension/lib/types";
+import type { ParsedDiff, ReviewErrorInfo, ReviewPlan, ReviewUnit } from "@extension/lib/types";
+import type { ReviewContext } from "@guided-review/core";
 import { NO_API_KEY_ERROR_CODE } from "@extension/lib/types";
 import type { PRIdentity } from "@extension/lib/github/diffFetch";
 import { buildFileReviewPlan } from "@guided-review/core";
@@ -17,7 +12,7 @@ import {
   type SelectableLine,
   type UiMode,
 } from "./commentTypes";
-import { DEFAULT_DIFF_VIEW_MODE, type DiffViewMode } from "@extension/lib/preferences";
+import { DEFAULT_DIFF_VIEW_MODE, type DiffViewMode } from "./diffView";
 import { getActiveReviewHost } from "./host";
 
 export type ReviewStatus = "idle" | "loading" | "streaming" | "ready" | "error";
@@ -75,7 +70,7 @@ export function displayUnitCount(plan: ReviewPlan | null): number {
 interface PersistedSession {
   diff: ParsedDiff;
   plan: ReviewPlan;
-  prContext: PRContext | null;
+  prContext: ReviewContext | null;
   /** Index into the display unit list (0 = PR description, then plan units). */
   currentUnitIndex: number;
   /** Local draft comments (session-scoped; not posted to GitHub). */
@@ -105,7 +100,7 @@ interface ReviewState {
   providerLabel: string | null;
   diff: ParsedDiff | null;
   plan: ReviewPlan | null;
-  prContext: PRContext | null;
+  prContext: ReviewContext | null;
   /** Index into the display unit list (0 = PR description, then plan units). */
   currentUnitIndex: number;
   /**
@@ -132,7 +127,7 @@ interface ReviewState {
   open: () => void;
   close: () => void;
   startLoading: (sessionKey: string) => void;
-  setPRContext: (prContext: PRContext) => void;
+  setPRContext: (prContext: ReviewContext) => void;
   setDiff: (diff: ParsedDiff) => void;
   setBuildPhase: (phase: BuildPhase, generation?: number) => void;
   setProviderLabel: (label: string | null) => void;

--- a/apps/extension/src/content/overlay/useOverlayKeyboard.ts
+++ b/apps/extension/src/content/overlay/useOverlayKeyboard.ts
@@ -27,7 +27,7 @@
 import { useEffect, useRef, type MutableRefObject, type RefObject } from "react";
 import { getConfirmationDialogElement, isConfirmationOpen } from "@extension/lib/confirmation";
 import type { SelectableLine } from "./commentTypes";
-import type { DiffViewMode } from "@extension/lib/preferences";
+import type { DiffViewMode } from "./diffView";
 import { trapTabKey } from "./focusTrap";
 import { useReviewStore } from "./store";
 

--- a/apps/extension/src/content/overlay/useSubmitReviewFlow.ts
+++ b/apps/extension/src/content/overlay/useSubmitReviewFlow.ts
@@ -1,9 +1,8 @@
 import { useRef, useState } from "react";
-import { getGitHubAuthStatus, requestSubmitReview } from "@extension/lib/messaging";
 import type { PRContext, ReviewCommentInput } from "@extension/lib/types";
 import { EMPTY_REVIEW_BODY_MESSAGE } from "@extension/lib/types";
 import type { DraftComment, ReviewEvent, ReviewSubmission } from "./commentTypes";
-import { navigateToPrConversation } from "@extension/lib/github/prUrls";
+import { useReviewHost } from "./host";
 
 /** Map local draft comments to GitHub create-review `comments[]` payloads. */
 function mapDraftsToReviewComments(drafts: DraftComment[]): ReviewCommentInput[] {
@@ -50,6 +49,7 @@ export function useSubmitReviewFlow({
   handleExit,
   overlayRef,
 }: UseSubmitReviewFlowOptions) {
+  const host = useReviewHost();
   const [submitReviewOpen, setSubmitReviewOpen] = useState(false);
   const [connectGitHubOpen, setConnectGitHubOpen] = useState(false);
   const [submittingReview, setSubmittingReview] = useState(false);
@@ -69,7 +69,7 @@ export function useSubmitReviewFlow({
   function exitAfterSubmit(): void {
     setSubmitSuccess(null);
     if (prContext) {
-      navigateToPrConversation(prContext);
+      host.submit?.afterSubmit?.(prContext);
     }
     // Post-submit exit is intentional (single CTA) — skip the confirm prompt.
     handleExit();
@@ -112,9 +112,11 @@ export function useSubmitReviewFlow({
       return;
     }
 
+    if (!host.submit) return;
+
     authCheckInFlightRef.current = true;
     try {
-      const status = await getGitHubAuthStatus();
+      const status = await host.submit.getAuthStatus();
       if (status.ok && status.auth) {
         setSubmitReviewError(null);
         setSubmitReviewOpen(true);
@@ -154,9 +156,14 @@ export function useSubmitReviewFlow({
     setSubmitReviewError(null);
 
     const comments = mapDraftsToReviewComments(draftComments);
+    const submit = host.submit;
+    if (!submit) {
+      setSubmitReviewError("This host cannot submit a GitHub review.");
+      return;
+    }
 
     try {
-      const result = await requestSubmitReview(
+      const result = await submit.submitReview(
         { owner: pr.owner, repo: pr.repo, number: pr.number },
         trimmedBody,
         submission.event,

--- a/apps/extension/src/content/overlay/useSubmitReviewFlow.ts
+++ b/apps/extension/src/content/overlay/useSubmitReviewFlow.ts
@@ -1,5 +1,6 @@
 import { useRef, useState } from "react";
-import type { PRContext, ReviewCommentInput } from "@extension/lib/types";
+import type { ReviewCommentInput } from "@extension/lib/types";
+import type { ReviewContext } from "@guided-review/core";
 import { EMPTY_REVIEW_BODY_MESSAGE } from "@extension/lib/types";
 import type { DraftComment, ReviewEvent, ReviewSubmission } from "./commentTypes";
 import { useReviewHost } from "./host";
@@ -27,7 +28,7 @@ export interface SubmitSuccessInfo {
 }
 
 interface UseSubmitReviewFlowOptions {
-  prContext: PRContext | null;
+  prContext: ReviewContext | null;
   draftComments: DraftComment[];
   clearDraftComments: () => void;
   handleExit: () => void;
@@ -144,7 +145,7 @@ export function useSubmitReviewFlow({
     }
 
     const pr = prContext;
-    if (!pr) {
+    if (!pr || pr.owner == null || pr.repo == null || pr.number == null) {
       setSubmitReviewError(
         "Missing pull request context. Close the review and try again from the PR page.",
       );

--- a/apps/extension/src/lib/preferences.ts
+++ b/apps/extension/src/lib/preferences.ts
@@ -42,9 +42,10 @@ export function onAutoOpenOnFilesTabChanged(listener: (enabled: boolean) => void
 
 // ---- Diff view mode (unified | split) --------------------------------------
 
-export type DiffViewMode = "unified" | "split";
+export type { DiffViewMode } from "@extension/content/overlay/diffView";
+export { DEFAULT_DIFF_VIEW_MODE } from "@extension/content/overlay/diffView";
 
-export const DEFAULT_DIFF_VIEW_MODE: DiffViewMode = "split";
+import { DEFAULT_DIFF_VIEW_MODE, type DiffViewMode } from "@extension/content/overlay/diffView";
 
 const DIFF_VIEW_MODE_KEY = "guidedReview.diffViewMode";
 


### PR DESCRIPTION
Part 2 of 13 in the local-review CLI stack. Base: [#77](https://github.com/nshntarora/guidedreview/pull/77).

Give the overlay a `ReviewHost` and store `ReviewContext` so the walkthrough does not assume GitHub chrome. The same overlay can later sit on a local git diff.

**Out of scope (later PRs):** the CLI itself, local scope picker, settings.