### PR TITLE
feat(core): support bearer auth, heartbeats, and new Grok models

### DIFF
--- a/packages/core/src/providers/anthropic.test.ts
+++ b/packages/core/src/providers/anthropic.test.ts
@@ -144,6 +144,41 @@ describe("anthropicProvider", () => {
     );
   });
 
+  it("sends bearer auth and extra headers when settings request it", async () => {
+    postMock.mockResolvedValue(
+      okStreamResponse(
+        streamOf(
+          'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"{}"}}\n',
+        ),
+      ),
+    );
+
+    await collect(
+      anthropicProvider.annotateReviewStream({
+        ...input,
+        settings: {
+          ...input.settings,
+          apiKey: "sk-ant-oat01-test",
+          authScheme: "bearer",
+          extraHeaders: { "anthropic-beta": "oauth-2025-04-20" },
+        },
+      }),
+    );
+
+    expect(postMock).toHaveBeenCalledWith(
+      "https://api.anthropic.com/v1/messages",
+      expect.objectContaining({
+        authorization: "Bearer sk-ant-oat01-test",
+        "anthropic-beta": "oauth-2025-04-20",
+      }),
+      expect.any(Object),
+      "Claude",
+      undefined,
+    );
+    const sent = postMock.mock.calls[0]?.[1] as Record<string, string>;
+    expect(sent["x-api-key"]).toBeUndefined();
+  });
+
   it("testConnection posts a minimal probe request", async () => {
     postMock.mockResolvedValue(new Response("{}", { status: 200 }));
 

--- a/packages/core/src/providers/anthropic.ts
+++ b/packages/core/src/providers/anthropic.ts
@@ -8,14 +8,20 @@ import { ProviderError } from "./types";
 
 const API_URL = "https://api.anthropic.com/v1/messages";
 
-function headers(apiKey: string): Record<string, string> {
-  return {
-    "x-api-key": apiKey,
+function headers(settings: ProviderSettings): Record<string, string> {
+  const result: Record<string, string> = {
     "anthropic-version": "2023-06-01",
     // Documented "bring your own API key" browser-CORS opt-in, which lets the
     // background worker call the Messages API directly.
     "anthropic-dangerous-direct-browser-access": "true",
+    ...settings.extraHeaders,
   };
+  if (settings.authScheme === "bearer") {
+    result.authorization = `Bearer ${settings.apiKey}`;
+  } else {
+    result["x-api-key"] = settings.apiKey;
+  }
+  return result;
 }
 
 /**
@@ -30,7 +36,7 @@ export const anthropicProvider: ProviderClient = {
   ): AsyncGenerator<AnnotateStreamEvent, void, unknown> {
     const response = await postProviderJson(
       API_URL,
-      headers(settings.apiKey),
+      headers(settings),
       {
         model: settings.model,
         max_tokens: 8000,
@@ -86,7 +92,7 @@ export const anthropicProvider: ProviderClient = {
   async testConnection(settings: ProviderSettings): Promise<void> {
     await postProviderJson(
       API_URL,
-      headers(settings.apiKey),
+      headers(settings),
       {
         model: settings.model,
         max_tokens: 8,

--- a/packages/core/src/providers/catalog.ts
+++ b/packages/core/src/providers/catalog.ts
@@ -81,6 +81,8 @@ export const MODELS: readonly ModelDefinition[] = [
   { id: "o4-mini", displayName: "o4 Mini", provider: "openai" },
 
   // --- Grok (xAI) ---
+  { id: "grok-4.6", displayName: "Grok 4.6", provider: "grok" },
+  { id: "grok-4.5", displayName: "Grok 4.5", provider: "grok" },
   { id: "grok-4", displayName: "Grok 4", provider: "grok" },
   { id: "grok-3", displayName: "Grok 3", provider: "grok" },
   { id: "grok-3-mini", displayName: "Grok 3 Mini", provider: "grok" },
@@ -106,7 +108,15 @@ export function normalizeProviderSettings(stored: {
   provider?: string;
   model?: string;
   apiKey?: string;
-}): { provider: ProviderId; model: string; apiKey: string } {
+  authScheme?: "api-key" | "bearer";
+  extraHeaders?: Record<string, string>;
+}): {
+  provider: ProviderId;
+  model: string;
+  apiKey: string;
+  authScheme?: "api-key" | "bearer";
+  extraHeaders?: Record<string, string>;
+} {
   const provider =
     stored.provider && stored.provider in PROVIDERS ? (stored.provider as ProviderId) : "anthropic";
   // Keep the stored model only if it still exists for this provider.
@@ -115,5 +125,7 @@ export function normalizeProviderSettings(stored: {
     provider,
     model: model?.id ?? defaultModelFor(provider),
     apiKey: stored.apiKey ?? "",
+    ...(stored.authScheme ? { authScheme: stored.authScheme } : {}),
+    ...(stored.extraHeaders ? { extraHeaders: stored.extraHeaders } : {}),
   };
 }

--- a/packages/core/src/providers/openaiCompatible.test.ts
+++ b/packages/core/src/providers/openaiCompatible.test.ts
@@ -92,6 +92,25 @@ describe("createOpenAICompatibleProvider", () => {
     ]);
   });
 
+  it("emits heartbeats for reasoning tokens without treating them as plan JSON", async () => {
+    postMock.mockResolvedValue(
+      okStreamResponse(
+        streamOf(
+          'data: {"choices":[{"delta":{"reasoning_content":"thinking"}}]}\n',
+          'data: {"choices":[{"delta":{"content":"{}"}}]}\n',
+          "data: [DONE]\n",
+        ),
+      ),
+    );
+
+    const events = await collect(provider.annotateReviewStream(input));
+    expect(events).toEqual([
+      { type: "heartbeat" },
+      { type: "text_delta", text: "{}" },
+      { type: "done" },
+    ]);
+  });
+
   it("throws when the response body is empty", async () => {
     postMock.mockResolvedValue(new Response(null, { status: 200 }));
 

--- a/packages/core/src/providers/openaiCompatible.ts
+++ b/packages/core/src/providers/openaiCompatible.ts
@@ -20,7 +20,10 @@ export function createOpenAICompatibleProvider(
   displayName: string,
 ): ProviderClient {
   const chatUrl = `${baseUrl}/chat/completions`;
-  const headers = (apiKey: string) => ({ authorization: `Bearer ${apiKey}` });
+  const headers = (settings: ProviderSettings) => ({
+    authorization: `Bearer ${settings.apiKey}`,
+    ...settings.extraHeaders,
+  });
 
   return {
     async *annotateReviewStream(
@@ -29,7 +32,7 @@ export function createOpenAICompatibleProvider(
     ): AsyncGenerator<AnnotateStreamEvent, void, unknown> {
       const response = await postProviderJson(
         chatUrl,
-        headers(settings.apiKey),
+        headers(settings),
         {
           model: settings.model,
           stream: true,
@@ -59,7 +62,10 @@ export function createOpenAICompatibleProvider(
       for await (const event of readSseJsonStream(response.body, { signal: options?.signal })) {
         if (!event || typeof event !== "object") continue;
         const data = event as {
-          choices?: Array<{ delta?: { content?: string | null }; finish_reason?: string | null }>;
+          choices?: Array<{
+            delta?: { content?: string | null; reasoning_content?: string | null };
+            finish_reason?: string | null;
+          }>;
           error?: { message?: string; code?: string; type?: string };
         };
 
@@ -69,7 +75,12 @@ export function createOpenAICompatibleProvider(
           });
         }
 
-        const content = data.choices?.[0]?.delta?.content;
+        const delta = data.choices?.[0]?.delta;
+        const reasoning = delta?.reasoning_content;
+        if (typeof reasoning === "string" && reasoning.length > 0) {
+          yield { type: "heartbeat" };
+        }
+        const content = delta?.content;
         if (typeof content === "string" && content.length > 0) {
           sawContent = true;
           yield { type: "text_delta", text: content };
@@ -86,7 +97,7 @@ export function createOpenAICompatibleProvider(
     async testConnection(settings: ProviderSettings): Promise<void> {
       await postProviderJson(
         chatUrl,
-        headers(settings.apiKey),
+        headers(settings),
         {
           model: settings.model,
           max_tokens: 8,

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -6,7 +6,11 @@ export interface AnnotateReviewInput {
   settings: ProviderSettings;
 }
 
-export type AnnotateStreamEvent = { type: "text_delta"; text: string } | { type: "done" };
+export type AnnotateStreamEvent =
+  | { type: "text_delta"; text: string }
+  /** Provider is alive (e.g. reasoning tokens) but has not emitted plan JSON yet. */
+  | { type: "heartbeat" }
+  | { type: "done" };
 
 export interface ProviderClient {
   /**

--- a/packages/core/src/review/annotate.ts
+++ b/packages/core/src/review/annotate.ts
@@ -31,19 +31,18 @@ export async function* annotateReview(
   const { diff, context, settings, signal } = input;
 
   try {
+    // Emit before chunking or the first provider call so the host can leave
+    // "processing the diff" even when those steps take a while.
+    yield { type: "STATUS", phase: "waiting_for_tokens" };
+
     const client = getProviderClient(settings.provider);
     const chunks = chunkDiffByFile(diff).filter((chunk) => chunk.files.length > 0);
     const allUnits: ReviewUnit[] = [];
     const seenHunkIds = new Set<string>();
-    const streamStatus = { postedWaiting: false, postedStreaming: false };
+    const streamStatus = { postedWaiting: true, postedStreaming: false };
 
     for (const [chunkIndex, chunk] of chunks.entries()) {
       if (signal?.aborted) return;
-
-      if (!streamStatus.postedWaiting) {
-        streamStatus.postedWaiting = true;
-        yield { type: "STATUS", phase: "waiting_for_tokens" };
-      }
 
       for await (const event of streamChunkUnits(client, chunk, context, settings, {
         chunkIndex,
@@ -103,6 +102,14 @@ async function* streamChunkUnits(
     { signal },
   )) {
     if (signal?.aborted) return;
+
+    if (event.type === "heartbeat") {
+      if (!sawToken) {
+        sawToken = true;
+        yield { type: "token" };
+      }
+      continue;
+    }
 
     if (event.type === "text_delta" && !sawToken) {
       sawToken = true;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -134,6 +134,13 @@ export interface ProviderSettings {
   provider: ProviderId;
   model: string;
   apiKey: string;
+  /**
+   * How to send `apiKey`. Anthropic defaults to `x-api-key`; OpenAI-compatible
+   * clients always use Bearer. Coding-agent OAuth tokens set `bearer`.
+   */
+  authScheme?: "api-key" | "bearer";
+  /** Merged into the provider request. Used by agent adapters (e.g. Anthropic beta). */
+  extraHeaders?: Record<string, string>;
 }
 
 // ---- Annotate stream (host-agnostic) ----------------------------------------


### PR DESCRIPTION
Part 4 of 13 in the local-review CLI stack. Base: [#79](https://github.com/nshntarora/guidedreview/pull/79).

Provider client: bearer auth, heartbeats, and updated Grok models. The CLI and coding-agent layers need this.

**Out of scope (later PRs):** reading keys from Claude Code / Codex / Grok, the local settings UI.