### PR TITLE
feat(cli): reuse coding-agent credentials for provider keys

### DIFF
--- a/apps/cli/src/args.test.ts
+++ b/apps/cli/src/args.test.ts
@@ -21,6 +21,8 @@ describe("parseArgs", () => {
       "--no-untracked",
       "--provider",
       "grok",
+      "--agent",
+      "codex",
     ]);
     expect(args.cwd).toBe("/tmp/repo");
     expect(args.base).toBe("develop");
@@ -29,5 +31,6 @@ describe("parseArgs", () => {
     expect(args.staged).toBe(true);
     expect(args.includeUntracked).toBe(false);
     expect(args.provider).toBe("grok");
+    expect(args.agent).toBe("codex");
   });
 });

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -7,6 +7,7 @@ export interface CliArgs {
   includeUntracked: boolean;
   provider?: string;
   model?: string;
+  agent?: string;
   help: boolean;
 }
 
@@ -59,6 +60,10 @@ export function parseArgs(argv: string[]): CliArgs {
       args.model = argv[++i];
       continue;
     }
+    if (token === "--agent") {
+      args.agent = argv[++i];
+      continue;
+    }
     if (token.startsWith("-")) {
       throw new Error(`Unknown flag ${token}. Run guided-review --help.`);
     }
@@ -81,5 +86,6 @@ Review local changes against the main branch. Opens a browser UI.
   --no-untracked     Skip untracked files
   --provider <id>    anthropic | openai | grok
   --model <id>       Provider model id
+  --agent <id>       claude-code | codex | grok (reuse that coding agent's key)
   -h, --help         Show this help
 `;

--- a/apps/cli/src/bin.ts
+++ b/apps/cli/src/bin.ts
@@ -6,8 +6,8 @@ import { fileURLToPath } from "node:url";
 import { HELP, parseArgs } from "./args";
 import { resolveSettings } from "./config";
 import { GitError } from "./git/run";
-import { buildLocalDiff } from "./git/localDiff";
-import { createReviewServer, listen } from "./server/createServer";
+import { buildLocalReview, reviewHasChanges } from "./git/localDiff";
+import { createReviewServer, createServerShutdown, listen } from "./server/createServer";
 
 function openBrowser(url: string): void {
   const command =
@@ -23,30 +23,30 @@ async function main(): Promise<void> {
     return;
   }
 
-  const local = await buildLocalDiff({
+  const local = await buildLocalReview({
     cwd: path.resolve(args.cwd),
     base: args.base,
     staged: args.staged,
     includeUntracked: args.includeUntracked,
   });
 
-  if (local.empty) {
+  if (!reviewHasChanges(local)) {
     process.stdout.write(`Nothing to review against ${local.context.baseRef}.\n`);
     return;
   }
 
-  const settings = await resolveSettings({
+  const resolved = await resolveSettings({
     provider: args.provider,
     model: args.model,
+    agent: args.agent,
   });
 
   const token = randomBytes(16).toString("hex");
   const staticDir = path.join(path.dirname(fileURLToPath(import.meta.url)), "ui");
   const server = createReviewServer({
-    context: local.context,
-    diff: local.diff,
-    sessionKey: local.sessionKey,
-    settings,
+    snapshot: local,
+    settings: resolved.settings,
+    codingAgent: resolved.codingAgent,
     token,
     staticDir,
   });
@@ -55,16 +55,18 @@ async function main(): Promise<void> {
   const url = `http://127.0.0.1:${port}/?token=${token}`;
 
   process.stdout.write(
-    `Reviewing ${local.diff.files.length} file(s) vs ${local.context.baseRef}.\n`,
+    `Reviewing ${local.diff.files.length} file(s) on ${local.context.headRef} vs ${local.context.baseRef}.\n`,
   );
   process.stdout.write(`${url}\n`);
   process.stdout.write("Ctrl+C to stop.\n");
+  const { settings, codingAgent } = resolved;
+  process.stderr.write(
+    `${settings.provider}/${settings.model}${codingAgent ? ` via ${codingAgent}` : ""}${settings.apiKey ? "" : "  no key"}\n`,
+  );
 
   if (args.open) openBrowser(url);
 
-  const shutdown = () => {
-    server.close(() => process.exit(0));
-  };
+  const shutdown = createServerShutdown(server);
   process.on("SIGINT", shutdown);
   process.on("SIGTERM", shutdown);
 }

--- a/apps/cli/src/codingAgents/claudeCode.test.ts
+++ b/apps/cli/src/codingAgents/claudeCode.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { claudeCodeAdapter } from "./claudeCode";
+import { createMemoryIo } from "./io";
+
+const home = "/home/test";
+const credPath = `${home}/.claude/.credentials.json`;
+
+function oauthJson(token: string, expiresAt = Date.now() + 60_000): string {
+  return JSON.stringify({ claudeAiOauth: { accessToken: token, expiresAt } });
+}
+
+describe("claudeCodeAdapter", () => {
+  it("detects nothing when the CLI and config are absent", async () => {
+    expect(await claudeCodeAdapter.detect(createMemoryIo({ home }))).toBeNull();
+  });
+
+  it("uses ANTHROPIC_API_KEY as a console key", async () => {
+    const io = createMemoryIo({
+      home,
+      binaries: ["claude"],
+      env: { ANTHROPIC_API_KEY: "sk-ant-api03-from-env" },
+    });
+    const detected = await claudeCodeAdapter.detect(io);
+    expect(detected?.auth).toMatchObject({
+      kind: "api_key",
+      usableForReview: true,
+      secret: "sk-ant-api03-from-env",
+    });
+  });
+
+  it("reads a console key from settings.json env", async () => {
+    const io = createMemoryIo({
+      home,
+      files: {
+        [`${home}/.claude/settings.json`]: JSON.stringify({
+          env: { ANTHROPIC_API_KEY: "sk-ant-api03-from-settings" },
+          model: "claude-sonnet-4-6",
+        }),
+      },
+    });
+    const auth = await claudeCodeAdapter.resolveAuth(io);
+    expect(auth.secret).toBe("sk-ant-api03-from-settings");
+    expect(auth.model).toBe("claude-sonnet-4-6");
+    expect(auth.kind).toBe("api_key");
+  });
+
+  it("maps a subscription token to bearer + beta header", async () => {
+    const io = createMemoryIo({
+      home,
+      files: {
+        [credPath]: oauthJson("sk-ant-oat01-from-file"),
+      },
+    });
+    const auth = await claudeCodeAdapter.resolveAuth(io);
+    expect(auth).toMatchObject({
+      kind: "oauth",
+      usableForReview: true,
+      secret: "sk-ant-oat01-from-file",
+      authScheme: "bearer",
+      extraHeaders: { "anthropic-beta": "oauth-2025-04-20" },
+    });
+  });
+
+  it("reads the macOS keychain credential", async () => {
+    const io = createMemoryIo({
+      home,
+      platform: "darwin",
+      binaries: ["claude"],
+      keychain: { "Claude Code-credentials": oauthJson("sk-ant-oat01-from-keychain") },
+    });
+    const auth = await claudeCodeAdapter.resolveAuth(io);
+    expect(auth.secret).toBe("sk-ant-oat01-from-keychain");
+    expect(auth.kind).toBe("oauth");
+  });
+
+  it("rejects an expired subscription login", async () => {
+    const io = createMemoryIo({
+      home,
+      files: {
+        [credPath]: oauthJson("sk-ant-oat01-old", Date.now() - 1000),
+      },
+    });
+    const auth = await claudeCodeAdapter.resolveAuth(io);
+    expect(auth.usableForReview).toBe(false);
+    expect(auth.reason).toMatch(/expired/i);
+  });
+});

--- a/apps/cli/src/codingAgents/claudeCode.ts
+++ b/apps/cli/src/codingAgents/claudeCode.ts
@@ -1,0 +1,162 @@
+import path from "node:path";
+import type { AgentAuth, AgentIo, CodingAgentAdapter, DetectedAgent } from "./types";
+import { unusableAuth } from "./types";
+
+const DISPLAY_NAME = "Claude Code";
+const KEYCHAIN_SERVICE = "Claude Code-credentials";
+
+function claudeHome(io: AgentIo): string {
+  return io.env("CLAUDE_CONFIG_DIR") ?? path.join(io.homedir(), ".claude");
+}
+
+function looksLikeApiKey(secret: string): boolean {
+  return secret.startsWith("sk-ant-api") || secret.startsWith("sk-ant-admin");
+}
+
+function looksLikeOauthToken(secret: string): boolean {
+  return secret.startsWith("sk-ant-oat01") || secret.startsWith("sk-ant-oat");
+}
+
+function apiKeyAuth(secret: string, model?: string): AgentAuth {
+  return {
+    provider: "anthropic",
+    model,
+    secret,
+    kind: "api_key",
+    usableForReview: true,
+  };
+}
+
+/**
+ * Claude Code subscription tokens (`sk-ant-oat01-…`) are not Console API keys.
+ * Anthropic accepts them on the Messages API as Bearer + this beta header.
+ * If that stops working, keep the change in this file.
+ */
+function oauthAuth(secret: string, model?: string): AgentAuth {
+  return {
+    provider: "anthropic",
+    model,
+    secret,
+    kind: "oauth",
+    usableForReview: true,
+    authScheme: "bearer",
+    extraHeaders: { "anthropic-beta": "oauth-2025-04-20" },
+  };
+}
+
+function authFromSecret(secret: string, model?: string, expiresAt?: number): AgentAuth {
+  if (typeof expiresAt === "number" && Number.isFinite(expiresAt) && expiresAt < Date.now()) {
+    return unusableAuth(
+      "anthropic",
+      "Claude Code login expired. Run claude to sign in again, or set ANTHROPIC_API_KEY.",
+      { kind: "oauth", model },
+    );
+  }
+  if (looksLikeApiKey(secret)) return apiKeyAuth(secret, model);
+  if (looksLikeOauthToken(secret)) return oauthAuth(secret, model);
+  if (secret) {
+    // Unknown prefix — still try as a Console key.
+    return apiKeyAuth(secret, model);
+  }
+  return unusableAuth("anthropic", "Claude Code is installed but no API key or login was found.", {
+    model,
+  });
+}
+
+function parseJson(raw: string | null): unknown {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function oauthFromCredentials(value: unknown): { token: string; expiresAt?: number } | null {
+  if (!value || typeof value !== "object") return null;
+  const root = value as Record<string, unknown>;
+  const oauth = root.claudeAiOauth;
+  if (!oauth || typeof oauth !== "object") return null;
+  const rec = oauth as Record<string, unknown>;
+  const token = stringField(rec.accessToken);
+  if (!token) return null;
+  const expiresAt = typeof rec.expiresAt === "number" ? rec.expiresAt : undefined;
+  return { token, expiresAt };
+}
+
+async function readSettingsModel(io: AgentIo): Promise<string | undefined> {
+  const raw = await io.readFile(path.join(claudeHome(io), "settings.json"));
+  const json = parseJson(raw);
+  if (!json || typeof json !== "object") return undefined;
+  const settings = json as Record<string, unknown>;
+  return stringField(settings.model);
+}
+
+async function readSettingsEnvKey(io: AgentIo): Promise<string | undefined> {
+  const raw = await io.readFile(path.join(claudeHome(io), "settings.json"));
+  const json = parseJson(raw);
+  if (!json || typeof json !== "object") return undefined;
+  const env = (json as Record<string, unknown>).env;
+  if (!env || typeof env !== "object") return undefined;
+  return stringField((env as Record<string, unknown>).ANTHROPIC_API_KEY);
+}
+
+async function installed(io: AgentIo): Promise<boolean> {
+  if (await io.which("claude")) return true;
+  if (await io.fileExists(path.join(io.homedir(), ".claude.json"))) return true;
+  const home = claudeHome(io);
+  return (
+    (await io.fileExists(path.join(home, "settings.json"))) ||
+    (await io.fileExists(path.join(home, ".credentials.json")))
+  );
+}
+
+export const claudeCodeAdapter: CodingAgentAdapter = {
+  id: "claude-code",
+  displayName: DISPLAY_NAME,
+  provider: "anthropic",
+
+  async detect(io) {
+    if (!(await installed(io))) return null;
+    const auth = await this.resolveAuth(io);
+    const detected: DetectedAgent = {
+      id: this.id,
+      displayName: this.displayName,
+      provider: this.provider,
+      auth,
+    };
+    return detected;
+  },
+
+  async resolveAuth(io) {
+    const model = await readSettingsModel(io);
+
+    const envKey = io.env("ANTHROPIC_API_KEY");
+    if (envKey?.trim()) return authFromSecret(envKey.trim(), model);
+
+    const settingsKey = await readSettingsEnvKey(io);
+    if (settingsKey) return authFromSecret(settingsKey, model);
+
+    if (io.platform() === "darwin") {
+      const raw = await io.readKeychainPassword(KEYCHAIN_SERVICE);
+      const fromKeychain = oauthFromCredentials(parseJson(raw));
+      if (fromKeychain) return authFromSecret(fromKeychain.token, model, fromKeychain.expiresAt);
+      // Some installs store the token as a bare string.
+      if (raw?.trim()) return authFromSecret(raw.trim(), model);
+    }
+
+    const credRaw = await io.readFile(path.join(claudeHome(io), ".credentials.json"));
+    const fromFile = oauthFromCredentials(parseJson(credRaw));
+    if (fromFile) return authFromSecret(fromFile.token, model, fromFile.expiresAt);
+
+    return unusableAuth(
+      "anthropic",
+      "Claude Code is installed but no API key or login was found.",
+      { model },
+    );
+  },
+};

--- a/apps/cli/src/codingAgents/codex.test.ts
+++ b/apps/cli/src/codingAgents/codex.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { codexAdapter } from "./codex";
+import { createMemoryIo } from "./io";
+
+const home = "/home/test";
+const authPath = `${home}/.codex/auth.json`;
+const configPath = `${home}/.codex/config.toml`;
+
+describe("codexAdapter", () => {
+  it("detects nothing when Codex is absent", async () => {
+    expect(await codexAdapter.detect(createMemoryIo({ home }))).toBeNull();
+  });
+
+  it("uses OPENAI_API_KEY and the configured model", async () => {
+    const io = createMemoryIo({
+      home,
+      binaries: ["codex"],
+      env: { OPENAI_API_KEY: "sk-from-env" },
+      files: { [configPath]: 'model = "gpt-4.1"\n' },
+    });
+    const detected = await codexAdapter.detect(io);
+    expect(detected?.auth).toMatchObject({
+      kind: "api_key",
+      usableForReview: true,
+      secret: "sk-from-env",
+      model: "gpt-4.1",
+    });
+  });
+
+  it("reads OPENAI_API_KEY from auth.json", async () => {
+    const io = createMemoryIo({
+      home,
+      files: {
+        [authPath]: JSON.stringify({ OPENAI_API_KEY: "sk-from-file", auth_mode: "apikey" }),
+      },
+    });
+    const auth = await codexAdapter.resolveAuth(io);
+    expect(auth.usableForReview).toBe(true);
+    expect(auth.secret).toBe("sk-from-file");
+  });
+
+  it("does not send ChatGPT session tokens to the OpenAI API", async () => {
+    const io = createMemoryIo({
+      home,
+      files: {
+        [authPath]: JSON.stringify({
+          auth_mode: "chatgpt",
+          OPENAI_API_KEY: null,
+          tokens: { access_token: "eyJhbGci.chatgpt" },
+        }),
+      },
+    });
+    const auth = await codexAdapter.resolveAuth(io);
+    expect(auth.usableForReview).toBe(false);
+    expect(auth.kind).toBe("oauth");
+    expect(auth.reason).toMatch(/ChatGPT/);
+    expect(auth.secret).toBe("");
+  });
+});

--- a/apps/cli/src/codingAgents/codex.ts
+++ b/apps/cli/src/codingAgents/codex.ts
@@ -1,0 +1,107 @@
+import path from "node:path";
+import type { AgentAuth, AgentIo, CodingAgentAdapter, DetectedAgent } from "./types";
+import { unusableAuth } from "./types";
+
+const DISPLAY_NAME = "Codex";
+const CHATGPT_REASON =
+  "Codex is signed in with ChatGPT, not an OpenAI API key. Guided Review calls api.openai.com, which rejects ChatGPT tokens. Set OPENAI_API_KEY or run `printenv OPENAI_API_KEY | codex login --with-api-key`.";
+
+function codexHome(io: AgentIo): string {
+  return io.env("CODEX_HOME") ?? path.join(io.homedir(), ".codex");
+}
+
+function parseJson(raw: string | null): unknown {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+/** Tiny pull of `model = "..."` — Codex config is TOML, we do not take a parser dep. */
+function modelFromToml(raw: string | null): string | undefined {
+  if (!raw) return undefined;
+  const match = raw.match(/^\s*model\s*=\s*"([^"]+)"/m);
+  return match?.[1];
+}
+
+async function installed(io: AgentIo): Promise<boolean> {
+  if (await io.which("codex")) return true;
+  const home = codexHome(io);
+  return (
+    (await io.fileExists(path.join(home, "auth.json"))) ||
+    (await io.fileExists(path.join(home, "config.toml")))
+  );
+}
+
+/**
+ * ChatGPT OAuth in `tokens.access_token` is a Codex/ChatGPT session, not a
+ * Platform key. Do not send it to api.openai.com. When (if) we learn a host
+ * that accepts it for this product, change only this file.
+ */
+export const codexAdapter: CodingAgentAdapter = {
+  id: "codex",
+  displayName: DISPLAY_NAME,
+  provider: "openai",
+
+  async detect(io) {
+    if (!(await installed(io))) return null;
+    const auth = await this.resolveAuth(io);
+    const detected: DetectedAgent = {
+      id: this.id,
+      displayName: this.displayName,
+      provider: this.provider,
+      auth,
+    };
+    return detected;
+  },
+
+  async resolveAuth(io) {
+    const home = codexHome(io);
+    const model = modelFromToml(await io.readFile(path.join(home, "config.toml")));
+
+    const envKey = io.env("OPENAI_API_KEY");
+    if (envKey?.trim()) {
+      return {
+        provider: "openai",
+        model,
+        secret: envKey.trim(),
+        kind: "api_key",
+        usableForReview: true,
+      } satisfies AgentAuth;
+    }
+
+    const authJson = parseJson(await io.readFile(path.join(home, "auth.json")));
+    if (authJson && typeof authJson === "object") {
+      const rec = authJson as Record<string, unknown>;
+      const storedKey = stringField(rec.OPENAI_API_KEY);
+      if (storedKey) {
+        return {
+          provider: "openai",
+          model,
+          secret: storedKey,
+          kind: "api_key",
+          usableForReview: true,
+        } satisfies AgentAuth;
+      }
+
+      const mode = stringField(rec.auth_mode);
+      const tokens = rec.tokens;
+      const hasChatGptTokens =
+        mode === "chatgpt" ||
+        (tokens !== null && typeof tokens === "object" && "access_token" in (tokens as object));
+      if (hasChatGptTokens) {
+        return unusableAuth("openai", CHATGPT_REASON, { kind: "oauth", model });
+      }
+    }
+
+    return unusableAuth("openai", "Codex is installed but no OpenAI API key was found.", {
+      model,
+    });
+  },
+};

--- a/apps/cli/src/codingAgents/grok.test.ts
+++ b/apps/cli/src/codingAgents/grok.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { grokAdapter } from "./grok";
+import { createMemoryIo } from "./io";
+
+const home = "/home/test";
+const authPath = `${home}/.grok/auth.json`;
+const configPath = `${home}/.grok/config.toml`;
+
+describe("grokAdapter", () => {
+  it("detects nothing when Grok is absent", async () => {
+    expect(await grokAdapter.detect(createMemoryIo({ home }))).toBeNull();
+  });
+
+  it("uses XAI_API_KEY", async () => {
+    const io = createMemoryIo({
+      home,
+      binaries: ["grok"],
+      env: { XAI_API_KEY: "xai-from-env" },
+      files: { [configPath]: '[models]\ndefault = "grok-4"\n' },
+    });
+    const detected = await grokAdapter.detect(io);
+    expect(detected?.auth).toMatchObject({
+      kind: "api_key",
+      usableForReview: true,
+      secret: "xai-from-env",
+      model: "grok-4",
+    });
+  });
+
+  it("prefers an xai- key stored in auth.json", async () => {
+    const io = createMemoryIo({
+      home,
+      files: {
+        [authPath]: JSON.stringify({
+          "https://auth.x.ai::a": { key: "xai-stored", auth_mode: "oidc" },
+        }),
+      },
+    });
+    const auth = await grokAdapter.resolveAuth(io);
+    expect(auth.kind).toBe("api_key");
+    expect(auth.secret).toBe("xai-stored");
+  });
+
+  it("reuses a live OIDC session as a bearer token", async () => {
+    const io = createMemoryIo({
+      home,
+      files: {
+        [authPath]: JSON.stringify({
+          "https://auth.x.ai::a": {
+            key: "eyJ0eXAiOiJhdCtqd3Qi.session",
+            auth_mode: "oidc",
+            expires_at: new Date(Date.now() + 60_000).toISOString(),
+            create_time: new Date().toISOString(),
+          },
+        }),
+      },
+    });
+    const auth = await grokAdapter.resolveAuth(io);
+    expect(auth).toMatchObject({
+      kind: "oauth",
+      usableForReview: true,
+      authScheme: "bearer",
+      secret: "eyJ0eXAiOiJhdCtqd3Qi.session",
+    });
+  });
+
+  it("rejects an expired OIDC session", async () => {
+    const io = createMemoryIo({
+      home,
+      files: {
+        [authPath]: JSON.stringify({
+          "https://auth.x.ai::a": {
+            key: "eyJ0eXAiOiJhdCtqd3Qi.old",
+            auth_mode: "oidc",
+            expires_at: new Date(Date.now() - 1000).toISOString(),
+          },
+        }),
+      },
+    });
+    const auth = await grokAdapter.resolveAuth(io);
+    expect(auth.usableForReview).toBe(false);
+    expect(auth.reason).toMatch(/expired/i);
+  });
+});

--- a/apps/cli/src/codingAgents/grok.ts
+++ b/apps/cli/src/codingAgents/grok.ts
@@ -1,0 +1,148 @@
+import path from "node:path";
+import type { AgentAuth, AgentIo, CodingAgentAdapter, DetectedAgent } from "./types";
+import { unusableAuth } from "./types";
+
+const DISPLAY_NAME = "Grok";
+
+function grokHome(io: AgentIo): string {
+  return path.join(io.homedir(), ".grok");
+}
+
+function parseJson(raw: string | null): unknown {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function isXaiApiKey(secret: string): boolean {
+  return secret.startsWith("xai-");
+}
+
+/** Tiny pull of `[models] default = "..."` — Grok config is TOML, we do not take a parser dep. */
+function defaultModelFromToml(raw: string | null): string | undefined {
+  if (!raw) return undefined;
+  const section = raw.match(/\[models\]([\s\S]*?)(?:\n\[|$)/);
+  const body = section?.[1] ?? raw;
+  const match = body.match(/^\s*default\s*=\s*"([^"]+)"/m);
+  return match?.[1];
+}
+
+interface GrokSession {
+  key: string;
+  expiresAt?: number;
+  createTime?: number;
+}
+
+function sessionsFromAuthJson(value: unknown): GrokSession[] {
+  if (!value || typeof value !== "object") return [];
+  const sessions: GrokSession[] = [];
+  for (const rec of Object.values(value as Record<string, unknown>)) {
+    if (!rec || typeof rec !== "object") continue;
+    const row = rec as Record<string, unknown>;
+    const key = stringField(row.key);
+    if (!key) continue;
+    const expiresAt = stringField(row.expires_at);
+    const createTime = stringField(row.create_time);
+    sessions.push({
+      key,
+      expiresAt: expiresAt ? Date.parse(expiresAt) : undefined,
+      createTime: createTime ? Date.parse(createTime) : undefined,
+    });
+  }
+  return sessions;
+}
+
+async function installed(io: AgentIo): Promise<boolean> {
+  if (await io.which("grok")) return true;
+  const home = grokHome(io);
+  return (
+    (await io.fileExists(path.join(home, "auth.json"))) ||
+    (await io.fileExists(path.join(home, "config.toml")))
+  );
+}
+
+/**
+ * Grok Build stores an OIDC access token in auth.json, not an `xai-` console
+ * key. Our Grok client already sends `Authorization: Bearer`, so a live
+ * session JWT is worth trying. Refresh stays in this file when we add it.
+ */
+export const grokAdapter: CodingAgentAdapter = {
+  id: "grok",
+  displayName: DISPLAY_NAME,
+  provider: "grok",
+
+  async detect(io) {
+    if (!(await installed(io))) return null;
+    const auth = await this.resolveAuth(io);
+    const detected: DetectedAgent = {
+      id: this.id,
+      displayName: this.displayName,
+      provider: this.provider,
+      auth,
+    };
+    return detected;
+  },
+
+  async resolveAuth(io) {
+    const home = grokHome(io);
+    const model = defaultModelFromToml(await io.readFile(path.join(home, "config.toml")));
+
+    const envKey = io.env("XAI_API_KEY") ?? io.env("GROK_API_KEY");
+    if (envKey?.trim()) {
+      return {
+        provider: "grok",
+        model,
+        secret: envKey.trim(),
+        kind: "api_key",
+        usableForReview: true,
+      } satisfies AgentAuth;
+    }
+
+    const sessions = sessionsFromAuthJson(
+      parseJson(await io.readFile(path.join(home, "auth.json"))),
+    );
+    const apiKeySession = sessions.find((s) => isXaiApiKey(s.key));
+    if (apiKeySession) {
+      return {
+        provider: "grok",
+        model,
+        secret: apiKeySession.key,
+        kind: "api_key",
+        usableForReview: true,
+      } satisfies AgentAuth;
+    }
+
+    const now = Date.now();
+    const live = sessions
+      .filter((s) => !s.expiresAt || s.expiresAt > now)
+      .sort((a, b) => (b.createTime ?? 0) - (a.createTime ?? 0));
+    const session = live[0];
+    if (session) {
+      return {
+        provider: "grok",
+        model,
+        secret: session.key,
+        kind: "oauth",
+        usableForReview: true,
+        authScheme: "bearer",
+      } satisfies AgentAuth;
+    }
+
+    if (sessions.length > 0) {
+      return unusableAuth(
+        "grok",
+        "Grok login expired. Run grok to sign in again, or set XAI_API_KEY.",
+        { kind: "oauth", model },
+      );
+    }
+
+    return unusableAuth("grok", "Grok is installed but no API key or login was found.", { model });
+  },
+};

--- a/apps/cli/src/codingAgents/index.ts
+++ b/apps/cli/src/codingAgents/index.ts
@@ -1,0 +1,13 @@
+export { createDefaultAgentIo, createMemoryIo } from "./io";
+export { promptForAgent } from "./prompt";
+export {
+  CODING_AGENTS,
+  adapterFor,
+  detectAll,
+  parseCodingAgentFlag,
+  pickAgent,
+  settingsFromAuth,
+  formatUnusable,
+} from "./registry";
+export { CODING_AGENT_IDS, isCodingAgentId } from "./types";
+export type { AgentAuth, AgentIo, CodingAgentAdapter, CodingAgentId, DetectedAgent } from "./types";

--- a/apps/cli/src/codingAgents/io.ts
+++ b/apps/cli/src/codingAgents/io.ts
@@ -1,0 +1,101 @@
+import { execFile } from "node:child_process";
+import { homedir } from "node:os";
+import path from "node:path";
+import { access, readFile } from "node:fs/promises";
+import { promisify } from "node:util";
+import type { AgentIo } from "./types";
+
+const execFileAsync = promisify(execFile);
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function whichOnPath(
+  command: string,
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): Promise<string | null> {
+  const pathEnv = env.PATH ?? env.Path ?? "";
+  const sep = platform === "win32" ? ";" : ":";
+  const exts = platform === "win32" ? (env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM").split(";") : [""];
+  for (const dir of pathEnv.split(sep)) {
+    if (!dir) continue;
+    for (const ext of exts) {
+      const candidate = path.join(dir, `${command}${ext}`);
+      if (await pathExists(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+export function createDefaultAgentIo(): AgentIo {
+  return {
+    homedir: () => homedir(),
+    env: (name) => process.env[name],
+    platform: () => process.platform,
+    which: (command) => whichOnPath(command),
+    async readFile(filePath) {
+      try {
+        return await readFile(filePath, "utf8");
+      } catch {
+        return null;
+      }
+    },
+    fileExists: pathExists,
+    async readKeychainPassword(service) {
+      if (process.platform !== "darwin") return null;
+      try {
+        const { stdout } = await execFileAsync("security", [
+          "find-generic-password",
+          "-s",
+          service,
+          "-w",
+        ]);
+        const value = stdout.trim();
+        return value || null;
+      } catch {
+        return null;
+      }
+    },
+  };
+}
+
+export function createMemoryIo(options: {
+  home?: string;
+  env?: Record<string, string | undefined>;
+  platform?: NodeJS.Platform;
+  binaries?: string[];
+  files?: Record<string, string>;
+  keychain?: Record<string, string>;
+}): AgentIo {
+  const home = options.home ?? "/home/test";
+  const files = options.files ?? {};
+  const binaries = new Set(options.binaries ?? []);
+  const env = options.env ?? {};
+  const platform = options.platform ?? "linux";
+  const keychain = options.keychain ?? {};
+
+  return {
+    homedir: () => home,
+    env: (name) => env[name],
+    platform: () => platform,
+    async which(command) {
+      return binaries.has(command) ? `/bin/${command}` : null;
+    },
+    async readFile(filePath) {
+      return files[filePath] ?? null;
+    },
+    async fileExists(filePath) {
+      return filePath in files;
+    },
+    async readKeychainPassword(service) {
+      return keychain[service] ?? null;
+    },
+  };
+}

--- a/apps/cli/src/codingAgents/prompt.ts
+++ b/apps/cli/src/codingAgents/prompt.ts
@@ -1,0 +1,55 @@
+import { createInterface } from "node:readline/promises";
+import type { CodingAgentId, DetectedAgent } from "./types";
+
+export async function promptForAgent(
+  agents: DetectedAgent[],
+  options?: {
+    input?: NodeJS.ReadableStream;
+    output?: NodeJS.WritableStream;
+    isTTY?: boolean;
+    /** Pre-selected agent (e.g. last used). Enter accepts it. */
+    preferred?: CodingAgentId;
+  },
+): Promise<CodingAgentId | null> {
+  const isTTY = options?.isTTY ?? Boolean(process.stdin.isTTY);
+  if (!isTTY || agents.length === 0) return null;
+  if (agents.length === 1) return agents[0]!.id;
+
+  const output = options?.output ?? process.stderr;
+  const input = options?.input ?? process.stdin;
+  const preferredIndex = options?.preferred
+    ? agents.findIndex((agent) => agent.id === options.preferred)
+    : -1;
+  const hasPreferred = preferredIndex >= 0;
+
+  output.write("Which coding agent should Guided Review use to generate the review?\n\n");
+  agents.forEach((agent, index) => {
+    const mark = hasPreferred && index === preferredIndex ? "  (last used)" : "";
+    output.write(`  ${index + 1}. ${agent.displayName}${mark}\n`);
+  });
+  output.write("\n");
+
+  const question = hasPreferred
+    ? `Enter a number (default ${preferredIndex + 1}), or press Enter to keep last used: `
+    : "Enter a number (or press Enter to skip): ";
+
+  const rl = createInterface({ input, output, terminal: Boolean(isTTY) });
+  try {
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const answer = (await rl.question(question)).trim();
+      if (!answer) return hasPreferred ? agents[preferredIndex]!.id : null;
+      const n = Number(answer);
+      if (Number.isInteger(n) && n >= 1 && n <= agents.length) {
+        return agents[n - 1]!.id;
+      }
+      output.write(
+        hasPreferred
+          ? `Choose 1–${agents.length}, or press Enter for ${agents[preferredIndex]!.displayName}.\n`
+          : `Choose 1–${agents.length}, or press Enter to skip.\n`,
+      );
+    }
+  } finally {
+    rl.close();
+  }
+  return null;
+}

--- a/apps/cli/src/codingAgents/registry.test.ts
+++ b/apps/cli/src/codingAgents/registry.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import { createMemoryIo } from "./io";
+import {
+  detectAll,
+  formatUnusable,
+  parseCodingAgentFlag,
+  pickAgent,
+  settingsFromAuth,
+} from "./registry";
+import type { DetectedAgent } from "./types";
+
+const home = "/home/test";
+
+function agent(
+  id: DetectedAgent["id"],
+  usable: boolean,
+  extras?: Partial<DetectedAgent["auth"]>,
+): DetectedAgent {
+  return {
+    id,
+    displayName: id,
+    provider: id === "claude-code" ? "anthropic" : id === "codex" ? "openai" : "grok",
+    auth: {
+      provider: id === "claude-code" ? "anthropic" : id === "codex" ? "openai" : "grok",
+      secret: usable ? "secret" : "",
+      kind: "api_key",
+      usableForReview: usable,
+      reason: usable ? undefined : `${id} has no key`,
+      ...extras,
+    },
+  };
+}
+
+describe("detectAll", () => {
+  it("returns no agents on an empty machine", async () => {
+    expect(await detectAll(createMemoryIo({ home }))).toEqual([]);
+  });
+
+  it("detects every agent that is present", async () => {
+    const io = createMemoryIo({
+      home,
+      binaries: ["claude", "codex", "grok"],
+      env: { ANTHROPIC_API_KEY: "sk-ant-api03-x", OPENAI_API_KEY: "sk-x", XAI_API_KEY: "xai-x" },
+    });
+    const found = await detectAll(io);
+    expect(found.map((a) => a.id)).toEqual(["claude-code", "codex", "grok"]);
+    expect(found.every((a) => a.auth.usableForReview)).toBe(true);
+  });
+});
+
+describe("pickAgent", () => {
+  it("still prompts when a saved preference exists among several agents", async () => {
+    const chosen = await pickAgent({
+      detected: [agent("claude-code", true), agent("grok", true)],
+      preferred: "grok",
+      isTTY: true,
+      prompt: async (agents) => {
+        expect(agents.map((a) => a.id)).toEqual(["claude-code", "grok"]);
+        return "claude-code";
+      },
+    });
+    expect(chosen?.id).toBe("claude-code");
+  });
+
+  it("returns the only usable agent without prompting", async () => {
+    const chosen = await pickAgent({
+      detected: [agent("claude-code", true), agent("codex", false)],
+      isTTY: true,
+      prompt: async () => {
+        throw new Error("should not prompt");
+      },
+    });
+    expect(chosen?.id).toBe("claude-code");
+  });
+
+  it("prompts when several agents are usable", async () => {
+    const chosen = await pickAgent({
+      detected: [agent("claude-code", true), agent("grok", true)],
+      isTTY: true,
+      prompt: async (agents) => {
+        expect(agents.map((a) => a.id)).toEqual(["claude-code", "grok"]);
+        return "grok";
+      },
+    });
+    expect(chosen?.id).toBe("grok");
+  });
+
+  it("does not hang when several agents are usable off a TTY", async () => {
+    const logs: string[] = [];
+    const chosen = await pickAgent({
+      detected: [agent("claude-code", true), agent("grok", true)],
+      isTTY: false,
+      log: (message) => logs.push(message),
+      prompt: async () => {
+        throw new Error("should not prompt");
+      },
+    });
+    expect(chosen).toBeNull();
+    expect(logs.join("\n")).toMatch(/--agent/);
+  });
+
+  it("honors --agent and errors when that agent is missing", async () => {
+    await expect(
+      pickAgent({ detected: [agent("grok", true)], requested: "codex" }),
+    ).rejects.toThrow(/Codex is not installed/);
+  });
+
+  it("explains when agents are present but none are usable", async () => {
+    const logs: string[] = [];
+    const chosen = await pickAgent({
+      detected: [agent("codex", false)],
+      log: (message) => logs.push(message),
+    });
+    expect(chosen).toBeNull();
+    expect(logs.join("\n")).toMatch(/none have a key/);
+  });
+});
+
+describe("parseCodingAgentFlag / settingsFromAuth", () => {
+  it("rejects an unknown --agent", () => {
+    expect(() => parseCodingAgentFlag("cursor")).toThrow(/Unknown --agent/);
+    expect(parseCodingAgentFlag(undefined)).toBeUndefined();
+    expect(parseCodingAgentFlag("claude-code")).toBe("claude-code");
+  });
+
+  it("copies adapter auth onto ProviderSettings", () => {
+    const settings = settingsFromAuth({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      secret: "sk-ant-oat01-x",
+      kind: "oauth",
+      usableForReview: true,
+      authScheme: "bearer",
+      extraHeaders: { "anthropic-beta": "oauth-2025-04-20" },
+    });
+    expect(settings).toMatchObject({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      apiKey: "sk-ant-oat01-x",
+      authScheme: "bearer",
+      extraHeaders: { "anthropic-beta": "oauth-2025-04-20" },
+    });
+  });
+
+  it("keeps an agent model that is not in the catalog", () => {
+    const settings = settingsFromAuth({
+      provider: "grok",
+      model: "grok-build",
+      secret: "xai-x",
+      kind: "api_key",
+      usableForReview: true,
+    });
+    expect(settings.model).toBe("grok-build");
+  });
+
+  it("lists unusable agents", () => {
+    expect(formatUnusable([agent("codex", false)])).toMatch(/Found codex/);
+  });
+});

--- a/apps/cli/src/codingAgents/registry.ts
+++ b/apps/cli/src/codingAgents/registry.ts
@@ -1,0 +1,116 @@
+import type { ProviderSettings } from "@guided-review/core";
+import { normalizeProviderSettings } from "@guided-review/core";
+import { claudeCodeAdapter } from "./claudeCode";
+import { codexAdapter } from "./codex";
+import { grokAdapter } from "./grok";
+import { promptForAgent } from "./prompt";
+import type { AgentIo, CodingAgentAdapter, CodingAgentId, DetectedAgent } from "./types";
+import { isCodingAgentId } from "./types";
+
+export const CODING_AGENTS: readonly CodingAgentAdapter[] = [
+  claudeCodeAdapter,
+  codexAdapter,
+  grokAdapter,
+];
+
+export function adapterFor(id: CodingAgentId): CodingAgentAdapter {
+  const found = CODING_AGENTS.find((agent) => agent.id === id);
+  if (!found) throw new Error(`Unknown coding agent ${id}.`);
+  return found;
+}
+
+export async function detectAll(io: AgentIo): Promise<DetectedAgent[]> {
+  const found: DetectedAgent[] = [];
+  for (const agent of CODING_AGENTS) {
+    const detected = await agent.detect(io);
+    if (detected) found.push(detected);
+  }
+  return found;
+}
+
+export function parseCodingAgentFlag(value: string | undefined): CodingAgentId | undefined {
+  if (value === undefined) return undefined;
+  if (isCodingAgentId(value)) return value;
+  throw new Error(`Unknown --agent ${value}. Use claude-code, codex, or grok.`);
+}
+
+export function settingsFromAuth(
+  auth: DetectedAgent["auth"],
+  modelOverride?: string,
+): ProviderSettings {
+  const requested = modelOverride ?? auth.model;
+  const normalized = normalizeProviderSettings({
+    provider: auth.provider,
+    model: requested,
+    apiKey: auth.secret,
+  });
+  return {
+    ...normalized,
+    // Keep the agent's configured model even if it is not in our catalog yet.
+    model: modelOverride || !auth.model ? normalized.model : auth.model,
+    ...(auth.authScheme ? { authScheme: auth.authScheme } : {}),
+    ...(auth.extraHeaders ? { extraHeaders: auth.extraHeaders } : {}),
+  };
+}
+
+export function formatUnusable(detected: DetectedAgent[]): string {
+  const names = detected.map((agent) => agent.displayName);
+  const list =
+    names.length === 1
+      ? names[0]
+      : names.length === 2
+        ? `${names[0]} and ${names[1]}`
+        : `${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]}`;
+  const reasons = detected
+    .filter((agent) => agent.auth.reason)
+    .map((agent) => `${agent.displayName}: ${agent.auth.reason}`)
+    .join("\n");
+  const header = `Found ${list}, but none have a key Guided Review can use yet.`;
+  return reasons ? `${header}\n${reasons}` : header;
+}
+
+export async function pickAgent(options: {
+  detected: DetectedAgent[];
+  preferred?: CodingAgentId;
+  requested?: CodingAgentId;
+  isTTY?: boolean;
+  prompt?: (agents: DetectedAgent[]) => Promise<CodingAgentId | null>;
+  log?: (message: string) => void;
+}): Promise<DetectedAgent | null> {
+  const log = options.log ?? ((message) => process.stderr.write(`${message}\n`));
+  const usable = options.detected.filter((agent) => agent.auth.usableForReview);
+
+  if (options.requested) {
+    const found = options.detected.find((agent) => agent.id === options.requested);
+    if (!found) {
+      const name = adapterFor(options.requested).displayName;
+      throw new Error(`${name} is not installed.`);
+    }
+    if (!found.auth.usableForReview) {
+      throw new Error(found.auth.reason ?? `${found.displayName} has no usable key.`);
+    }
+    return found;
+  }
+
+  if (usable.length === 0) {
+    if (options.detected.length > 0) log(formatUnusable(options.detected));
+    return null;
+  }
+
+  if (usable.length === 1) return usable[0]!;
+
+  const isTTY = options.isTTY ?? Boolean(process.stdin.isTTY);
+  if (!isTTY) {
+    log("Multiple coding agents found. Pass --agent claude-code, --agent codex, or --agent grok.");
+    return null;
+  }
+
+  const preferred =
+    options.preferred && usable.some((agent) => agent.id === options.preferred)
+      ? options.preferred
+      : undefined;
+
+  const prompt = options.prompt ?? ((agents) => promptForAgent(agents, { preferred }));
+  const chosen = await prompt(usable);
+  return usable.find((agent) => agent.id === chosen) ?? null;
+}

--- a/apps/cli/src/codingAgents/types.ts
+++ b/apps/cli/src/codingAgents/types.ts
@@ -1,0 +1,61 @@
+import type { ProviderId } from "@guided-review/core";
+
+export const CODING_AGENT_IDS = ["claude-code", "codex", "grok"] as const;
+
+export type CodingAgentId = (typeof CODING_AGENT_IDS)[number];
+
+export function isCodingAgentId(value: string | undefined): value is CodingAgentId {
+  return CODING_AGENT_IDS.includes(value as CodingAgentId);
+}
+
+export interface AgentAuth {
+  provider: ProviderId;
+  model?: string;
+  secret: string;
+  kind: "api_key" | "oauth";
+  /** Adapter decides whether this credential can be sent to our provider client. */
+  usableForReview: boolean;
+  reason?: string;
+  extraHeaders?: Record<string, string>;
+  authScheme?: "api-key" | "bearer";
+}
+
+export interface DetectedAgent {
+  id: CodingAgentId;
+  displayName: string;
+  provider: ProviderId;
+  auth: AgentAuth;
+}
+
+export interface CodingAgentAdapter {
+  id: CodingAgentId;
+  displayName: string;
+  provider: ProviderId;
+  detect(io: AgentIo): Promise<DetectedAgent | null>;
+  resolveAuth(io: AgentIo): Promise<AgentAuth>;
+}
+
+export interface AgentIo {
+  homedir(): string;
+  env(name: string): string | undefined;
+  platform(): NodeJS.Platform;
+  which(command: string): Promise<string | null>;
+  readFile(path: string): Promise<string | null>;
+  fileExists(path: string): Promise<boolean>;
+  readKeychainPassword(service: string): Promise<string | null>;
+}
+
+export function unusableAuth(
+  provider: ProviderId,
+  reason: string,
+  extras?: Partial<Omit<AgentAuth, "provider" | "usableForReview" | "reason">>,
+): AgentAuth {
+  return {
+    secret: "",
+    kind: extras?.kind ?? "api_key",
+    ...extras,
+    provider,
+    usableForReview: false,
+    reason,
+  };
+}

--- a/apps/cli/src/config.test.ts
+++ b/apps/cli/src/config.test.ts
@@ -1,0 +1,124 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveSettings, writeConfigFile } from "./config";
+import { createMemoryIo } from "./codingAgents";
+
+const ENV_KEYS = [
+  "GUIDED_REVIEW_CONFIG_DIR",
+  "GUIDED_REVIEW_PROVIDER",
+  "GUIDED_REVIEW_MODEL",
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "XAI_API_KEY",
+  "GROK_API_KEY",
+] as const;
+
+const prevEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = prevEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+async function withTempConfig(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "guided-review-"));
+  process.env.GUIDED_REVIEW_CONFIG_DIR = dir;
+  delete process.env.GUIDED_REVIEW_PROVIDER;
+  delete process.env.GUIDED_REVIEW_MODEL;
+  delete process.env.ANTHROPIC_API_KEY;
+  delete process.env.OPENAI_API_KEY;
+  delete process.env.XAI_API_KEY;
+  delete process.env.GROK_API_KEY;
+  return dir;
+}
+
+describe("resolveSettings", () => {
+  it("skips agent detection when config already has a key", async () => {
+    const dir = await withTempConfig();
+    await writeConfigFile({
+      provider: "openai",
+      model: "gpt-4.1",
+      apiKey: "sk-saved",
+    });
+    const io = createMemoryIo({
+      home: "/home/test",
+      binaries: ["claude"],
+      env: { ANTHROPIC_API_KEY: "sk-ant-api03-should-not-win" },
+    });
+    const resolved = await resolveSettings({
+      io,
+      persist: false,
+      pickAgent: async () => {
+        throw new Error("should not pick");
+      },
+    });
+    expect(resolved.settings.apiKey).toBe("sk-saved");
+    expect(resolved.settings.provider).toBe("openai");
+    expect(resolved.codingAgent).toBeNull();
+    expect(dir).toBeTruthy();
+  });
+
+  it("uses a single usable coding agent and persists the preference, not the secret", async () => {
+    const dir = await withTempConfig();
+    const io = createMemoryIo({
+      home: "/home/test",
+      binaries: ["claude"],
+      files: {
+        "/home/test/.claude/.credentials.json": JSON.stringify({
+          claudeAiOauth: { accessToken: "sk-ant-oat01-live", expiresAt: Date.now() + 60_000 },
+        }),
+      },
+    });
+    const logs: string[] = [];
+    const resolved = await resolveSettings({
+      io,
+      persist: true,
+      isTTY: false,
+      log: (message) => logs.push(message),
+    });
+    expect(resolved.codingAgent).toBe("claude-code");
+    expect(resolved.settings.apiKey).toBe("sk-ant-oat01-live");
+    expect(resolved.settings.authScheme).toBe("bearer");
+    expect(logs.join("\n")).toMatch(/Claude Code/);
+
+    const saved = JSON.parse(await readFile(path.join(dir, "config.json"), "utf8")) as {
+      codingAgent?: string;
+      apiKey?: string;
+    };
+    expect(saved.codingAgent).toBe("claude-code");
+    expect(saved.apiKey).toBeUndefined();
+  });
+
+  it("does not pick among multiple agents off a TTY", async () => {
+    await withTempConfig();
+    const io = createMemoryIo({
+      home: "/home/test",
+      binaries: ["claude", "grok"],
+      env: { ANTHROPIC_API_KEY: undefined, XAI_API_KEY: undefined },
+      files: {
+        "/home/test/.claude/.credentials.json": JSON.stringify({
+          claudeAiOauth: { accessToken: "sk-ant-oat01-live", expiresAt: Date.now() + 60_000 },
+        }),
+        "/home/test/.grok/auth.json": JSON.stringify({
+          "https://auth.x.ai::a": {
+            key: "eyJ0eXAiOiJhdCtqd3Qi.session",
+            expires_at: new Date(Date.now() + 60_000).toISOString(),
+          },
+        }),
+      },
+    });
+    const resolved = await resolveSettings({
+      io,
+      persist: false,
+      isTTY: false,
+      log: () => undefined,
+    });
+    expect(resolved.codingAgent).toBeNull();
+    expect(resolved.settings.apiKey).toBe("");
+  });
+});

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -7,11 +7,27 @@ import {
   type ProviderId,
   type ProviderSettings,
 } from "@guided-review/core";
+import {
+  createDefaultAgentIo,
+  detectAll,
+  parseCodingAgentFlag,
+  pickAgent,
+  settingsFromAuth,
+  type AgentIo,
+  type CodingAgentId,
+  type DetectedAgent,
+} from "./codingAgents";
 
 export interface CliConfigFile {
   provider?: ProviderId;
   model?: string;
   apiKey?: string;
+  codingAgent?: CodingAgentId;
+}
+
+export interface ResolvedCliSettings {
+  settings: ProviderSettings;
+  codingAgent: CodingAgentId | null;
 }
 
 export function configDir(): string {
@@ -50,10 +66,21 @@ export async function writeConfigFile(next: CliConfigFile): Promise<void> {
   await writeFile(configPath(), `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
 }
 
+export async function patchConfigFile(partial: Partial<CliConfigFile>): Promise<void> {
+  const current = await readConfigFile();
+  await writeConfigFile({ ...current, ...partial });
+}
+
 export async function resolveSettings(flags: {
   provider?: string;
   model?: string;
-}): Promise<ProviderSettings> {
+  agent?: string;
+  io?: AgentIo;
+  pickAgent?: (agents: DetectedAgent[]) => Promise<CodingAgentId | null>;
+  persist?: boolean;
+  isTTY?: boolean;
+  log?: (message: string) => void;
+}): Promise<ResolvedCliSettings> {
   const file = await readConfigFile();
   const envProvider = process.env.GUIDED_REVIEW_PROVIDER;
   const provider = flags.provider ?? envProvider ?? file.provider ?? "anthropic";
@@ -64,19 +91,61 @@ export async function resolveSettings(flags: {
     apiKey: file.apiKey ?? "",
   });
   const envKey = envKeyFor(normalized.provider);
-  return {
+  const settings: ProviderSettings = {
     ...normalized,
     apiKey:
       flags.provider || flags.model ? (envKey ?? normalized.apiKey) : (envKey ?? file.apiKey ?? ""),
     model: flags.model ?? normalized.model ?? defaultModelFor(normalized.provider),
   };
+
+  if (settings.apiKey) {
+    return { settings, codingAgent: null };
+  }
+
+  const requested = parseCodingAgentFlag(flags.agent);
+  const io = flags.io ?? createDefaultAgentIo();
+  const persist = flags.persist ?? true;
+  const log = flags.log ?? ((message) => process.stderr.write(`${message}\n`));
+
+  let detected = await detectAll(io);
+  if ((flags.provider || envProvider) && !requested) {
+    detected = detected.filter((agent) => agent.provider === settings.provider);
+  }
+
+  const chosen = await pickAgent({
+    detected,
+    preferred: file.codingAgent,
+    requested,
+    isTTY: flags.isTTY,
+    prompt: flags.pickAgent,
+    log,
+  });
+
+  if (!chosen) {
+    return { settings, codingAgent: null };
+  }
+
+  const fromAgent = settingsFromAuth(chosen.auth, flags.model ?? process.env.GUIDED_REVIEW_MODEL);
+  if (persist) {
+    await patchConfigFile({
+      provider: fromAgent.provider,
+      model: fromAgent.model,
+      codingAgent: chosen.id,
+    });
+  }
+  log(`Using ${chosen.displayName} for summaries.`);
+  return { settings: fromAgent, codingAgent: chosen.id };
 }
 
-export function publicSettings(settings: ProviderSettings): {
+export function publicSettings(
+  settings: ProviderSettings,
+  codingAgent?: CodingAgentId | null,
+): {
   provider: ProviderId;
   model: string;
   hasKey: boolean;
   last4: string | null;
+  codingAgent: CodingAgentId | null;
 } {
   const key = settings.apiKey;
   return {
@@ -84,5 +153,6 @@ export function publicSettings(settings: ProviderSettings): {
     model: settings.model,
     hasKey: Boolean(key),
     last4: key ? key.slice(-4) : null,
+    codingAgent: codingAgent ?? null,
   };
 }

--- a/apps/cli/src/server/createServer.test.ts
+++ b/apps/cli/src/server/createServer.test.ts
@@ -1,44 +1,107 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import net from "node:net";
 import { describe, expect, it } from "vitest";
-import type { ParsedDiff, ReviewContext } from "@guided-review/core";
-import { createReviewServer, listen } from "./createServer";
+import type { ParsedDiff } from "@guided-review/core";
+import { buildLocalReview, type LocalReviewSnapshot } from "../git/localDiff";
+import {
+  createReviewServer,
+  createServerShutdown,
+  listen,
+  type ReviewSessionPayload,
+} from "./createServer";
 
-const context: ReviewContext = {
-  source: "local",
-  title: "feat",
-  description: "work",
-  baseRef: "main",
-  headRef: "feat",
-};
+const execFileAsync = promisify(execFile);
 
-const diff: ParsedDiff = {
-  files: [
+const snapshot: LocalReviewSnapshot = {
+  repo: {
+    repoRoot: "/tmp/repo",
+    baseRef: "main",
+    headRef: "feat",
+    mergeBase: "abc",
+    includeUntracked: true,
+    staged: false,
+  },
+  commits: [
     {
-      path: "src/a.ts",
-      status: "modified",
-      isBinaryOrElided: false,
-      hunks: [
-        {
-          id: "src/a.ts#0",
-          header: "@@ -1 +1 @@",
-          oldStart: 1,
-          oldLines: 1,
-          newStart: 1,
-          newLines: 1,
-          lines: [{ type: "add", content: "x", newLine: 1 }],
-        },
-      ],
+      sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      shortSha: "aaaaaaa",
+      subject: "Add feat",
+      body: "",
+      author: "Test",
+      authoredAt: "2026-01-02T00:00:00Z",
     },
   ],
+  scopes: [
+    {
+      id: "branch",
+      label: "feat vs main",
+      description: "Committed work",
+      meta: "1 commit · 1 file · +1 −0",
+      stat: { files: 1, additions: 1, deletions: 0 },
+      empty: false,
+    },
+    {
+      id: "uncommitted",
+      label: "Uncommitted changes",
+      description: "Dirty tree",
+      meta: "No changes",
+      stat: { files: 0, additions: 0, deletions: 0 },
+      empty: true,
+    },
+    {
+      id: "unstaged",
+      label: "Unstaged changes",
+      description: "Unstaged only",
+      meta: "No changes",
+      stat: { files: 0, additions: 0, deletions: 0 },
+      empty: true,
+    },
+  ],
+  selectedScope: "branch",
+  context: {
+    source: "local",
+    title: "feat",
+    description: "Add feat (aaaaaaa)",
+    baseRef: "main",
+    headRef: "feat",
+  },
+  diff: {
+    files: [
+      {
+        path: "src/a.ts",
+        status: "modified",
+        isBinaryOrElided: false,
+        hunks: [
+          {
+            id: "src/a.ts#0",
+            header: "@@ -1 +1 @@",
+            oldStart: 1,
+            oldLines: 1,
+            newStart: 1,
+            newLines: 1,
+            lines: [{ type: "add", content: "x", newLine: 1 }],
+          },
+        ],
+      },
+    ],
+  },
+  raw: "",
+  sessionKey: "repo:main:feat:branch:abc",
+  empty: false,
 };
 
 describe("createReviewServer", () => {
   it("serves the session only with the token and streams no_api_key without a key", async () => {
+    const logs: string[] = [];
     const server = createReviewServer({
-      context,
-      diff,
-      sessionKey: "repo:main:feat:abc",
+      snapshot,
       settings: { provider: "anthropic", model: "claude-opus-4-8", apiKey: "" },
       token: "secret",
+      log: (message) => logs.push(message),
     });
     const port = await listen(server);
     const base = `http://127.0.0.1:${port}`;
@@ -47,17 +110,122 @@ describe("createReviewServer", () => {
     expect(denied.status).toBe(401);
 
     const session = await fetch(`${base}/api/session?token=secret`).then(
-      (r) => r.json() as Promise<{ diff: ParsedDiff; settings: { hasKey: boolean } }>,
+      (r) => r.json() as Promise<ReviewSessionPayload>,
     );
     expect(session.diff.files).toHaveLength(1);
     expect(session.settings.hasKey).toBe(false);
+    expect(session.selectedScope).toBe("branch");
+    expect(session.commits).toHaveLength(1);
+    expect(session.scopes).toHaveLength(3);
 
     const planRes = await fetch(`${base}/api/plan?token=secret`);
     const body = await planRes.text();
+    expect(body.startsWith(":")).toBe(true);
     expect(body).toContain("no_api_key");
+    expect(logs.some((line) => line.includes("401 unauthorized"))).toBe(true);
+    expect(logs.some((line) => line.includes("GET /api/session"))).toBe(true);
+    expect(logs.some((line) => line.includes("no API key"))).toBe(true);
 
     await new Promise<void>((resolve, reject) =>
       server.close((err) => (err ? reject(err) : resolve())),
     );
+  });
+
+  it("rejects an unknown scope and swaps the session on a real repo", async () => {
+    const root = await mkdir(path.join(os.tmpdir(), `gr-srv-${Date.now()}`), { recursive: true });
+    const cwd = root!;
+    const git = (args: string[]) => execFileAsync("git", args, { cwd });
+    await git(["init", "-b", "main"]);
+    await git(["config", "user.email", "test@example.com"]);
+    await git(["config", "user.name", "Test"]);
+    await writeFile(path.join(cwd, "readme.md"), "hello\n");
+    await git(["add", "readme.md"]);
+    await git(["commit", "-m", "initial"]);
+    await git(["checkout", "-b", "feat"]);
+    await writeFile(path.join(cwd, "feat.ts"), "export const n = 1;\n");
+    await git(["add", "feat.ts"]);
+    await git(["commit", "-m", "add feat"]);
+    await writeFile(path.join(cwd, "dirty.ts"), "export const d = 1;\n");
+
+    const live = await buildLocalReview({ cwd });
+    const server = createReviewServer({
+      snapshot: live,
+      settings: { provider: "anthropic", model: "claude-opus-4-8", apiKey: "" },
+      token: "secret",
+    });
+    const port = await listen(server);
+    const base = `http://127.0.0.1:${port}`;
+
+    const unknown = await fetch(`${base}/api/diff?token=secret`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ scope: "nope" }),
+    });
+    expect(unknown.status).toBe(400);
+
+    const switched = await fetch(`${base}/api/diff?token=secret`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ scope: "uncommitted" }),
+    }).then((r) => r.json() as Promise<ReviewSessionPayload>);
+    expect(switched.selectedScope).toBe("uncommitted");
+    expect(switched.diff.files.map((file) => file.path)).toContain("dirty.ts");
+    expect(switched.diff.files.map((file) => file.path)).not.toContain("feat.ts");
+
+    const session = await fetch(`${base}/api/session?token=secret`).then(
+      (r) => r.json() as Promise<{ selectedScope: string; diff: ParsedDiff }>,
+    );
+    expect(session.selectedScope).toBe("uncommitted");
+    expect(session.diff.files.map((file) => file.path)).toContain("dirty.ts");
+
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve())),
+    );
+  });
+
+  it("shuts down once under repeated signals without stacking close listeners", async () => {
+    const server = createReviewServer({
+      snapshot,
+      settings: { provider: "anthropic", model: "claude-opus-4-8", apiKey: "" },
+      token: "secret",
+    });
+    const port = await listen(server);
+
+    // Hold an open socket so close would otherwise hang (same class of problem as SSE).
+    const held = await new Promise<net.Socket>((resolve, reject) => {
+      const socket = net.connect(port, "127.0.0.1", () => resolve(socket));
+      socket.on("error", reject);
+    });
+
+    let closeCalls = 0;
+    const realClose = server.close.bind(server);
+    server.close = ((cb?: (err?: Error) => void) => {
+      closeCalls += 1;
+      return realClose(cb);
+    }) as typeof server.close;
+
+    const exits: number[] = [];
+    const shutdown = createServerShutdown(server, (code) => {
+      exits.push(code);
+    });
+
+    shutdown();
+    shutdown();
+    shutdown();
+
+    expect(closeCalls).toBe(1);
+    expect(server.listenerCount("close")).toBeLessThanOrEqual(1);
+    // Second and third signals force-exit instead of stacking more close listeners.
+    expect(exits.filter((code) => code === 1)).toHaveLength(2);
+
+    held.destroy();
+    await new Promise<void>((resolve) => {
+      if (!server.listening) {
+        resolve();
+        return;
+      }
+      realClose(() => resolve());
+      server.closeAllConnections();
+    });
   });
 });

--- a/apps/cli/src/server/createServer.ts
+++ b/apps/cli/src/server/createServer.ts
@@ -9,27 +9,69 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   annotateReview,
-  type ParsedDiff,
+  type AnnotateReviewStreamEvent,
   type ProviderSettings,
-  type ReviewContext,
 } from "@guided-review/core";
-import { publicSettings, writeConfigFile } from "../config";
+import { publicSettings, patchConfigFile } from "../config";
+import type { CodingAgentId } from "../codingAgents";
+import {
+  isDiffScopeId,
+  rebuildLocalReview,
+  type DiffScopeId,
+  type DiffScopeOption,
+  type LocalCommit,
+  type LocalReviewSnapshot,
+} from "../git/localDiff";
+import { GitError } from "../git/run";
+
+export type ServerLog = (message: string) => void;
+
+function defaultLog(message: string): void {
+  process.stderr.write(`${new Date().toISOString().slice(11, 23)}  ${message}\n`);
+}
+
+function formatThrown(error: unknown): string {
+  if (error instanceof Error) return error.stack ?? error.message;
+  return String(error);
+}
+
+function describePlanEvent(event: AnnotateReviewStreamEvent): string | null {
+  switch (event.type) {
+    case "STATUS":
+      return `plan  ${event.phase}`;
+    case "UNIT":
+      return `plan  unit ${event.unit.id} (${event.unit.files.length} file(s))`;
+    case "DONE":
+      return `plan  done ${event.plan.units.length} unit(s)`;
+    case "ERROR": {
+      const parts = [
+        event.error.statusCode !== undefined ? String(event.error.statusCode) : null,
+        event.error.code,
+        event.error.message,
+      ].filter((part): part is string => Boolean(part));
+      return `plan  error ${parts.join(" ")}`;
+    }
+  }
+}
 
 export interface ReviewSessionPayload {
-  context: ReviewContext;
-  diff: ParsedDiff;
+  context: LocalReviewSnapshot["context"];
+  diff: LocalReviewSnapshot["diff"];
   sessionKey: string;
   settings: ReturnType<typeof publicSettings>;
+  commits: LocalCommit[];
+  scopes: DiffScopeOption[];
+  selectedScope: DiffScopeId;
 }
 
 export interface CreateReviewServerOptions {
-  context: ReviewContext;
-  diff: ParsedDiff;
-  sessionKey: string;
+  snapshot: LocalReviewSnapshot;
   settings: ProviderSettings;
+  codingAgent?: CodingAgentId | null;
   token: string;
   staticDir?: string;
   onSettings?: (settings: ProviderSettings) => void;
+  log?: ServerLog;
 }
 
 function sendJson(res: ServerResponse, status: number, body: unknown): void {
@@ -60,8 +102,26 @@ function contentTypeFor(filePath: string): string {
   return "application/octet-stream";
 }
 
+function sessionPayload(
+  snapshot: LocalReviewSnapshot,
+  settings: ReturnType<typeof publicSettings>,
+): ReviewSessionPayload {
+  return {
+    context: snapshot.context,
+    diff: snapshot.diff,
+    sessionKey: snapshot.sessionKey,
+    settings,
+    commits: snapshot.commits,
+    scopes: snapshot.scopes,
+    selectedScope: snapshot.selectedScope,
+  };
+}
+
 export function createReviewServer(options: CreateReviewServerOptions) {
   let settings = options.settings;
+  let codingAgent = options.codingAgent ?? null;
+  let snapshot = options.snapshot;
+  const log = options.log ?? defaultLog;
 
   function authorized(req: IncomingMessage, url: URL): boolean {
     const header = req.headers.authorization;
@@ -75,40 +135,70 @@ export function createReviewServer(options: CreateReviewServerOptions) {
       const url = new URL(req.url ?? "/", `http://${host}`);
 
       if (url.pathname.startsWith("/api/") && !authorized(req, url)) {
+        log(`${req.method} ${url.pathname}  401 unauthorized`);
         sendJson(res, 401, { error: "Unauthorized. Open the URL printed by the CLI." });
         return;
       }
 
       if (req.method === "GET" && url.pathname === "/api/session") {
-        const payload: ReviewSessionPayload = {
-          context: options.context,
-          diff: options.diff,
-          sessionKey: options.sessionKey,
-          settings: publicSettings(settings),
-        };
-        sendJson(res, 200, payload);
+        const published = publicSettings(settings, codingAgent);
+        log(
+          `GET /api/session  ${snapshot.diff.files.length} file(s)  ${snapshot.selectedScope}  ${published.provider}/${published.model}  key=${published.hasKey ? "yes" : "no"}${published.codingAgent ? `  agent=${published.codingAgent}` : ""}`,
+        );
+        sendJson(res, 200, sessionPayload(snapshot, published));
         return;
       }
 
       if (req.method === "GET" && url.pathname === "/api/settings") {
-        sendJson(res, 200, publicSettings(settings));
+        sendJson(res, 200, publicSettings(settings, codingAgent));
         return;
       }
 
       if (req.method === "PUT" && url.pathname === "/api/settings") {
         const body = JSON.parse(await readBody(req)) as Partial<ProviderSettings>;
+        const nextKey =
+          body.apiKey !== undefined && body.apiKey !== "" ? body.apiKey : settings.apiKey;
         settings = {
           provider: body.provider ?? settings.provider,
           model: body.model ?? settings.model,
-          apiKey: body.apiKey !== undefined && body.apiKey !== "" ? body.apiKey : settings.apiKey,
+          apiKey: nextKey,
         };
-        await writeConfigFile({
+        if (body.apiKey) codingAgent = null;
+        await patchConfigFile({
           provider: settings.provider,
           model: settings.model,
           apiKey: settings.apiKey,
         });
         options.onSettings?.(settings);
-        sendJson(res, 200, publicSettings(settings));
+        const published = publicSettings(settings, codingAgent);
+        log(
+          `PUT /api/settings  ${published.provider}/${published.model}  key=${published.hasKey ? "yes" : "no"}`,
+        );
+        sendJson(res, 200, published);
+        return;
+      }
+
+      if (req.method === "PUT" && url.pathname === "/api/diff") {
+        const body = JSON.parse(await readBody(req)) as { scope?: string };
+        const scope = body.scope;
+        if (!scope || !isDiffScopeId(scope)) {
+          sendJson(res, 400, { error: "Unknown diff scope." });
+          return;
+        }
+        try {
+          const next = await rebuildLocalReview(snapshot.repo, scope);
+          if (next.empty) {
+            sendJson(res, 400, { error: "That scope has no changes." });
+            return;
+          }
+          snapshot = next;
+          const published = publicSettings(settings, codingAgent);
+          log(`PUT /api/diff  ${scope}  ${next.diff.files.length} file(s)`);
+          sendJson(res, 200, sessionPayload(next, published));
+        } catch (error) {
+          const message = error instanceof GitError ? error.message : "Could not load that diff.";
+          sendJson(res, 400, { error: message });
+        }
         return;
       }
 
@@ -117,30 +207,48 @@ export function createReviewServer(options: CreateReviewServerOptions) {
           "content-type": "text/event-stream; charset=utf-8",
           "cache-control": "no-cache, no-transform",
           connection: "keep-alive",
+          "x-accel-buffering": "no",
         });
+        res.flushHeaders();
+        res.socket?.setNoDelay(true);
+        // Comment frame so EventSource leaves CONNECTING before the first provider call.
+        res.write(":\n\n");
         const abort = new AbortController();
-        req.on("close", () => abort.abort());
+        let planFinished = false;
+        req.on("close", () => {
+          abort.abort();
+          if (!planFinished) log("plan  client closed");
+        });
 
         if (!settings.apiKey) {
+          log("plan  no API key");
           res.write(
             `data: ${JSON.stringify({
               type: "ERROR",
               error: { message: "No API key configured.", code: "no_api_key" },
             })}\n\n`,
           );
+          planFinished = true;
           res.end();
           return;
         }
 
+        log(
+          `GET /api/plan  ${settings.provider}/${settings.model}  ${snapshot.selectedScope}  ${snapshot.diff.files.length} file(s)`,
+        );
+
         for await (const event of annotateReview({
-          diff: options.diff,
-          context: options.context,
+          diff: snapshot.diff,
+          context: snapshot.context,
           settings,
           signal: abort.signal,
         })) {
           if (abort.signal.aborted) return;
+          const line = describePlanEvent(event);
+          if (line) log(line);
           res.write(`data: ${JSON.stringify(event)}\n\n`);
         }
+        planFinished = true;
         res.end();
         return;
       }
@@ -171,10 +279,12 @@ export function createReviewServer(options: CreateReviewServerOptions) {
           res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
           createReadStream(fallback).pipe(res);
         } catch {
+          log("UI not built. Run npm run build -w @guided-review/cli.");
           sendJson(res, 404, { error: "UI not built. Run npm run build -w @guided-review/cli." });
         }
       }
     } catch (error) {
+      log(`server error  ${formatThrown(error)}`);
       const message = error instanceof Error ? error.message : "Server error.";
       if (!res.headersSent) sendJson(res, 500, { error: message });
       else res.end();
@@ -196,4 +306,26 @@ export function listen(server: ReturnType<typeof createReviewServer>, port = 0):
       resolve(address.port);
     });
   });
+}
+
+/**
+ * Idempotent Ctrl+C / SIGTERM handler. `server.close(cb)` adds a `close` listener
+ * per call; while SSE plans hold connections open, repeated signals would trip
+ * MaxListenersExceededWarning. First signal closes the server and drops sockets;
+ * a second signal forces exit.
+ */
+export function createServerShutdown(
+  server: ReturnType<typeof createReviewServer>,
+  exit: (code: number) => void = (code) => process.exit(code),
+): () => void {
+  let shuttingDown = false;
+  return () => {
+    if (shuttingDown) {
+      exit(1);
+      return;
+    }
+    shuttingDown = true;
+    server.close(() => exit(0));
+    server.closeAllConnections();
+  };
 }


### PR DESCRIPTION
Part 6 of 13 in the local-review CLI stack. Base: [#81](https://github.com/nshntarora/guidedreview/pull/81).

Read API keys from Claude Code, Codex, or Grok already on the machine. Server sessions become agent-aware so a local review can borrow those credentials without copying secrets into Guided Review config.

**Out of scope (later PRs):** overlay scope picker, settings/about UI, connection-test API.