### PR TITLE
feat(overlay): local scope picker and CLI wiring

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,6 +1,6 @@
 # `@guided-review/cli`
 
-Local Guided Review: diffs your working tree against the main branch, starts a localhost server, and opens the same walkthrough UI in the browser.
+Local Guided Review: opens a localhost walkthrough of the current branch versus its base, or of uncommitted / unstaged work, or of a single commit. File-by-file until you click **Structure with AI**.
 
 ```bash
 npm run build:cli
@@ -10,6 +10,6 @@ npm run review -- --base main --no-open
 
 Do not run `npx guided-review` — that name is taken on npm by another tool (Bun shebang). This package is `@guided-review/cli` and is workspace-only for now.
 
-The CLI binds `127.0.0.1` only. Every `/api/*` route requires the token printed in the URL. Keys live in `~/.config/guided-review/config.json` or provider env vars. No Guided Review backend.
+The CLI binds `127.0.0.1` only. Every `/api/*` route requires the token printed in the URL. Keys live in `~/.config/guided-review/config.json`, provider env vars, or a coding agent already on the machine (Claude Code, Codex, Grok). No Guided Review backend.
 
 See [Review local changes](https://guidedreview.dev/docs/local-review).

--- a/apps/cli/src/args.test.ts
+++ b/apps/cli/src/args.test.ts
@@ -33,4 +33,11 @@ describe("parseArgs", () => {
     expect(args.provider).toBe("grok");
     expect(args.agent).toBe("codex");
   });
+
+  it("requires a value after flags that take one", () => {
+    expect(() => parseArgs(["--base"])).toThrow(/--base requires a value/);
+    expect(() => parseArgs(["--base", "--port", "0"])).toThrow(/--base requires a value/);
+    expect(() => parseArgs(["--provider"])).toThrow(/--provider requires a value/);
+    expect(() => parseArgs(["--port"])).toThrow(/--port requires a value/);
+  });
 });

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -11,6 +11,14 @@ export interface CliArgs {
   help: boolean;
 }
 
+function takeValue(flag: string, argv: string[], index: number): string {
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith("-")) {
+    throw new Error(`${flag} requires a value. Run guided-review --help.`);
+  }
+  return value;
+}
+
 export function parseArgs(argv: string[]): CliArgs {
   const args: CliArgs = {
     cwd: process.cwd(),
@@ -40,11 +48,13 @@ export function parseArgs(argv: string[]): CliArgs {
       continue;
     }
     if (token === "--base") {
-      args.base = argv[++i];
+      args.base = takeValue(token, argv, i);
+      i += 1;
       continue;
     }
     if (token === "--port") {
-      const raw = argv[++i];
+      const raw = takeValue(token, argv, i);
+      i += 1;
       const port = Number(raw);
       if (!Number.isInteger(port) || port < 0 || port > 65535) {
         throw new Error(`Invalid --port ${raw}. Use an integer 0–65535.`);
@@ -53,15 +63,18 @@ export function parseArgs(argv: string[]): CliArgs {
       continue;
     }
     if (token === "--provider") {
-      args.provider = argv[++i];
+      args.provider = takeValue(token, argv, i);
+      i += 1;
       continue;
     }
     if (token === "--model") {
-      args.model = argv[++i];
+      args.model = takeValue(token, argv, i);
+      i += 1;
       continue;
     }
     if (token === "--agent") {
-      args.agent = argv[++i];
+      args.agent = takeValue(token, argv, i);
+      i += 1;
       continue;
     }
     if (token.startsWith("-")) {

--- a/apps/cli/src/codingAgents/claudeCode.ts
+++ b/apps/cli/src/codingAgents/claudeCode.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
-import type { AgentAuth, AgentIo, CodingAgentAdapter, DetectedAgent } from "./types";
+import { detectIfInstalled, parseJson, stringField } from "./parse";
+import type { AgentAuth, AgentIo, CodingAgentAdapter } from "./types";
 import { unusableAuth } from "./types";
 
 const DISPLAY_NAME = "Claude Code";
@@ -63,19 +64,6 @@ function authFromSecret(secret: string, model?: string, expiresAt?: number): Age
   });
 }
 
-function parseJson(raw: string | null): unknown {
-  if (!raw) return null;
-  try {
-    return JSON.parse(raw) as unknown;
-  } catch {
-    return null;
-  }
-}
-
-function stringField(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
 function oauthFromCredentials(value: unknown): { token: string; expiresAt?: number } | null {
   if (!value || typeof value !== "object") return null;
   const root = value as Record<string, unknown>;
@@ -88,21 +76,19 @@ function oauthFromCredentials(value: unknown): { token: string; expiresAt?: numb
   return { token, expiresAt };
 }
 
-async function readSettingsModel(io: AgentIo): Promise<string | undefined> {
+async function readSettings(io: AgentIo): Promise<{ model?: string; envKey?: string }> {
   const raw = await io.readFile(path.join(claudeHome(io), "settings.json"));
   const json = parseJson(raw);
-  if (!json || typeof json !== "object") return undefined;
+  if (!json || typeof json !== "object") return {};
   const settings = json as Record<string, unknown>;
-  return stringField(settings.model);
-}
-
-async function readSettingsEnvKey(io: AgentIo): Promise<string | undefined> {
-  const raw = await io.readFile(path.join(claudeHome(io), "settings.json"));
-  const json = parseJson(raw);
-  if (!json || typeof json !== "object") return undefined;
-  const env = (json as Record<string, unknown>).env;
-  if (!env || typeof env !== "object") return undefined;
-  return stringField((env as Record<string, unknown>).ANTHROPIC_API_KEY);
+  const env = settings.env;
+  return {
+    model: stringField(settings.model),
+    envKey:
+      env && typeof env === "object"
+        ? stringField((env as Record<string, unknown>).ANTHROPIC_API_KEY)
+        : undefined,
+  };
 }
 
 async function installed(io: AgentIo): Promise<boolean> {
@@ -121,24 +107,15 @@ export const claudeCodeAdapter: CodingAgentAdapter = {
   provider: "anthropic",
 
   async detect(io) {
-    if (!(await installed(io))) return null;
-    const auth = await this.resolveAuth(io);
-    const detected: DetectedAgent = {
-      id: this.id,
-      displayName: this.displayName,
-      provider: this.provider,
-      auth,
-    };
-    return detected;
+    return detectIfInstalled(this, io, installed);
   },
 
   async resolveAuth(io) {
-    const model = await readSettingsModel(io);
+    const { model, envKey: settingsKey } = await readSettings(io);
 
     const envKey = io.env("ANTHROPIC_API_KEY");
     if (envKey?.trim()) return authFromSecret(envKey.trim(), model);
 
-    const settingsKey = await readSettingsEnvKey(io);
     if (settingsKey) return authFromSecret(settingsKey, model);
 
     if (io.platform() === "darwin") {

--- a/apps/cli/src/codingAgents/codex.ts
+++ b/apps/cli/src/codingAgents/codex.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
-import type { AgentAuth, AgentIo, CodingAgentAdapter, DetectedAgent } from "./types";
+import { detectIfInstalled, parseJson, stringField } from "./parse";
+import type { AgentAuth, AgentIo, CodingAgentAdapter } from "./types";
 import { unusableAuth } from "./types";
 
 const DISPLAY_NAME = "Codex";
@@ -8,19 +9,6 @@ const CHATGPT_REASON =
 
 function codexHome(io: AgentIo): string {
   return io.env("CODEX_HOME") ?? path.join(io.homedir(), ".codex");
-}
-
-function parseJson(raw: string | null): unknown {
-  if (!raw) return null;
-  try {
-    return JSON.parse(raw) as unknown;
-  } catch {
-    return null;
-  }
-}
-
-function stringField(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 /** Tiny pull of `model = "..."` — Codex config is TOML, we do not take a parser dep. */
@@ -50,15 +38,7 @@ export const codexAdapter: CodingAgentAdapter = {
   provider: "openai",
 
   async detect(io) {
-    if (!(await installed(io))) return null;
-    const auth = await this.resolveAuth(io);
-    const detected: DetectedAgent = {
-      id: this.id,
-      displayName: this.displayName,
-      provider: this.provider,
-      auth,
-    };
-    return detected;
+    return detectIfInstalled(this, io, installed);
   },
 
   async resolveAuth(io) {

--- a/apps/cli/src/codingAgents/grok.ts
+++ b/apps/cli/src/codingAgents/grok.ts
@@ -1,24 +1,12 @@
 import path from "node:path";
-import type { AgentAuth, AgentIo, CodingAgentAdapter, DetectedAgent } from "./types";
+import { detectIfInstalled, parseJson, stringField } from "./parse";
+import type { AgentAuth, AgentIo, CodingAgentAdapter } from "./types";
 import { unusableAuth } from "./types";
 
 const DISPLAY_NAME = "Grok";
 
 function grokHome(io: AgentIo): string {
   return path.join(io.homedir(), ".grok");
-}
-
-function parseJson(raw: string | null): unknown {
-  if (!raw) return null;
-  try {
-    return JSON.parse(raw) as unknown;
-  } catch {
-    return null;
-  }
-}
-
-function stringField(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 function isXaiApiKey(secret: string): boolean {
@@ -79,15 +67,7 @@ export const grokAdapter: CodingAgentAdapter = {
   provider: "grok",
 
   async detect(io) {
-    if (!(await installed(io))) return null;
-    const auth = await this.resolveAuth(io);
-    const detected: DetectedAgent = {
-      id: this.id,
-      displayName: this.displayName,
-      provider: this.provider,
-      auth,
-    };
-    return detected;
+    return detectIfInstalled(this, io, installed);
   },
 
   async resolveAuth(io) {

--- a/apps/cli/src/codingAgents/parse.ts
+++ b/apps/cli/src/codingAgents/parse.ts
@@ -1,0 +1,30 @@
+import type { AgentAuth, AgentIo, CodingAgentAdapter, DetectedAgent } from "./types";
+
+export function parseJson(raw: string | null): unknown {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+export function stringField(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export async function detectIfInstalled(
+  adapter: Pick<CodingAgentAdapter, "id" | "displayName" | "provider"> & {
+    resolveAuth(io: AgentIo): Promise<AgentAuth>;
+  },
+  io: AgentIo,
+  isInstalled: (io: AgentIo) => Promise<boolean>,
+): Promise<DetectedAgent | null> {
+  if (!(await isInstalled(io))) return null;
+  return {
+    id: adapter.id,
+    displayName: adapter.displayName,
+    provider: adapter.provider,
+    auth: await adapter.resolveAuth(io),
+  };
+}

--- a/apps/cli/src/config.test.ts
+++ b/apps/cli/src/config.test.ts
@@ -1,8 +1,14 @@
-import { mkdtemp, readFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { resolveSettings, writeConfigFile } from "./config";
+import {
+  applyProviderSettings,
+  ConfigError,
+  readConfigFile,
+  resolveSettings,
+  writeConfigFile,
+} from "./config";
 import { createMemoryIo } from "./codingAgents";
 
 const ENV_KEYS = [
@@ -120,5 +126,47 @@ describe("resolveSettings", () => {
     });
     expect(resolved.codingAgent).toBeNull();
     expect(resolved.settings.apiKey).toBe("");
+  });
+
+  it("rejects a corrupt config file instead of treating it as empty", async () => {
+    const dir = await withTempConfig();
+    await writeFile(path.join(dir, "config.json"), "{not json", "utf8");
+    await expect(readConfigFile()).rejects.toBeInstanceOf(ConfigError);
+  });
+});
+
+describe("applyProviderSettings", () => {
+  const agentSettings = {
+    provider: "anthropic" as const,
+    model: "claude-sonnet-4-6",
+    apiKey: "sk-ant-oat01-live",
+    authScheme: "bearer" as const,
+    extraHeaders: { "anthropic-beta": "oauth-2025-04-20" },
+  };
+
+  it("keeps agent auth when no key is pasted", () => {
+    const next = applyProviderSettings(agentSettings, "claude-code", {
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+    });
+    expect(next.settings.authScheme).toBe("bearer");
+    expect(next.settings.extraHeaders).toEqual({ "anthropic-beta": "oauth-2025-04-20" });
+    expect(next.settings.apiKey).toBe("sk-ant-oat01-live");
+    expect(next.codingAgent).toBe("claude-code");
+    expect(next.persist.apiKey).toBeUndefined();
+    expect(next.persist.model).toBe("claude-opus-4-8");
+  });
+
+  it("drops agent auth when a console key is pasted", () => {
+    const next = applyProviderSettings(agentSettings, "claude-code", {
+      provider: "openai",
+      model: "gpt-4.1",
+      apiKey: "sk-user",
+    });
+    expect(next.settings.authScheme).toBeUndefined();
+    expect(next.settings.extraHeaders).toBeUndefined();
+    expect(next.settings.apiKey).toBe("sk-user");
+    expect(next.codingAgent).toBeNull();
+    expect(next.persist).toMatchObject({ apiKey: "sk-user", codingAgent: null });
   });
 });

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -18,12 +18,23 @@ import {
   type DetectedAgent,
 } from "./codingAgents";
 
+export class ConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConfigError";
+  }
+}
+
 export interface CliConfigFile {
   provider?: ProviderId;
   model?: string;
   apiKey?: string;
   codingAgent?: CodingAgentId;
 }
+
+export type ConfigPatch = Omit<Partial<CliConfigFile>, "codingAgent"> & {
+  codingAgent?: CodingAgentId | null;
+};
 
 export interface ResolvedCliSettings {
   settings: ProviderSettings;
@@ -53,11 +64,19 @@ function envKeyFor(provider: ProviderId): string | undefined {
 }
 
 export async function readConfigFile(): Promise<CliConfigFile> {
+  let raw: string;
   try {
-    const raw = await readFile(configPath(), "utf8");
+    raw = await readFile(configPath(), "utf8");
+  } catch (error) {
+    if ((error as { code?: string }).code === "ENOENT") return {};
+    throw error;
+  }
+  try {
     return JSON.parse(raw) as CliConfigFile;
   } catch {
-    return {};
+    throw new ConfigError(
+      `Could not parse ${configPath()}. Fix or delete that file and try again.`,
+    );
   }
 }
 
@@ -66,9 +85,51 @@ export async function writeConfigFile(next: CliConfigFile): Promise<void> {
   await writeFile(configPath(), `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
 }
 
-export async function patchConfigFile(partial: Partial<CliConfigFile>): Promise<void> {
+export async function patchConfigFile(partial: ConfigPatch): Promise<void> {
   const current = await readConfigFile();
-  await writeConfigFile({ ...current, ...partial });
+  const { codingAgent, ...rest } = partial;
+  const next: CliConfigFile = { ...current, ...rest };
+  if (codingAgent === null) delete next.codingAgent;
+  else if (codingAgent !== undefined) next.codingAgent = codingAgent;
+  await writeConfigFile(next);
+}
+
+/**
+ * Apply a settings-panel PATCH. A blank/missing apiKey keeps the in-memory
+ * secret and agent auth fields; only a pasted key is persisted.
+ */
+export function applyProviderSettings(
+  current: ProviderSettings,
+  codingAgent: CodingAgentId | null,
+  body: Partial<Pick<ProviderSettings, "provider" | "model" | "apiKey">>,
+): {
+  settings: ProviderSettings;
+  codingAgent: CodingAgentId | null;
+  persist: ConfigPatch;
+} {
+  const hasNewKey = typeof body.apiKey === "string" && body.apiKey.length > 0;
+  const requestedModel = body.model ?? current.model;
+  const normalized = normalizeProviderSettings({
+    provider: body.provider ?? current.provider,
+    model: requestedModel,
+    apiKey: hasNewKey ? body.apiKey : current.apiKey,
+    authScheme: hasNewKey ? undefined : current.authScheme,
+    extraHeaders: hasNewKey ? undefined : current.extraHeaders,
+  });
+  const settings: ProviderSettings = {
+    ...normalized,
+    // Keep a coding-agent model that is not in the catalog yet.
+    model: requestedModel || normalized.model,
+  };
+  return {
+    settings,
+    codingAgent: hasNewKey ? null : codingAgent,
+    persist: {
+      provider: settings.provider,
+      model: settings.model,
+      ...(hasNewKey ? { apiKey: settings.apiKey, codingAgent: null } : {}),
+    },
+  };
 }
 
 export async function resolveSettings(flags: {
@@ -93,8 +154,7 @@ export async function resolveSettings(flags: {
   const envKey = envKeyFor(normalized.provider);
   const settings: ProviderSettings = {
     ...normalized,
-    apiKey:
-      flags.provider || flags.model ? (envKey ?? normalized.apiKey) : (envKey ?? file.apiKey ?? ""),
+    apiKey: envKey ?? file.apiKey ?? "",
     model: flags.model ?? normalized.model ?? defaultModelFor(normalized.provider),
   };
 

--- a/apps/cli/src/git/localDiff.test.ts
+++ b/apps/cli/src/git/localDiff.test.ts
@@ -274,6 +274,21 @@ describe("buildLocalReview", () => {
     expect(scoped.selectedScope).toBe(`commit:${first!.sha}`);
   });
 
+  it("rebuilds the same scope to the same files and session-key shape", async () => {
+    const root = await makeRepo();
+    await writeFile(path.join(root, "readme.md"), "hello rebuild\n");
+    const built = await buildLocalReview({ cwd: root });
+    const rebuilt = await rebuildLocalReview(built.repo, built.selectedScope);
+    expect(rebuilt.selectedScope).toBe(built.selectedScope);
+    expect(rebuilt.diff.files.map((file) => file.path)).toEqual(
+      built.diff.files.map((file) => file.path),
+    );
+    expect(rebuilt.sessionKey.split(":").slice(0, 4)).toEqual(
+      built.sessionKey.split(":").slice(0, 4),
+    );
+    expect(rebuilt.sessionKey).toBe(built.sessionKey);
+  });
+
   it("fails outside a git repo", async () => {
     const dir = await mkdir(path.join(os.tmpdir(), `gr-nongit-${Date.now()}`), { recursive: true });
     await expect(buildLocalReview({ cwd: dir! })).rejects.toBeInstanceOf(GitError);

--- a/apps/cli/src/git/localDiff.ts
+++ b/apps/cli/src/git/localDiff.ts
@@ -35,6 +35,8 @@ export interface DiffScopeOption {
   label: string;
   description: string;
   meta: string;
+  /** Extra shown ahead of file/+− counts (commit count, short SHA). */
+  metaPrefix?: string;
   stat: DiffStat;
   empty: boolean;
 }
@@ -61,7 +63,7 @@ export interface LocalReviewSnapshot {
 }
 
 const COMMIT_SCOPE_PREFIX = "commit:";
-/** Individual commit scopes and the Change summary list. */
+/** Individual commit scopes and the Change summary list. Keep in sync with overlay/localReview.ts. */
 export const MAX_RECENT_COMMITS = 5;
 
 export function isDiffScopeId(value: string): value is DiffScopeId {
@@ -116,27 +118,43 @@ async function resolveBase(repoRoot: string, requested?: string): Promise<string
   );
 }
 
-async function collectUntrackedDiffs(repoRoot: string): Promise<string> {
-  const listed = await runGit(["ls-files", "--others", "--exclude-standard", "-z"], repoRoot);
-  const files = listed.split("\0").filter(Boolean);
-  if (files.length === 0) return "";
-
-  const chunks: string[] = [];
-  for (const file of files) {
-    const patch = await runGit(
-      ["diff", "--no-color", "--no-index", "--", nullDevice(), file],
-      repoRoot,
-      { allowExitCodes: [1] },
-    );
-    if (patch.trim())
-      chunks.push(patch.replace(/^diff --git a\/.*$/m, `diff --git a/${file} b/${file}`));
+async function mapLimit<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) return [];
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  async function worker(): Promise<void> {
+    while (next < items.length) {
+      const index = next;
+      next += 1;
+      results[index] = await fn(items[index]!);
+    }
   }
-  return chunks.join("");
+  const workers = Math.min(limit, items.length);
+  await Promise.all(Array.from({ length: workers }, () => worker()));
+  return results;
 }
 
 async function listUntracked(repoRoot: string): Promise<string[]> {
   const listed = await runGit(["ls-files", "--others", "--exclude-standard", "-z"], repoRoot);
   return listed.split("\0").filter(Boolean);
+}
+
+async function collectUntrackedDiffs(repoRoot: string, files: string[]): Promise<string> {
+  if (files.length === 0) return "";
+  const chunks = await mapLimit(files, 8, async (file) => {
+    const patch = await runGit(
+      ["diff", "--no-color", "--no-index", "--", nullDevice(), file],
+      repoRoot,
+      { allowExitCodes: [1] },
+    );
+    if (!patch.trim()) return "";
+    return patch.replace(/^diff --git a\/.*$/m, `diff --git a/${file} b/${file}`);
+  });
+  return chunks.filter(Boolean).join("");
 }
 
 export function parseShortstat(raw: string): DiffStat {
@@ -170,7 +188,6 @@ export function parseCommitLog(raw: string): LocalCommit[] {
 }
 
 export function formatScopeMeta(stat: DiffStat, extra?: string): string {
-  if (stat.files === 0 && !extra) return "No changes";
   if (stat.files === 0) return extra ? `${extra} · No changes` : "No changes";
   const fileLabel = `${stat.files} file${stat.files === 1 ? "" : "s"}`;
   const counts = `+${stat.additions} −${stat.deletions}`;
@@ -229,27 +246,28 @@ async function commitPatch(repoRoot: string, sha: string): Promise<string> {
   }
 }
 
-async function rawDiffForScope(repo: LocalRepoState, scope: DiffScopeId): Promise<string> {
-  const { repoRoot, mergeBase } = repo;
+/** Shared git args so the patch and the shortstat for a scope cannot drift. */
+function gitForScope(
+  repo: LocalRepoState,
+  scope: DiffScopeId,
+): { sha: string } | { range: string[]; includeUntracked: boolean } {
   const sha = commitShaFromScope(scope);
-  if (sha) return commitPatch(repoRoot, sha);
+  if (sha) return { sha };
+  if (scope === "branch") return { range: [repo.mergeBase, "HEAD"], includeUntracked: false };
+  if (scope === "unstaged") return { range: [], includeUntracked: false };
+  if (repo.staged) return { range: ["--cached", "HEAD"], includeUntracked: false };
+  return { range: ["HEAD"], includeUntracked: repo.includeUntracked };
+}
 
-  if (scope === "branch") {
-    return runGit(["diff", "--no-color", "--find-renames", mergeBase, "HEAD"], repoRoot);
-  }
-
-  if (scope === "unstaged") {
-    return runGit(["diff", "--no-color", "--find-renames"], repoRoot);
-  }
-
-  if (repo.staged) {
-    return runGit(["diff", "--no-color", "--find-renames", "--cached", "HEAD"], repoRoot);
-  }
-
-  let raw = await runGit(["diff", "--no-color", "--find-renames", "HEAD"], repoRoot);
-  if (repo.includeUntracked) {
-    raw += await collectUntrackedDiffs(repoRoot);
-  }
+async function rawDiffForScope(
+  repo: LocalRepoState,
+  scope: DiffScopeId,
+  untracked: string[],
+): Promise<string> {
+  const spec = gitForScope(repo, scope);
+  if ("sha" in spec) return commitPatch(repo.repoRoot, spec.sha);
+  let raw = await runGit(["diff", "--no-color", "--find-renames", ...spec.range], repo.repoRoot);
+  if (spec.includeUntracked) raw += await collectUntrackedDiffs(repo.repoRoot, untracked);
   return raw;
 }
 
@@ -258,23 +276,10 @@ async function statForScope(
   scope: DiffScopeId,
   untrackedCount: number,
 ): Promise<DiffStat> {
-  const sha = commitShaFromScope(scope);
-  if (sha) return commitShortstat(repo.repoRoot, sha);
-
-  if (scope === "branch") {
-    return shortstat(repo.repoRoot, [repo.mergeBase, "HEAD"]);
-  }
-
-  if (scope === "unstaged") {
-    return shortstat(repo.repoRoot, []);
-  }
-
-  if (repo.staged) {
-    return shortstat(repo.repoRoot, ["--cached", "HEAD"]);
-  }
-
-  const stat = await shortstat(repo.repoRoot, ["HEAD"]);
-  if (repo.includeUntracked && untrackedCount > 0) {
+  const spec = gitForScope(repo, scope);
+  if ("sha" in spec) return commitShortstat(repo.repoRoot, spec.sha);
+  const stat = await shortstat(repo.repoRoot, spec.range);
+  if (spec.includeUntracked && untrackedCount > 0) {
     return { ...stat, files: stat.files + untrackedCount };
   }
   return stat;
@@ -316,16 +321,27 @@ async function listCommits(repo: LocalRepoState): Promise<LocalCommit[]> {
 async function buildScopes(
   repo: LocalRepoState,
   commits: LocalCommit[],
+  untracked: string[],
 ): Promise<DiffScopeOption[]> {
-  const untracked = repo.includeUntracked && !repo.staged ? await listUntracked(repo.repoRoot) : [];
   const untrackedCount = untracked.length;
   const headLabel = repo.headRef === "HEAD" ? "this HEAD" : repo.headRef;
+  const recent = commits.slice(0, MAX_RECENT_COMMITS);
 
-  const branchStat = await statForScope(repo, "branch", untrackedCount);
-  const uncommittedStat = await statForScope(repo, "uncommitted", untrackedCount);
-  const unstagedStat = await statForScope(repo, "unstaged", untrackedCount);
+  const [workingTreeStats, commitCount, commitStats] = await Promise.all([
+    Promise.all([
+      statForScope(repo, "branch", untrackedCount),
+      statForScope(repo, "uncommitted", untrackedCount),
+      statForScope(repo, "unstaged", untrackedCount),
+    ]),
+    countCommitsAhead(repo),
+    Promise.all(
+      recent.map((commit) =>
+        statForScope(repo, `${COMMIT_SCOPE_PREFIX}${commit.sha}`, untrackedCount),
+      ),
+    ),
+  ]);
+  const [branchStat, uncommittedStat, unstagedStat] = workingTreeStats;
 
-  const commitCount = await countCommitsAhead(repo);
   const commitExtra = `${commitCount} commit${commitCount === 1 ? "" : "s"}`;
 
   const scopes: DiffScopeOption[] = [
@@ -334,6 +350,7 @@ async function buildScopes(
       label: `${headLabel} vs ${repo.baseRef}`,
       description: `Committed work on this branch since it diverged from ${repo.baseRef}.`,
       meta: formatScopeMeta(branchStat, commitExtra),
+      metaPrefix: commitExtra,
       stat: branchStat,
       empty: branchStat.files === 0,
     },
@@ -357,8 +374,8 @@ async function buildScopes(
     },
   ];
 
-  for (const commit of commits.slice(0, MAX_RECENT_COMMITS)) {
-    const stat = await statForScope(repo, `${COMMIT_SCOPE_PREFIX}${commit.sha}`, untrackedCount);
+  recent.forEach((commit, index) => {
+    const stat = commitStats[index]!;
     commit.stat = stat;
     const when = dateLabel(commit.authoredAt);
     scopes.push({
@@ -366,10 +383,11 @@ async function buildScopes(
       label: commit.subject,
       description: [commit.author, when].filter(Boolean).join(" · "),
       meta: formatScopeMeta(stat, commit.shortSha),
+      metaPrefix: commit.shortSha,
       stat,
       empty: stat.files === 0,
     });
-  }
+  });
 
   return scopes;
 }
@@ -416,36 +434,18 @@ export async function inspectLocalRepo(options: LocalDiffOptions): Promise<Local
   };
 }
 
-export async function rebuildLocalReview(
+async function snapshotFrom(
   repo: LocalRepoState,
-  scope: DiffScopeId,
+  requested?: DiffScopeId,
 ): Promise<LocalReviewSnapshot> {
+  const untracked = repo.includeUntracked && !repo.staged ? await listUntracked(repo.repoRoot) : [];
   const commits = await listCommits(repo);
-  const scopes = await buildScopes(repo, commits);
-  if (!scopes.some((option) => option.id === scope)) {
-    throw new GitError(`Unknown diff scope "${scope}".`);
+  const scopes = await buildScopes(repo, commits, untracked);
+  const selected = requested ?? pickDefaultScope(scopes, repo.staged);
+  if (requested && !scopes.some((option) => option.id === requested)) {
+    throw new GitError(`Unknown diff scope "${requested}".`);
   }
-  const raw = await rawDiffForScope(repo, scope);
-  const diff = parseDiff(raw);
-  return {
-    repo,
-    commits,
-    scopes,
-    selectedScope: scope,
-    context: contextFor(repo, commits, scope),
-    diff,
-    raw,
-    sessionKey: sessionKeyFor(repo, scope, raw),
-    empty: diff.files.length === 0,
-  };
-}
-
-export async function buildLocalReview(options: LocalDiffOptions): Promise<LocalReviewSnapshot> {
-  const repo = await inspectLocalRepo(options);
-  const commits = await listCommits(repo);
-  const scopes = await buildScopes(repo, commits);
-  const selected = options.scope ?? pickDefaultScope(scopes, repo.staged);
-  const raw = await rawDiffForScope(repo, selected);
+  const raw = await rawDiffForScope(repo, selected, untracked);
   const diff = parseDiff(raw);
   return {
     repo,
@@ -458,4 +458,15 @@ export async function buildLocalReview(options: LocalDiffOptions): Promise<Local
     sessionKey: sessionKeyFor(repo, selected, raw),
     empty: diff.files.length === 0,
   };
+}
+
+export function rebuildLocalReview(
+  repo: LocalRepoState,
+  scope: DiffScopeId,
+): Promise<LocalReviewSnapshot> {
+  return snapshotFrom(repo, scope);
+}
+
+export async function buildLocalReview(options: LocalDiffOptions): Promise<LocalReviewSnapshot> {
+  return snapshotFrom(await inspectLocalRepo(options), options.scope);
 }

--- a/apps/cli/src/server/createServer.test.ts
+++ b/apps/cli/src/server/createServer.test.ts
@@ -1,12 +1,13 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import net from "node:net";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import type { ParsedDiff } from "@guided-review/core";
 import { buildLocalReview, type LocalReviewSnapshot } from "../git/localDiff";
+import { configPath } from "../config";
 import {
   createReviewServer,
   createServerShutdown,
@@ -226,6 +227,121 @@ describe("createReviewServer", () => {
       }
       realClose(() => resolve());
       server.closeAllConnections();
+    });
+  });
+
+  describe("PUT /api/settings", () => {
+    const prevConfigDir = process.env.GUIDED_REVIEW_CONFIG_DIR;
+
+    afterEach(() => {
+      if (prevConfigDir === undefined) delete process.env.GUIDED_REVIEW_CONFIG_DIR;
+      else process.env.GUIDED_REVIEW_CONFIG_DIR = prevConfigDir;
+    });
+
+    async function withTempConfig(): Promise<string> {
+      const dir = await mkdir(path.join(os.tmpdir(), `gr-cfg-${Date.now()}`), { recursive: true });
+      process.env.GUIDED_REVIEW_CONFIG_DIR = dir!;
+      return dir!;
+    }
+
+    it("keeps agent auth in memory and does not persist the secret", async () => {
+      const dir = await withTempConfig();
+      const server = createReviewServer({
+        snapshot,
+        settings: {
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          apiKey: "sk-ant-oat01-live",
+          authScheme: "bearer",
+          extraHeaders: { "anthropic-beta": "oauth-2025-04-20" },
+        },
+        codingAgent: "claude-code",
+        token: "secret",
+      });
+      const port = await listen(server);
+      const base = `http://127.0.0.1:${port}`;
+
+      const saved = await fetch(`${base}/api/settings?token=secret`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ provider: "anthropic", model: "claude-opus-4-8" }),
+      }).then((r) => r.json() as Promise<{ codingAgent: string | null; hasKey: boolean }>);
+      expect(saved.codingAgent).toBe("claude-code");
+      expect(saved.hasKey).toBe(true);
+
+      const file = JSON.parse(await readFile(path.join(dir, "config.json"), "utf8")) as {
+        apiKey?: string;
+        codingAgent?: string;
+        model?: string;
+      };
+      expect(file.apiKey).toBeUndefined();
+      expect(file.codingAgent).toBeUndefined();
+      expect(file.model).toBe("claude-opus-4-8");
+
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      );
+    });
+
+    it("stores a pasted key and clears the coding agent", async () => {
+      await withTempConfig();
+      const server = createReviewServer({
+        snapshot,
+        settings: {
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          apiKey: "sk-ant-oat01-live",
+          authScheme: "bearer",
+          extraHeaders: { "anthropic-beta": "oauth-2025-04-20" },
+        },
+        codingAgent: "claude-code",
+        token: "secret",
+      });
+      const port = await listen(server);
+      const base = `http://127.0.0.1:${port}`;
+
+      const saved = await fetch(`${base}/api/settings?token=secret`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          provider: "openai",
+          model: "gpt-4.1",
+          apiKey: "sk-user",
+        }),
+      }).then((r) => r.json() as Promise<{ codingAgent: string | null; last4: string | null }>);
+      expect(saved.codingAgent).toBeNull();
+      expect(saved.last4).toBe("user");
+
+      const file = JSON.parse(await readFile(configPath(), "utf8")) as {
+        apiKey?: string;
+        codingAgent?: string;
+        provider?: string;
+      };
+      expect(file.apiKey).toBe("sk-user");
+      expect(file.codingAgent).toBeUndefined();
+      expect(file.provider).toBe("openai");
+
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      );
+    });
+
+    it("rejects invalid JSON with 400", async () => {
+      const server = createReviewServer({
+        snapshot,
+        settings: { provider: "anthropic", model: "claude-opus-4-8", apiKey: "" },
+        token: "secret",
+      });
+      const port = await listen(server);
+      const res = await fetch(`http://127.0.0.1:${port}/api/settings?token=secret`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: "{",
+      });
+      expect(res.status).toBe(400);
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      );
     });
   });
 });

--- a/apps/cli/src/server/createServer.ts
+++ b/apps/cli/src/server/createServer.ts
@@ -12,7 +12,7 @@ import {
   type AnnotateReviewStreamEvent,
   type ProviderSettings,
 } from "@guided-review/core";
-import { publicSettings, patchConfigFile } from "../config";
+import { applyProviderSettings, publicSettings, patchConfigFile } from "../config";
 import type { CodingAgentId } from "../codingAgents";
 import {
   isDiffScopeId,
@@ -92,6 +92,18 @@ function readBody(req: IncomingMessage): Promise<string> {
   });
 }
 
+async function readJsonBody(
+  req: IncomingMessage,
+): Promise<{ ok: true; value: unknown } | { ok: false }> {
+  const raw = await readBody(req);
+  if (!raw.trim()) return { ok: false };
+  try {
+    return { ok: true, value: JSON.parse(raw) as unknown };
+  } catch {
+    return { ok: false };
+  }
+}
+
 function contentTypeFor(filePath: string): string {
   if (filePath.endsWith(".html")) return "text/html; charset=utf-8";
   if (filePath.endsWith(".js")) return "text/javascript; charset=utf-8";
@@ -155,20 +167,16 @@ export function createReviewServer(options: CreateReviewServerOptions) {
       }
 
       if (req.method === "PUT" && url.pathname === "/api/settings") {
-        const body = JSON.parse(await readBody(req)) as Partial<ProviderSettings>;
-        const nextKey =
-          body.apiKey !== undefined && body.apiKey !== "" ? body.apiKey : settings.apiKey;
-        settings = {
-          provider: body.provider ?? settings.provider,
-          model: body.model ?? settings.model,
-          apiKey: nextKey,
-        };
-        if (body.apiKey) codingAgent = null;
-        await patchConfigFile({
-          provider: settings.provider,
-          model: settings.model,
-          apiKey: settings.apiKey,
-        });
+        const parsed = await readJsonBody(req);
+        if (!parsed.ok || !parsed.value || typeof parsed.value !== "object") {
+          sendJson(res, 400, { error: "Request body must be JSON." });
+          return;
+        }
+        const body = parsed.value as Partial<ProviderSettings>;
+        const applied = applyProviderSettings(settings, codingAgent, body);
+        settings = applied.settings;
+        codingAgent = applied.codingAgent;
+        await patchConfigFile(applied.persist);
         options.onSettings?.(settings);
         const published = publicSettings(settings, codingAgent);
         log(
@@ -179,7 +187,12 @@ export function createReviewServer(options: CreateReviewServerOptions) {
       }
 
       if (req.method === "PUT" && url.pathname === "/api/diff") {
-        const body = JSON.parse(await readBody(req)) as { scope?: string };
+        const parsed = await readJsonBody(req);
+        if (!parsed.ok || !parsed.value || typeof parsed.value !== "object") {
+          sendJson(res, 400, { error: "Request body must be JSON." });
+          return;
+        }
+        const body = parsed.value as { scope?: string };
         const scope = body.scope;
         if (!scope || !isDiffScopeId(scope)) {
           sendJson(res, 400, { error: "Unknown diff scope." });

--- a/apps/cli/src/ui/App.tsx
+++ b/apps/cli/src/ui/App.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useMemo, useState } from "react";
-import { buildFileReviewPlan, getProvider } from "@guided-review/core";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { buildFileReviewPlan, getProvider, type ProviderId } from "@guided-review/core";
 import type { ReviewSessionPayload } from "../server/createServer";
 import { Overlay } from "@extension/content/overlay/Overlay";
 import { ReviewHostProvider, setActiveReviewHost } from "@extension/content/overlay/host";
 import { restoreSession, useReviewStore } from "@extension/content/overlay/store";
+import type { LocalDiffControls } from "@extension/content/overlay/localReview";
 import { createLocalReviewHost } from "./host";
+import { codingAgentLabel } from "./codingAgentLabel";
 import { SettingsPanel } from "./SettingsPanel";
 
 function tokenFromLocation(): string {
@@ -15,6 +17,15 @@ export function App() {
   const token = tokenFromLocation();
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [bootError, setBootError] = useState<string | null>(null);
+  const [commits, setCommits] = useState<ReviewSessionPayload["commits"]>([]);
+  const [scopes, setScopes] = useState<ReviewSessionPayload["scopes"]>([]);
+  const [selectedScope, setSelectedScope] = useState("");
+  const [structured, setStructured] = useState(false);
+  const [scopeBusy, setScopeBusy] = useState(false);
+  const cancelStreamRef = useRef<(() => void) | undefined>(undefined);
+  const hasKeyRef = useRef(false);
+  const providerIdRef = useRef<ProviderId>("anthropic");
+  const codingAgentRef = useRef<string | null>(null);
 
   const host = useMemo(
     () =>
@@ -26,6 +37,64 @@ export function App() {
   );
   setActiveReviewHost(host);
 
+  const applyMeta = useCallback((session: ReviewSessionPayload) => {
+    setCommits(session.commits);
+    setScopes(session.scopes);
+    setSelectedScope(session.selectedScope);
+    useReviewStore.getState().open();
+    useReviewStore.getState().setPRContext(session.context);
+  }, []);
+
+  const installFilePlan = useCallback(
+    (session: ReviewSessionPayload) => {
+      applyMeta(session);
+      useReviewStore.getState().bootReady({
+        sessionKey: session.sessionKey,
+        diff: session.diff,
+        plan: buildFileReviewPlan(session.diff),
+      });
+      setStructured(false);
+    },
+    [applyMeta],
+  );
+
+  const startStructure = useCallback(() => {
+    const { diff, prContext } = useReviewStore.getState();
+    if (!diff || !prContext) return;
+    if (!hasKeyRef.current) {
+      host.connectProvider();
+      return;
+    }
+    cancelStreamRef.current?.();
+    const generation = useReviewStore.getState().beginRetry();
+    const agentLabel = codingAgentLabel(codingAgentRef.current);
+    useReviewStore
+      .getState()
+      .setProviderLabel(agentLabel ?? getProvider(providerIdRef.current).displayName);
+    const { cancel } = host.streamPlan(diff, prContext, {
+      onStatus: (phase) => useReviewStore.getState().setBuildPhase(phase, generation),
+      onUnit: (unit) => useReviewStore.getState().appendUnit(unit, generation),
+      onDone: (plan) => {
+        useReviewStore.getState().setReady(diff, plan, generation);
+        setStructured(true);
+      },
+      onError: (error) => {
+        if (error.code === "no_api_key") {
+          host.connectProvider();
+          const sessionKey = useReviewStore.getState().sessionKey ?? "local";
+          useReviewStore.getState().bootReady({
+            sessionKey,
+            diff,
+            plan: buildFileReviewPlan(diff),
+          });
+          return;
+        }
+        useReviewStore.getState().setError(error, generation);
+      },
+    });
+    cancelStreamRef.current = cancel;
+  }, [host]);
+
   useEffect(() => {
     if (!token) {
       setBootError("Missing session token. Open the URL printed by the CLI.");
@@ -33,7 +102,6 @@ export function App() {
     }
 
     let cancelled = false;
-    let cancelStream: (() => void) | undefined;
 
     async function boot() {
       const res = await fetch(`/api/session?token=${encodeURIComponent(token)}`);
@@ -44,37 +112,24 @@ export function App() {
       const session = (await res.json()) as ReviewSessionPayload;
       if (cancelled) return;
 
-      const store = useReviewStore.getState();
-      store.open();
-      store.setPRContext(session.context);
-      store.startLoading(session.sessionKey);
-      const generation = store.streamGeneration;
-
-      const restored = await restoreSession(session.sessionKey);
-      if (cancelled || restored) return;
-
-      store.setDiff(session.diff);
-
-      if (!session.settings.hasKey) {
-        store.setNeedsProvider();
-        return;
+      hasKeyRef.current = session.settings.hasKey;
+      providerIdRef.current = session.settings.provider;
+      codingAgentRef.current = session.settings.codingAgent ?? null;
+      if (session.settings.hasKey) {
+        const agentLabel = codingAgentLabel(codingAgentRef.current);
+        useReviewStore
+          .getState()
+          .setProviderLabel(agentLabel ?? getProvider(session.settings.provider).displayName);
       }
 
-      store.setProviderLabel(getProvider(session.settings.provider).displayName);
-      store.beginStreaming(generation);
-      const { cancel } = host.streamPlan(session.diff, session.context, {
-        onStatus: (phase) => useReviewStore.getState().setBuildPhase(phase, generation),
-        onUnit: (unit) => useReviewStore.getState().appendUnit(unit, generation),
-        onDone: (plan) => useReviewStore.getState().setReady(session.diff, plan, generation),
-        onError: (error) => {
-          if (error.code === "no_api_key") {
-            useReviewStore.getState().setNeedsProvider();
-            return;
-          }
-          useReviewStore.getState().setError(error, generation);
-        },
-      });
-      cancelStream = cancel;
+      applyMeta(session);
+      const restored = await restoreSession(session.sessionKey);
+      if (cancelled) return;
+      if (restored) {
+        setStructured(true);
+        return;
+      }
+      installFilePlan(session);
     }
 
     void boot().catch((error: unknown) => {
@@ -87,9 +142,49 @@ export function App() {
 
     return () => {
       cancelled = true;
-      cancelStream?.();
+      cancelStreamRef.current?.();
     };
-  }, [host, token]);
+  }, [applyMeta, installFilePlan, token]);
+
+  async function selectScope(scope: string) {
+    if (!token || scope === selectedScope || scopeBusy) return;
+    setScopeBusy(true);
+    cancelStreamRef.current?.();
+    cancelStreamRef.current = undefined;
+    try {
+      const res = await fetch(`/api/diff?token=${encodeURIComponent(token)}`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ scope }),
+      });
+      const body = (await res.json().catch(() => ({}))) as ReviewSessionPayload & {
+        error?: string;
+      };
+      if (!res.ok) {
+        throw new Error(body.error ?? `Could not load that diff (${res.status}).`);
+      }
+      installFilePlan(body);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : "Could not load that diff.";
+      useReviewStore.getState().setError(message);
+    } finally {
+      setScopeBusy(false);
+    }
+  }
+
+  const status = useReviewStore((s) => s.status);
+  const localDiff: LocalDiffControls = {
+    scopes,
+    selectedScope,
+    commits,
+    onSelectScope: (id) => {
+      void selectScope(id);
+    },
+    onStructureReview: startStructure,
+    structuring: status === "loading" || status === "streaming",
+    structured,
+    scopeBusy,
+  };
 
   if (bootError && !useReviewStore.getState().isOpen) {
     return (
@@ -102,18 +197,15 @@ export function App() {
   return (
     <ReviewHostProvider host={host}>
       <Overlay
+        allowExit={false}
+        localDiff={localDiff}
         onRetry={() => {
           const { diff, prContext } = useReviewStore.getState();
           if (!diff || !prContext) {
             window.location.reload();
             return;
           }
-          if (!useReviewStore.getState().needsProvider && !token) return;
-          const generation = useReviewStore.getState().beginRetry();
-          if (!useReviewStore.getState().needsProvider) {
-            useReviewStore.getState().setReady(diff, buildFileReviewPlan(diff), generation);
-          }
-          window.location.reload();
+          startStructure();
         }}
       />
       {settingsOpen && (

--- a/apps/cli/src/ui/SettingsPanel.tsx
+++ b/apps/cli/src/ui/SettingsPanel.tsx
@@ -49,7 +49,7 @@ export function SettingsPanel({ token, onClose, onSaved }: SettingsPanelProps) {
       const res = await fetch(`/api/settings?token=${encodeURIComponent(token)}`, {
         method: "PUT",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ provider, model, apiKey }),
+        body: JSON.stringify({ provider, model, ...(apiKey ? { apiKey } : {}) }),
       });
       if (!res.ok) throw new Error("Save failed.");
       onSaved();

--- a/apps/cli/src/ui/SettingsPanel.tsx
+++ b/apps/cli/src/ui/SettingsPanel.tsx
@@ -6,6 +6,7 @@ import {
   type ProviderId,
 } from "@guided-review/core";
 import { Button, Input, Label, Select } from "@guided-review/ui";
+import { codingAgentLabel } from "./codingAgentLabel";
 
 interface SettingsPanelProps {
   token: string;
@@ -18,17 +19,26 @@ export function SettingsPanel({ token, onClose, onSaved }: SettingsPanelProps) {
   const [model, setModel] = useState(defaultModelFor("anthropic"));
   const [apiKey, setApiKey] = useState("");
   const [hasKey, setHasKey] = useState(false);
+  const [codingAgent, setCodingAgent] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     void fetch(`/api/settings?token=${encodeURIComponent(token)}`)
       .then((res) => res.json())
-      .then((data: { provider: ProviderId; model: string; hasKey: boolean }) => {
-        setProvider(data.provider);
-        setModel(data.model);
-        setHasKey(data.hasKey);
-      })
+      .then(
+        (data: {
+          provider: ProviderId;
+          model: string;
+          hasKey: boolean;
+          codingAgent?: string | null;
+        }) => {
+          setProvider(data.provider);
+          setModel(data.model);
+          setHasKey(data.hasKey);
+          setCodingAgent(data.codingAgent ?? null);
+        },
+      )
       .catch(() => setError("Could not load settings."));
   }, [token]);
 
@@ -57,9 +67,18 @@ export function SettingsPanel({ token, onClose, onSaved }: SettingsPanelProps) {
       <div className="w-full max-w-md rounded-lg border border-border bg-surface p-6 text-foreground">
         <h2 className="m-0 mb-4 text-lg font-semibold">AI provider</h2>
         <p className="m-0 mb-4 text-sm text-muted">
-          Keys stay on this machine in ~/.config/guided-review/config.json. Traffic goes to your
-          provider only.
+          {codingAgent
+            ? `Generating with ${codingAgentLabel(codingAgent)} on this machine. Paste a key to override. Traffic goes to your provider only.`
+            : "Keys stay on this machine in ~/.config/guided-review/config.json. Traffic goes to your provider only."}
         </p>
+        {codingAgent && (
+          <p
+            className="m-0 mb-4 rounded-md border border-border bg-surface-muted px-3 py-2 text-sm text-foreground"
+            data-testid="coding-agent-badge"
+          >
+            Coding agent: <span className="font-medium">{codingAgentLabel(codingAgent)}</span>
+          </p>
+        )}
         <div className="flex flex-col gap-3">
           <Label>
             Provider

--- a/apps/cli/src/ui/codingAgentLabel.ts
+++ b/apps/cli/src/ui/codingAgentLabel.ts
@@ -1,0 +1,14 @@
+/** Browser-safe display names for coding agents chosen at CLI start. */
+export function codingAgentLabel(id: string | null | undefined): string | null {
+  if (!id) return null;
+  switch (id) {
+    case "claude-code":
+      return "Claude Code";
+    case "codex":
+      return "Codex";
+    case "grok":
+      return "Grok";
+    default:
+      return id;
+  }
+}

--- a/apps/cli/src/ui/host.ts
+++ b/apps/cli/src/ui/host.ts
@@ -40,7 +40,15 @@ export function createLocalReviewHost(options: {
         fn();
       };
       source.onmessage = (event) => {
-        const message = JSON.parse(event.data) as AnnotateReviewStreamEvent;
+        let message: AnnotateReviewStreamEvent;
+        try {
+          message = JSON.parse(event.data) as AnnotateReviewStreamEvent;
+        } catch {
+          finish(() =>
+            handlers.onError({ message: "The local review server sent an unreadable response." }),
+          );
+          return;
+        }
         switch (message.type) {
           case "STATUS":
             handlers.onStatus?.(message.phase);

--- a/apps/extension/src/content/index.tsx
+++ b/apps/extension/src/content/index.tsx
@@ -282,8 +282,7 @@ async function onStartReview(): Promise<void> {
   const prContext = scrapePRContext(pr);
   useReviewStore.getState().open();
   useReviewStore.getState().setPRContext(prContext);
-  useReviewStore.getState().startLoading(sessionKey);
-  const streamGeneration = useReviewStore.getState().streamGeneration;
+  const streamGeneration = useReviewStore.getState().startLoading(sessionKey);
 
   try {
     const restored = await restoreSession(sessionKey);

--- a/apps/extension/src/content/overlay/Overlay.test.tsx
+++ b/apps/extension/src/content/overlay/Overlay.test.tsx
@@ -101,6 +101,7 @@ function resetStore(): void {
     streamGeneration: 0,
     sessionKey: null,
     diffViewMode: DEFAULT_DIFF_VIEW_MODE,
+    planSource: null,
     uiMode: "navigate",
     selectableLines: [],
     lineSelection: null,
@@ -161,12 +162,128 @@ describe("Overlay", () => {
       }),
     );
     seedReadyReview(0);
-    render(<Overlay />);
+    render(<Overlay allowExit={false} />);
 
     expect(screen.getByTestId("submit-review-button")).toHaveTextContent("Copy notes");
     expect(screen.getByTestId("submit-review-button")).toBeDisabled();
     expect(screen.getAllByText("Change summary").length).toBeGreaterThanOrEqual(1);
     expect(screen.queryByText("#1")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^exit$/i })).not.toBeInTheDocument();
+  });
+
+  it("does not exit a local review on Escape, but still leaves comment mode", () => {
+    setActiveReviewHost(
+      createMemoryReviewHost({
+        kind: "local",
+        exportNotes: vi.fn(),
+        submit: undefined,
+      }),
+    );
+    seedReadyReview(1);
+    render(<Overlay allowExit={false} />);
+
+    fireEvent.keyDown(window, { key: "c" });
+    expect(useReviewStore.getState().uiMode).toBe("comment");
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(useReviewStore.getState().uiMode).toBe("navigate");
+    expect(useReviewStore.getState().isOpen).toBe(true);
+    expect(screen.queryByText("Exit review?")).not.toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByText("Exit review?")).not.toBeInTheDocument();
+    expect(useReviewStore.getState().isOpen).toBe(true);
+  });
+
+  it("shows the local scope picker, commit cards, and structure trigger", () => {
+    setActiveReviewHost(
+      createMemoryReviewHost({
+        kind: "local",
+        exportNotes: vi.fn(),
+        submit: undefined,
+      }),
+    );
+    seedReadyReview(0);
+    useReviewStore.setState({
+      prContext: prContextFixture({
+        source: "local",
+        title: "feat",
+        description: "raw log",
+        descriptionHtml: "",
+        author: undefined,
+        number: undefined,
+      }),
+    });
+    const onSelectScope = vi.fn();
+    const onStructureReview = vi.fn();
+    render(
+      <Overlay
+        allowExit={false}
+        localDiff={{
+          scopes: [
+            {
+              id: "branch",
+              label: "feat vs main",
+              description: "Committed work on this branch.",
+              meta: "1 commit · 1 file · +1 −0",
+              stat: { files: 1, additions: 1, deletions: 0 },
+              empty: false,
+            },
+            {
+              id: "uncommitted",
+              label: "Uncommitted changes",
+              description: "Staged and unstaged work versus HEAD.",
+              meta: "1 file · +2 −0",
+              stat: { files: 1, additions: 2, deletions: 0 },
+              empty: false,
+            },
+            {
+              id: "commit:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              label: "Add header",
+              description: "Ada · 2026-01-02",
+              meta: "aaaaaaa · 1 file · +1 −0",
+              stat: { files: 1, additions: 1, deletions: 0 },
+              empty: false,
+            },
+          ],
+          selectedScope: "branch",
+          commits: [
+            {
+              sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              shortSha: "aaaaaaa",
+              subject: "Add header",
+              body: "",
+              author: "Ada",
+              authoredAt: "2026-01-02T00:00:00Z",
+              stat: { files: 1, additions: 1, deletions: 0 },
+            },
+          ],
+          onSelectScope,
+          onStructureReview,
+          structuring: false,
+          structured: false,
+        }}
+      />,
+    );
+
+    const picker = screen.getByRole("combobox", { name: /diff to review/i });
+    expect(picker).toBeInTheDocument();
+    expect(picker).toHaveTextContent("feat vs main");
+    expect(picker).not.toHaveTextContent("1 commit · 1 file");
+    expect(screen.queryByText(/main\s*←\s*feat/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/main\s*←\s*feature/)).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: "feat" })).toHaveClass("gr-sr-only");
+    expect(screen.getByTestId("uncommitted-card")).toHaveTextContent("Uncommitted changes");
+    expect(screen.getByTestId("commit-card")).toHaveTextContent("Add header");
+    expect(screen.getByTestId("structure-review")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^exit$/i })).not.toBeInTheDocument();
+
+    fireEvent.click(picker);
+    expect(screen.getByText("Last 5 commits")).toBeInTheDocument();
+    const commitOption = screen.getByRole("option", { name: /add header/i });
+    expect(commitOption).toBeInTheDocument();
+    expect(commitOption.querySelector(".text-diff-add")).toHaveTextContent("+1");
+    expect(commitOption.querySelector(".text-diff-del")).toHaveTextContent("−0");
   });
 
   it("shows the full layout with the PR description unit while loading", () => {

--- a/apps/extension/src/content/overlay/Overlay.tsx
+++ b/apps/extension/src/content/overlay/Overlay.tsx
@@ -26,12 +26,17 @@ import { SubmitReviewModal } from "./components/SubmitReviewModal";
 import { ReviewSubmittedModal } from "./components/ReviewSubmittedModal";
 import { BUILD_PLAN_PRIMARY, buildPhaseDetail } from "./overlayCopy";
 import { useReviewHost } from "./host";
+import type { LocalDiffControls } from "./localReview";
 
 interface OverlayProps {
   /** Invoked when the user exits so any in-flight stream can be cancelled. */
   onRequestClose?: () => void;
   /** Retry a failed annotate / review-build step. */
   onRetry?: () => void;
+  /** When false, hide Exit and ignore Esc-to-exit (local CLI). Default true. */
+  allowExit?: boolean;
+  /** CLI-only: scope picker, commit cards, opt-in structure. */
+  localDiff?: LocalDiffControls;
 }
 
 /** Polite live-region text for build / error / ready status. */
@@ -66,7 +71,7 @@ function statusAnnouncementText(
   return "";
 }
 
-export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
+export function Overlay({ onRequestClose, onRetry, allowExit = true, localDiff }: OverlayProps) {
   const host = useReviewHost();
   const isOpen = useReviewStore((s) => s.isOpen);
   const status = useReviewStore((s) => s.status);
@@ -140,6 +145,7 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
 
   /** Esc (and Exit button) — confirm before leaving the review. */
   function requestExit() {
+    if (!allowExit) return;
     confirm({
       title: "Exit review?",
       body:
@@ -325,6 +331,8 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
         titleId={titleId}
         title={dialogTitle}
         onExit={requestExit}
+        allowExit={allowExit}
+        localDiff={localDiff}
         notesCount={draftComments.length}
         onSubmitReview={() => {
           if (host.exportNotes) {
@@ -344,7 +352,14 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
           tabIndex={-1}
         >
           {isDescriptionUnit ? (
-            <DescriptionPane prContext={prContext} diff={diff} />
+            <DescriptionPane
+              prContext={prContext}
+              diff={diff}
+              commits={localDiff?.commits}
+              uncommitted={localDiff?.scopes.find(
+                (scope) => scope.id === "uncommitted" && !scope.empty,
+              )}
+            />
           ) : (
             <DiffPane
               files={resolvedFiles}
@@ -382,6 +397,10 @@ export function Overlay({ onRequestClose, onRetry }: OverlayProps) {
                 loading={showBuildingSpinner && isDescriptionUnit}
                 loadingDetail={showBuildingSpinner && isDescriptionUnit ? loadingDetail : null}
                 onRetry={status === "error" ? onRetry : undefined}
+                onStructureReview={
+                  localDiff && !localDiff.structured ? localDiff.onStructureReview : undefined
+                }
+                structured={localDiff?.structured}
               />
             </div>
           </div>

--- a/apps/extension/src/content/overlay/components/ConnectProviderPrompt.tsx
+++ b/apps/extension/src/content/overlay/components/ConnectProviderPrompt.tsx
@@ -123,8 +123,9 @@ export function ConnectProviderPrompt() {
       <h2 className="m-0 text-lg font-semibold text-foreground">Connect an AI provider</h2>
 
       <p className="m-0 text-base leading-relaxed text-muted">
-        You&rsquo;re walking this PR file by file. Connect Claude, OpenAI, or Grok and Guided Review
-        will cluster related changes into review units — you still read the code.
+        {host.kind === "local"
+          ? "You're walking this change file by file. Connect Claude, OpenAI, or Grok and Guided Review will cluster related changes into review units — you still read the code."
+          : "You're walking this PR file by file. Connect Claude, OpenAI, or Grok and Guided Review will cluster related changes into review units — you still read the code."}
       </p>
 
       <div className="flex flex-col items-center gap-2">

--- a/apps/extension/src/content/overlay/components/ContextPanel.test.tsx
+++ b/apps/extension/src/content/overlay/components/ContextPanel.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createGitHubReviewHost } from "@extension/content/githubHost";
-import { setActiveReviewHost } from "../host";
+import { createMemoryReviewHost, setActiveReviewHost } from "../host";
 import { ContextPanel } from "./ContextPanel";
 
 beforeEach(() => {
@@ -101,5 +101,69 @@ describe("ContextPanel needs-provider state", () => {
     expect(screen.getByTestId("connect-provider-prompt")).toBeInTheDocument();
     expect(screen.queryByTestId("context-panel-error")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /^retry$/i })).not.toBeInTheDocument();
+  });
+});
+
+describe("ContextPanel structure trigger", () => {
+  it("offers Structure with AI on the local summary card", () => {
+    setActiveReviewHost(
+      createMemoryReviewHost({
+        kind: "local",
+        exportNotes: vi.fn(),
+        submit: undefined,
+      }),
+    );
+    const onStructureReview = vi.fn();
+    render(
+      <ContextPanel unit={null} hasTitle hasDescription onStructureReview={onStructureReview} />,
+    );
+
+    expect(screen.getByText(/one unit per file until you structure it/i)).toBeInTheDocument();
+    screen.getByTestId("structure-review").click();
+    expect(onStructureReview).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the trigger after the review is structured", () => {
+    setActiveReviewHost(
+      createMemoryReviewHost({
+        kind: "local",
+        exportNotes: vi.fn(),
+        submit: undefined,
+      }),
+    );
+    render(
+      <ContextPanel unit={null} hasTitle hasDescription onStructureReview={vi.fn()} structured />,
+    );
+    expect(screen.queryByTestId("structure-review")).not.toBeInTheDocument();
+  });
+
+  it("shows structure prompt and shortcuts on empty-context file units", () => {
+    setActiveReviewHost(
+      createMemoryReviewHost({
+        kind: "local",
+        exportNotes: vi.fn(),
+        submit: undefined,
+      }),
+    );
+    const onStructureReview = vi.fn();
+    render(
+      <ContextPanel
+        unit={{
+          id: "file-0-src/foo.ts",
+          title: "src/foo.ts",
+          kind: "change",
+          context: "",
+          files: [{ fileId: "src/foo.ts", hunkIds: [], role: "core_logic" }],
+        }}
+        hasTitle
+        hasDescription
+        onStructureReview={onStructureReview}
+      />,
+    );
+
+    expect(screen.getByText(/one unit per file until you structure it/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/keyboard shortcuts/i)).toBeInTheDocument();
+    screen.getByTestId("structure-review").click();
+    expect(onStructureReview).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/extension/src/content/overlay/components/ContextPanel.tsx
+++ b/apps/extension/src/content/overlay/components/ContextPanel.tsx
@@ -6,6 +6,7 @@ import {
   BUILD_PLAN_PRIMARY,
   missingMetadataHint,
   PR_DESCRIPTION_HINT,
+  STRUCTURE_REVIEW_HINT,
 } from "@extension/content/overlay/overlayCopy";
 import { useReviewHost } from "../host";
 
@@ -24,11 +25,16 @@ interface ContextPanelProps {
   loadingDetail?: string | null;
   /** Retry the failed API / review build step. */
   onRetry?: () => void;
+  /** Local: start the opt-in annotation stream from the Change summary card. */
+  onStructureReview?: () => void;
+  /** Local: an AI plan is already in place for the current scope. */
+  structured?: boolean;
 }
 
 /**
  * Right-pane copy for the active unit. Branch precedence:
- * needsProvider (no AI context yet) → error → description unit → unit context.
+ * needsProvider (no AI context yet) → error → summary chrome (description or
+ * empty-context file units) → unit context.
  */
 export function ContextPanel({
   unit,
@@ -39,6 +45,8 @@ export function ContextPanel({
   loading,
   loadingDetail,
   onRetry,
+  onStructureReview,
+  structured = false,
 }: ContextPanelProps) {
   const host = useReviewHost();
   // Takes precedence over `error`: a missing key is a setup step, not a failure.
@@ -95,7 +103,10 @@ export function ContextPanel({
     );
   }
 
-  if (!unit) {
+  // Change summary (null unit) and file-mode units (empty context) share the
+  // same chrome: structure CTA when available, otherwise the summary hint,
+  // plus keyboard shortcuts. AI units always have real commentary.
+  if (!unit || !unit.context.trim()) {
     const hint =
       hasTitle && hasDescription && host.kind === "github"
         ? PR_DESCRIPTION_HINT
@@ -104,8 +115,15 @@ export function ContextPanel({
     return (
       <div className="rounded-none border-0 bg-transparent px-0 py-0.5 pb-1">
         <div className="text-lg leading-[1.7] text-foreground" data-testid="context-panel-body">
-          {hint}
+          {onStructureReview && !structured ? STRUCTURE_REVIEW_HINT : hint}
         </div>
+        {onStructureReview && !structured && !loading ? (
+          <div className="mt-4">
+            <Button size="sm" onClick={onStructureReview} data-testid="structure-review">
+              Structure with AI
+            </Button>
+          </div>
+        ) : null}
         {loading ? (
           <div
             className="mt-4 flex items-center gap-2.5 border-t border-border-strong pt-3"
@@ -127,7 +145,7 @@ export function ContextPanel({
             </div>
           </div>
         ) : (
-          <KeyboardShortcuts />
+          <KeyboardShortcuts allowExit={host.kind !== "local"} />
         )}
       </div>
     );

--- a/apps/extension/src/content/overlay/components/DescriptionPane.test.tsx
+++ b/apps/extension/src/content/overlay/components/DescriptionPane.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 import type { ParsedDiff, PRContext } from "@extension/lib/types";
 import { createGitHubReviewHost } from "@extension/content/githubHost";
-import { setActiveReviewHost } from "../host";
+import { createMemoryReviewHost, setActiveReviewHost } from "../host";
 import { DescriptionPane } from "./DescriptionPane";
 
 beforeEach(() => {
@@ -132,5 +132,89 @@ describe("DescriptionPane", () => {
   it("omits the summary when the diff has no files", () => {
     render(<DescriptionPane prContext={prContext()} diff={{ files: [] }} />);
     expect(screen.queryByLabelText(/diff summary/i)).not.toBeInTheDocument();
+  });
+
+  it("renders commit cards for a local review instead of the raw log", () => {
+    setActiveReviewHost(
+      createMemoryReviewHost({
+        kind: "local",
+        exportNotes: vi.fn(),
+        submit: undefined,
+      }),
+    );
+    render(
+      <DescriptionPane
+        prContext={prContext({
+          source: "local",
+          title: "feat",
+          description: "raw log should not show",
+          descriptionHtml: "",
+        })}
+        diff={diffFixture()}
+        commits={[
+          {
+            sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            shortSha: "aaaaaaa",
+            subject: "Add the overlay header",
+            body: "Why we did it.",
+            author: "Ada",
+            authoredAt: "2026-01-02T10:00:00Z",
+            stat: { files: 1, additions: 1915, deletions: 262 },
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId("commit-list")).toBeInTheDocument();
+    expect(screen.getByText("Add the overlay header")).toBeInTheDocument();
+    expect(screen.getByText("aaaaaaa")).toBeInTheDocument();
+    expect(screen.getByText("+1915")).toHaveClass("text-diff-add");
+    expect(screen.getByText("−262")).toHaveClass("text-diff-del");
+    expect(screen.getByText("Why we did it.")).toBeInTheDocument();
+    expect(screen.queryByText("raw log should not show")).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/diff summary/i)).toBeInTheDocument();
+  });
+
+  it("shows an uncommitted card above commits and keeps only the last 5 commits", () => {
+    setActiveReviewHost(
+      createMemoryReviewHost({
+        kind: "local",
+        exportNotes: vi.fn(),
+        submit: undefined,
+      }),
+    );
+    const commits = Array.from({ length: 6 }, (_, i) => ({
+      sha: `${i}`.repeat(40),
+      shortSha: `${i}`.repeat(7),
+      subject: `Commit ${i}`,
+      body: "",
+      author: "Ada",
+      authoredAt: "2026-01-02T10:00:00Z",
+    }));
+    render(
+      <DescriptionPane
+        prContext={prContext({
+          source: "local",
+          title: "feat",
+          descriptionHtml: "",
+        })}
+        diff={diffFixture()}
+        commits={commits}
+        uncommitted={{
+          id: "uncommitted",
+          label: "Uncommitted changes",
+          description: "Staged and unstaged work versus HEAD.",
+          meta: "1 file · +2 −0",
+          stat: { files: 1, additions: 2, deletions: 0 },
+          empty: false,
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("uncommitted-card")).toHaveTextContent("Uncommitted changes");
+    expect(screen.getByTestId("uncommitted-card")).toHaveTextContent("1 file · +2 −0");
+    expect(screen.getAllByTestId("commit-card")).toHaveLength(5);
+    expect(screen.getByText("Commit 0")).toBeInTheDocument();
+    expect(screen.queryByText("Commit 5")).not.toBeInTheDocument();
   });
 });

--- a/apps/extension/src/content/overlay/components/DescriptionPane.tsx
+++ b/apps/extension/src/content/overlay/components/DescriptionPane.tsx
@@ -5,11 +5,20 @@ import { cn } from "@guided-review/ui";
 import { missingMetadataHint } from "@extension/content/overlay/overlayCopy";
 import { summaryUnitTitle } from "@extension/content/overlay/store";
 import { useReviewHost } from "@extension/content/overlay/host";
+import {
+  MAX_RECENT_COMMITS,
+  type LocalCommitCard,
+  type LocalDiffScopeOption,
+} from "@extension/content/overlay/localReview";
+import { DiffStatCounts } from "./DiffStatCounts";
 import { MiddleEllipsisText } from "./MiddleEllipsisText";
 
 interface DescriptionPaneProps {
   prContext: ReviewContext | null;
   diff: ParsedDiff | null;
+  commits?: LocalCommitCard[];
+  /** Non-empty uncommitted scope, shown as a card above recent commits. */
+  uncommitted?: LocalDiffScopeOption;
 }
 
 function hasNonEmpty(value: string | undefined | null): boolean {
@@ -36,12 +45,15 @@ const STATUS_BADGE_CLASS: Record<FileChangeStatus, string> = {
  * state when the PR has no description (and notes a missing title too).
  * When a parsed diff is available, also shows a summary of file changes.
  */
-export function DescriptionPane({ prContext, diff }: DescriptionPaneProps) {
+export function DescriptionPane({ prContext, diff, commits, uncommitted }: DescriptionPaneProps) {
   const host = useReviewHost();
   const description = prContext?.description ?? "";
   const descriptionHtml = prContext?.descriptionHtml ?? "";
   const hasTitle = hasNonEmpty(prContext?.title);
   const summary = diff && diff.files.length > 0 ? summarizeDiff(diff) : null;
+  const recentCommits = commits?.slice(0, MAX_RECENT_COMMITS) ?? [];
+  const showUncommitted = Boolean(uncommitted && !uncommitted.empty);
+  const showCommitCards = host.kind === "local" && (recentCommits.length > 0 || showUncommitted);
 
   return (
     <div
@@ -57,12 +69,19 @@ export function DescriptionPane({ prContext, diff }: DescriptionPaneProps) {
         <h2 className="mb-5 text-[1.375rem] font-semibold leading-snug tracking-[-0.01em] text-foreground">
           {summaryUnitTitle(host.kind)}
         </h2>
-        {descriptionHtml ? (
+        {showCommitCards ? (
+          <ol className="m-0 flex list-none flex-col gap-2.5 p-0" data-testid="commit-list">
+            {showUncommitted && uncommitted && <UncommittedCard scope={uncommitted} />}
+            {recentCommits.map((commit) => (
+              <CommitCard key={commit.sha} commit={commit} />
+            ))}
+          </ol>
+        ) : descriptionHtml ? (
           <div
             className="markdown-body text-[0.9375rem] leading-[1.7] break-words text-foreground"
             dangerouslySetInnerHTML={{ __html: descriptionHtml }}
           />
-        ) : description ? (
+        ) : description && host.kind !== "local" ? (
           <div className="text-[0.9375rem] leading-[1.7] break-words whitespace-pre-wrap text-foreground">
             {description}
           </div>
@@ -97,6 +116,72 @@ export function DescriptionPane({ prContext, diff }: DescriptionPaneProps) {
         </section>
       )}
     </div>
+  );
+}
+
+function formatCommitDate(iso: string): string {
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) return iso;
+  return parsed.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function UncommittedCard({ scope }: { scope: LocalDiffScopeOption }) {
+  return (
+    <li
+      className="rounded-lg border border-border bg-background px-3.5 py-3"
+      data-testid="uncommitted-card"
+    >
+      <h3 className="m-0 text-[0.9375rem] font-semibold leading-snug text-foreground">
+        {scope.label}
+      </h3>
+      {scope.stat && scope.stat.files > 0 ? (
+        <p className="m-0 mt-1 text-sm">
+          <DiffStatCounts {...scope.stat} />
+        </p>
+      ) : scope.meta ? (
+        <p className="m-0 mt-1 text-sm text-muted">{scope.meta}</p>
+      ) : null}
+      {scope.description ? (
+        <p className="m-0 mt-2 text-sm leading-relaxed text-foreground">{scope.description}</p>
+      ) : null}
+    </li>
+  );
+}
+
+function CommitCard({ commit }: { commit: LocalCommitCard }) {
+  return (
+    <li
+      className="rounded-lg border border-border bg-background px-3.5 py-3"
+      data-testid="commit-card"
+    >
+      <div className="flex items-baseline justify-between gap-3">
+        <h3 className="m-0 text-[0.9375rem] font-semibold leading-snug text-foreground">
+          {commit.subject}
+        </h3>
+        <span className="shrink-0 font-mono text-xs text-muted">{commit.shortSha}</span>
+      </div>
+      <p className="m-0 mt-1 flex items-baseline justify-between gap-3 text-sm text-muted">
+        <span>
+          {[commit.author, formatCommitDate(commit.authoredAt)].filter(Boolean).join(" · ")}
+        </span>
+        {commit.stat && commit.stat.files > 0 ? (
+          <DiffStatCounts
+            additions={commit.stat.additions}
+            deletions={commit.stat.deletions}
+            className="shrink-0"
+          />
+        ) : null}
+      </p>
+      {commit.body ? (
+        <p className="m-0 mt-2 text-sm leading-relaxed whitespace-pre-wrap text-foreground">
+          {commit.body}
+        </p>
+      ) : null}
+    </li>
   );
 }
 

--- a/apps/extension/src/content/overlay/components/DiffStatCounts.tsx
+++ b/apps/extension/src/content/overlay/components/DiffStatCounts.tsx
@@ -1,0 +1,34 @@
+import { cn } from "@guided-review/ui";
+
+/** Green/red +/− counts, matching the Changes sidebar. */
+export function DiffStatCounts({
+  additions,
+  deletions,
+  files,
+  prefix,
+  className,
+}: {
+  additions: number;
+  deletions: number;
+  files?: number;
+  prefix?: string;
+  className?: string;
+}) {
+  const parts: string[] = [];
+  if (prefix) parts.push(prefix);
+  if (files != null && files > 0) parts.push(`${files} file${files === 1 ? "" : "s"}`);
+
+  return (
+    <span className={cn("tabular-nums", className)}>
+      {parts.map((part, i) => (
+        <span key={part}>
+          {i > 0 ? <span className="text-muted"> · </span> : null}
+          <span className="text-muted">{part}</span>
+        </span>
+      ))}
+      {parts.length > 0 ? <span className="text-muted"> · </span> : null}
+      <span className="font-medium text-diff-add">+{additions}</span>{" "}
+      <span className="font-medium text-diff-del">−{deletions}</span>
+    </span>
+  );
+}

--- a/apps/extension/src/content/overlay/components/KeyboardShortcuts.tsx
+++ b/apps/extension/src/content/overlay/components/KeyboardShortcuts.tsx
@@ -45,6 +45,12 @@ const SHORTCUTS: readonly ShortcutRow[] = [
   { keys: ["Esc"], join: "none", description: "Exit comment mode / exit review" },
 ];
 
+const LOCAL_SHORTCUTS: readonly ShortcutRow[] = SHORTCUTS.map((row) =>
+  "keys" in row && row.keys[0] === "Esc"
+    ? { keys: ["Esc"], join: "none" as const, description: "Exit comment mode" }
+    : row,
+);
+
 function ShortcutRowKeys({ row }: { row: ShortcutRow }) {
   if ("chordWithAlternatives" in row) {
     const { modifier, alternatives } = row.chordWithAlternatives;
@@ -63,7 +69,8 @@ function ShortcutRowKeys({ row }: { row: ShortcutRow }) {
   return <ShortcutKeys keys={row.keys} join={row.join} />;
 }
 
-export function KeyboardShortcuts() {
+export function KeyboardShortcuts({ allowExit = true }: { allowExit?: boolean }) {
+  const rows = allowExit ? SHORTCUTS : LOCAL_SHORTCUTS;
   return (
     <section
       className="mt-4 border-t border-border-strong pt-3"
@@ -76,7 +83,7 @@ export function KeyboardShortcuts() {
         Keyboard Shortcuts
       </h2>
       <ul className="m-0 flex list-none flex-col gap-2 p-0">
-        {SHORTCUTS.map((row) => (
+        {rows.map((row) => (
           <li key={row.description} className="flex items-center gap-3 text-base text-muted">
             <span className="inline-flex min-w-[72px] shrink-0 items-center gap-1">
               <ShortcutRowKeys row={row} />

--- a/apps/extension/src/content/overlay/components/ProgressHeader.tsx
+++ b/apps/extension/src/content/overlay/components/ProgressHeader.tsx
@@ -1,8 +1,16 @@
 import type { ParsedDiff } from "@extension/lib/types";
 import type { ReviewContext } from "@guided-review/core";
 import { summarizeDiff } from "@guided-review/core";
-import { Kbd } from "@guided-review/ui";
+import { Kbd, Select } from "@guided-review/ui";
 import { useReviewHost } from "../host";
+import {
+  isCommitScopeId,
+  limitCommitScopes,
+  RECENT_COMMITS_GROUP,
+  type LocalDiffControls,
+  type LocalDiffScopeOption,
+} from "../localReview";
+import { DiffStatCounts } from "./DiffStatCounts";
 import { ModEnterChord } from "./ShortcutKeys";
 
 interface ProgressHeaderProps {
@@ -13,14 +21,38 @@ interface ProgressHeaderProps {
   /** Accessible / visible title text. */
   title: string;
   onExit: () => void;
+  /** When false, hide Exit (local CLI — the process owns the window). */
+  allowExit?: boolean;
   /** Opens the Submit Review modal or copies local notes. */
   onSubmitReview: () => void;
   /** When set, the primary action is copy-notes (no GitHub submit). */
   notesCount?: number;
+  localDiff?: LocalDiffControls;
 }
 
 const headerBtn =
   "inline-flex cursor-pointer items-center gap-1.5 rounded-md border px-3 py-1.5 text-base font-medium";
+
+function scopeMetaPrefix(scope: LocalDiffScopeOption): string | undefined {
+  const parts = scope.meta.split(" · ");
+  return parts.length >= 3 ? parts.slice(0, -2).join(" · ") : undefined;
+}
+
+function ScopeMeta({ scope }: { scope: LocalDiffScopeOption }) {
+  const stat = scope.stat;
+  if (!stat || stat.files === 0) {
+    return <span className="truncate font-mono text-xs text-muted">{scope.meta}</span>;
+  }
+  return (
+    <DiffStatCounts
+      prefix={scopeMetaPrefix(scope)}
+      files={stat.files}
+      additions={stat.additions}
+      deletions={stat.deletions}
+      className="truncate font-mono text-xs"
+    />
+  );
+}
 
 export function ProgressHeader({
   prContext,
@@ -28,8 +60,10 @@ export function ProgressHeader({
   titleId,
   title,
   onExit,
+  allowExit = true,
   onSubmitReview,
   notesCount,
+  localDiff,
 }: ProgressHeaderProps) {
   const host = useReviewHost();
   const stats = diff ? summarizeDiff(diff) : null;
@@ -37,6 +71,21 @@ export function ProgressHeader({
   const showPrNumber = host.kind === "github" && prContext?.number != null;
   const primaryIsExport = !host.submit && Boolean(host.exportNotes);
   const primaryDisabled = primaryIsExport && (notesCount ?? 0) === 0;
+  const isLocal = host.kind === "local";
+  const scopeOptions = (localDiff ? limitCommitScopes(localDiff.scopes) : []).map((scope) => ({
+    value: scope.id,
+    label: scope.label,
+    disabled: scope.empty,
+    group: isCommitScopeId(scope.id) ? RECENT_COMMITS_GROUP : undefined,
+    trigger: () => <span className="truncate">{scope.label}</span>,
+    content: () => (
+      <span className="flex min-w-0 flex-col gap-0.5">
+        <span className="truncate">{scope.label}</span>
+        <span className="truncate text-xs text-muted">{scope.description}</span>
+        <ScopeMeta scope={scope} />
+      </span>
+    ),
+  }));
 
   return (
     <header className="flex shrink-0 flex-col gap-1.5 border-b border-border bg-background px-5 py-3.5">
@@ -50,33 +99,60 @@ export function ProgressHeader({
             height={16}
             aria-hidden="true"
           />
-          <div className="flex min-w-0 flex-col gap-1">
-            <div className="flex min-w-0 items-baseline gap-2">
-              <h1 id={titleId} className="m-0 truncate text-lg font-semibold leading-snug">
+          {isLocal ? (
+            <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2.5 text-sm text-muted">
+              <h1 id={titleId} className="gr-sr-only">
                 {title}
               </h1>
-              {showPrNumber && (
-                <span className="shrink-0 text-base text-muted">#{prContext!.number}</span>
+              {localDiff && scopeOptions.length > 0 && (
+                <Select
+                  aria-label="Diff to review"
+                  className="w-auto min-w-[10rem] max-w-[16rem]"
+                  menuClassName="min-w-[20rem] max-w-[24rem]"
+                  value={localDiff.selectedScope}
+                  options={scopeOptions}
+                  disabled={localDiff.scopeBusy}
+                  onChange={localDiff.onSelectScope}
+                />
+              )}
+              {stats && (
+                <span>
+                  {stats.files} file{stats.files === 1 ? "" : "s"} changed
+                  <span className="ml-1 text-diff-add"> +{stats.additions}</span>
+                  <span className="ml-1 text-diff-del"> −{stats.deletions}</span>
+                </span>
               )}
             </div>
-            {prContext && (prContext.author || prContext.baseRef || prContext.headRef || stats) && (
-              <div className="flex items-center gap-2.5 text-sm text-muted">
-                {prContext.author && <span>@{prContext.author}</span>}
-                {(prContext.baseRef || prContext.headRef) && (
-                  <span className="inline-block rounded-full border border-border bg-surface px-2.5 py-px font-mono text-xs text-foreground">
-                    {prContext.baseRef || "?"} ← {prContext.headRef || "?"}
-                  </span>
-                )}
-                {stats && (
-                  <span>
-                    {stats.files} file{stats.files === 1 ? "" : "s"} changed
-                    <span className="ml-1 text-diff-add"> +{stats.additions}</span>
-                    <span className="ml-1 text-diff-del"> −{stats.deletions}</span>
-                  </span>
+          ) : (
+            <div className="flex min-w-0 flex-col gap-1">
+              <div className="flex min-w-0 items-baseline gap-2">
+                <h1 id={titleId} className="m-0 truncate text-lg font-semibold leading-snug">
+                  {title}
+                </h1>
+                {showPrNumber && (
+                  <span className="shrink-0 text-base text-muted">#{prContext!.number}</span>
                 )}
               </div>
-            )}
-          </div>
+              {prContext &&
+                (prContext.author || prContext.baseRef || prContext.headRef || stats) && (
+                  <div className="flex flex-wrap items-center gap-2.5 text-sm text-muted">
+                    {prContext.author && <span>@{prContext.author}</span>}
+                    {(prContext.baseRef || prContext.headRef) && (
+                      <span className="inline-block rounded-full border border-border bg-surface px-2.5 py-px font-mono text-xs text-foreground">
+                        {prContext.baseRef || "?"} ← {prContext.headRef || "?"}
+                      </span>
+                    )}
+                    {stats && (
+                      <span>
+                        {stats.files} file{stats.files === 1 ? "" : "s"} changed
+                        <span className="ml-1 text-diff-add"> +{stats.additions}</span>
+                        <span className="ml-1 text-diff-del"> −{stats.deletions}</span>
+                      </span>
+                    )}
+                  </div>
+                )}
+            </div>
+          )}
         </div>
         <div className="flex shrink-0 items-center gap-3">
           <button
@@ -89,14 +165,16 @@ export function ProgressHeader({
             {primaryIsExport ? "Copy notes" : "Submit Review"}
             <ModEnterChord />
           </button>
-          <button
-            type="button"
-            className={`${headerBtn} gap-2 border-border bg-surface text-foreground hover:bg-surface-muted`}
-            onClick={onExit}
-          >
-            Exit
-            <Kbd>Esc</Kbd>
-          </button>
+          {allowExit && (
+            <button
+              type="button"
+              className={`${headerBtn} gap-2 border-border bg-surface text-foreground hover:bg-surface-muted`}
+              onClick={onExit}
+            >
+              Exit
+              <Kbd>Esc</Kbd>
+            </button>
+          )}
         </div>
       </div>
     </header>

--- a/apps/extension/src/content/overlay/localReview.ts
+++ b/apps/extension/src/content/overlay/localReview.ts
@@ -1,0 +1,59 @@
+/** Individual commit scopes and the Change summary list. */
+export const MAX_RECENT_COMMITS = 5;
+
+export const RECENT_COMMITS_GROUP = "Last 5 commits";
+
+const COMMIT_SCOPE_PREFIX = "commit:";
+
+export function isCommitScopeId(id: string): boolean {
+  return id.startsWith(COMMIT_SCOPE_PREFIX);
+}
+
+/** Keep working-tree scopes, then at most the last N commit scopes. */
+export function limitCommitScopes<T extends { id: string }>(scopes: T[]): T[] {
+  let commits = 0;
+  return scopes.filter((scope) => {
+    if (!isCommitScopeId(scope.id)) return true;
+    if (commits >= MAX_RECENT_COMMITS) return false;
+    commits += 1;
+    return true;
+  });
+}
+
+export interface DiffStat {
+  files: number;
+  additions: number;
+  deletions: number;
+}
+
+/** Structured commit shown as a card in the local Change summary. */
+export interface LocalCommitCard {
+  sha: string;
+  shortSha: string;
+  subject: string;
+  body: string;
+  author: string;
+  authoredAt: string;
+  stat?: DiffStat;
+}
+
+export interface LocalDiffScopeOption {
+  id: string;
+  label: string;
+  description: string;
+  meta: string;
+  stat?: DiffStat;
+  empty: boolean;
+}
+
+/** CLI-only controls passed into the shared overlay. */
+export interface LocalDiffControls {
+  scopes: LocalDiffScopeOption[];
+  selectedScope: string;
+  commits: LocalCommitCard[];
+  onSelectScope: (id: string) => void;
+  onStructureReview: () => void;
+  structuring: boolean;
+  structured: boolean;
+  scopeBusy?: boolean;
+}

--- a/apps/extension/src/content/overlay/overlayCopy.ts
+++ b/apps/extension/src/content/overlay/overlayCopy.ts
@@ -7,6 +7,10 @@ export const BUILD_PLAN_PRIMARY = "Building a review plan";
 export const PR_DESCRIPTION_HINT =
   "Author's summary of intent. Start here, then step through the planned units.";
 
+/** Right-pane copy on the local Change summary before an AI plan is requested. */
+export const STRUCTURE_REVIEW_HINT =
+  "One unit per file until you structure it. AI groups files and adds context — it does not review for you.";
+
 /** Subtext for the active pipeline phase. */
 export function buildPhaseDetail(phase: BuildPhase, providerLabel: string | null): string {
   switch (phase) {
@@ -38,12 +42,12 @@ export function missingMetadataHint(
       return "No branch summary. Intent will be inferred from the diff.";
     }
     if (!hasDescription) {
-      return "No commit log. Intent will be inferred from the branch name and diff.";
+      return "No commits on this branch. Intent will be inferred from the branch name and diff.";
     }
     if (!hasTitle) {
-      return "No branch name. Intent will be inferred from the commit log and diff.";
+      return "No branch name. Intent will be inferred from the commits and diff.";
     }
-    return "Commit log and dirty-tree notes. Start here, then step through the planned units.";
+    return "Commits on this branch. Start here, then step through the files.";
   }
   if (!hasTitle && !hasDescription) {
     return "No PR title or description. Intent will be inferred from the diff.";

--- a/apps/extension/src/content/overlay/store.test.ts
+++ b/apps/extension/src/content/overlay/store.test.ts
@@ -54,6 +54,7 @@ function resetStore(): void {
     streamGeneration: 0,
     sessionKey: null,
     diffViewMode: DEFAULT_DIFF_VIEW_MODE,
+    planSource: null,
     uiMode: "navigate",
     selectableLines: [],
     lineSelection: null,
@@ -114,7 +115,7 @@ describe("useReviewStore", () => {
       buildPhase: "tokens_streaming",
       providerLabel: "OpenAI",
     });
-    useReviewStore.getState().startLoading(SESSION_KEY);
+    const generation = useReviewStore.getState().startLoading(SESSION_KEY);
     const state = useReviewStore.getState();
     expect(state.status).toBe("loading");
     expect(state.error).toBeNull();
@@ -124,6 +125,27 @@ describe("useReviewStore", () => {
     expect(state.sessionKey).toBe(SESSION_KEY);
     expect(state.buildPhase).toBe("extracting_diff");
     expect(state.providerLabel).toBeNull();
+    expect(generation).toBe(state.streamGeneration);
+    expect(generation).toBeGreaterThan(0);
+  });
+
+  it("bootReady installs a file plan without loading or persisting", async () => {
+    resetStore();
+    const generation = useReviewStore.getState().bootReady({
+      sessionKey: SESSION_KEY,
+      diff: diffFixture(),
+      plan: planFixture(2),
+    });
+    const state = useReviewStore.getState();
+    expect(state.status).toBe("ready");
+    expect(state.planSource).toBe("files");
+    expect(state.buildPhase).toBeNull();
+    expect(state.sessionKey).toBe(SESSION_KEY);
+    expect(state.plan?.units).toHaveLength(2);
+    expect(generation).toBe(state.streamGeneration);
+
+    await persistSession();
+    expect(await chrome.storage.session.get(STORAGE_KEY)).toEqual({});
   });
 
   it("setDiff stores the diff and advances buildPhase to processing", () => {
@@ -137,6 +159,23 @@ describe("useReviewStore", () => {
     expect(state.diff).toBe(diff);
     expect(state.plan).toBeNull();
     expect(state.buildPhase).toBe("processing_diff");
+  });
+
+  it("stream updates must use startLoading's return value, not a prior getState() snapshot", () => {
+    resetStore();
+    const snapshot = useReviewStore.getState();
+    const generation = snapshot.startLoading(SESSION_KEY);
+    expect(snapshot.streamGeneration).not.toBe(generation);
+
+    useReviewStore.getState().beginStreaming(generation);
+    const unit = planFixture(1).units[0];
+    useReviewStore.getState().appendUnit(unit, generation);
+    expect(useReviewStore.getState().plan?.units).toHaveLength(1);
+
+    useReviewStore
+      .getState()
+      .appendUnit({ ...unit, id: "stale-snapshot" }, snapshot.streamGeneration);
+    expect(useReviewStore.getState().plan?.units).toHaveLength(1);
   });
 
   it("beginStreaming and appendUnit grow the plan while streaming", () => {

--- a/apps/extension/src/content/overlay/store.ts
+++ b/apps/extension/src/content/overlay/store.ts
@@ -17,6 +17,9 @@ import { getActiveReviewHost } from "./host";
 
 export type ReviewStatus = "idle" | "loading" | "streaming" | "ready" | "error";
 
+/** How the current plan was produced. File plans are cheap and must not be persisted. */
+export type PlanSource = "files" | "ai";
+
 /**
  * Fine-grained progress while the review plan is being built (diff fetch →
  * provider stream). Orthogonal to coarse `status`; cleared when ready/error.
@@ -115,6 +118,8 @@ interface ReviewState {
   sessionKey: string | null;
   /** Unified vs side-by-side code view (UI preference, not session data). */
   diffViewMode: DiffViewMode;
+  /** `null` until a plan is installed. File plans are not persisted. */
+  planSource: PlanSource | null;
 
   /** navigate = unit walkthrough; comment = line selection for drafts. */
   uiMode: UiMode;
@@ -126,7 +131,12 @@ interface ReviewState {
 
   open: () => void;
   close: () => void;
-  startLoading: (sessionKey: string) => void;
+  startLoading: (sessionKey: string) => number;
+  /**
+   * Open a walkthrough on an already-built file plan without a loading flash
+   * or an annotation stream. Bumps streamGeneration so a late SSE is ignored.
+   */
+  bootReady: (args: { sessionKey: string; diff: ParsedDiff; plan: ReviewPlan }) => number;
   setPRContext: (prContext: ReviewContext) => void;
   setDiff: (diff: ParsedDiff) => void;
   setBuildPhase: (phase: BuildPhase, generation?: number) => void;
@@ -196,6 +206,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   streamGeneration: 0,
   sessionKey: null,
   diffViewMode: DEFAULT_DIFF_VIEW_MODE,
+  planSource: null,
   uiMode: "navigate",
   selectableLines: [],
   lineSelection: null,
@@ -205,8 +216,9 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   open: () => set({ isOpen: true }),
   close: () => set({ isOpen: false, ...COMMENT_UI_RESET }),
 
-  startLoading: (sessionKey) =>
-    set((state) => ({
+  startLoading: (sessionKey) => {
+    const streamGeneration = get().streamGeneration + 1;
+    set({
       status: "loading",
       error: null,
       needsProvider: false,
@@ -216,10 +228,32 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
       plan: null,
       diff: null,
       sessionKey,
-      streamGeneration: state.streamGeneration + 1,
+      streamGeneration,
+      draftComments: [],
+      planSource: null,
+      ...COMMENT_UI_RESET,
+    });
+    return streamGeneration;
+  },
+
+  bootReady: ({ sessionKey, diff, plan }) => {
+    const streamGeneration = get().streamGeneration + 1;
+    set({
+      status: "ready",
+      error: null,
+      needsProvider: false,
+      buildPhase: null,
+      currentUnitIndex: 0,
+      plan,
+      diff,
+      sessionKey,
+      streamGeneration,
+      planSource: "files",
       draftComments: [],
       ...COMMENT_UI_RESET,
-    })),
+    });
+    return streamGeneration;
+  },
 
   setPRContext: (prContext) => set({ prContext }),
 
@@ -290,6 +324,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
         currentUnitIndex: index,
         error: null,
         buildPhase: null,
+        planSource: "ai",
       };
     });
   },
@@ -321,6 +356,7 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
       plan: buildFileReviewPlan(diff),
       currentUnitIndex: 0,
       buildPhase: null,
+      planSource: "files",
       ...COMMENT_UI_RESET,
     });
   },
@@ -546,11 +582,12 @@ export async function persistSession(): Promise<void> {
     currentUnitIndex,
     sessionKey,
     draftComments,
+    planSource,
   } = useReviewStore.getState();
   if (status !== "ready" || !diff || !plan || !sessionKey) return;
   // The file-per-unit fallback is cheap to rebuild and would otherwise be
   // resumed in place of the AI plan once a provider is configured.
-  if (needsProvider) return;
+  if (needsProvider || planSource !== "ai") return;
 
   const host = getActiveReviewHost();
   if (!host) return;
@@ -594,6 +631,7 @@ export async function restoreSession(sessionKey: string): Promise<boolean> {
     status: "ready",
     // Persisted sessions are always AI-built (see persistSession).
     needsProvider: false,
+    planSource: "ai",
     diff: saved.diff,
     plan: saved.plan,
     prContext: saved.prContext ?? null,

--- a/apps/extension/src/content/overlay/useOverlayKeyboard.ts
+++ b/apps/extension/src/content/overlay/useOverlayKeyboard.ts
@@ -84,6 +84,8 @@ function findEditableInPath(event: KeyboardEvent): HTMLElement | null {
     const tag = node.tagName;
     if (tag === "TEXTAREA" || tag === "INPUT" || tag === "SELECT") return node;
     if (node.isContentEditable) return node;
+    const role = node.getAttribute("role");
+    if (role === "combobox" || role === "listbox" || role === "option") return node;
   }
   return null;
 }
@@ -412,7 +414,20 @@ export function useOverlayKeyboard({
     // and would fire s/t/c/a/i/etc. Always stopPropagation so the page never
     // sees keys while the overlay is open. Only preventDefault when we consume
     // the key (so typing into the comment composer still inserts characters).
+    function isComboboxEvent(event: KeyboardEvent): boolean {
+      for (const node of event.composedPath()) {
+        if (!(node instanceof HTMLElement)) continue;
+        const role = node.getAttribute("role");
+        if (role === "combobox" || role === "listbox" || role === "option") return true;
+      }
+      return false;
+    }
+
     function onKeyDown(event: KeyboardEvent): void {
+      // Custom selects own their keys. Do not stopPropagation or GitHub-style
+      // capture handling — React onKeyDown on the combobox never fires otherwise.
+      if (isComboboxEvent(event)) return;
+
       event.stopPropagation();
 
       if (handleTabTrap(event)) return;

--- a/apps/web/content/help/configure-provider.mdx
+++ b/apps/web/content/help/configure-provider.mdx
@@ -46,7 +46,7 @@ Models currently listed in Options (ids can change as providers ship or retire m
 | --------- | ------------------------------------------------------------- |
 | Anthropic | Claude Opus 4.8, Opus 4.7, Sonnet 5, Sonnet 4.6, Haiku 4.5    |
 | OpenAI    | GPT-5, GPT-5 Mini, GPT-4.1, GPT-4.1 Mini, GPT-4o, o3, o4 Mini |
-| Grok      | Grok 4, Grok 3, Grok 3 Mini                                   |
+| Grok      | Grok 4.6, Grok 4.5, Grok 4, Grok 3, Grok 3 Mini               |
 
 If a stored model disappears from the catalog, Options falls back to that provider’s default.
 

--- a/apps/web/content/help/local-review.mdx
+++ b/apps/web/content/help/local-review.mdx
@@ -8,7 +8,7 @@ export const toc = [
 
 # Review local changes
 
-The Chrome extension still reviews GitHub pull requests. The CLI reviews the changes in your working tree against the main branch, using the same engine and walkthrough.
+The Chrome extension still reviews GitHub pull requests. The CLI reviews a local branch, a commit, or your working tree, using the same engine and walkthrough. It does not start an AI plan until you ask.
 
 <TocCard toc={toc} />
 
@@ -32,17 +32,28 @@ The CLI binds `127.0.0.1`, prints a tokenized URL, and opens it unless you pass 
 
 ## What it compares
 
-Default: working tree (staged + unstaged) plus untracked files (gitignore respected) versus the merge-base of `HEAD` and the default base branch.
+The header shows the current branch and the base branch. A dropdown picks the diff:
+
+- **Branch vs base** — committed work on this branch since it diverged from the base (`git diff <merge-base> HEAD`)
+- **Uncommitted** — staged and unstaged work versus `HEAD` (untracked files included unless you passed `--no-untracked`)
+- **Unstaged** — worktree versus the index only
+- **A specific commit** — that commit’s patch
+
+Default selected scope: the first non-empty of branch, uncommitted, unstaged, then the newest commit. `--staged` starts on index-only uncommitted work.
 
 Base resolution, in order: `--base` → `origin/HEAD` → `main` → `master`.
 
-Empty diff: `Nothing to review against <base>.` and exit 0. Not a git repo: an error that says what failed.
+If every scope is empty: `Nothing to review against <base>.` and exit 0. Not a git repo: an error that says what failed.
+
+The walkthrough starts one unit per file. **Structure with AI** on the Change summary card is the opt-in LLM call. It groups files and adds context — it does not review for you.
 
 ## API keys
 
-Same providers as the extension: Anthropic, OpenAI, Grok. Resolution: flags → env (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `XAI_API_KEY` or `GROK_API_KEY`) → `~/.config/guided-review/config.json`.
+Same providers as the extension: Anthropic, OpenAI, Grok.
 
-No key still walks one unit per file. The browser UI can save a key to that config file.
+Resolution, in order: `--provider` / `--model` / `--agent` and env (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `XAI_API_KEY` or `GROK_API_KEY`) → a key already saved in `~/.config/guided-review/config.json` → a coding agent already on this machine (Claude Code, Codex, or Grok). If more than one agent has a usable key, the CLI asks which to use each run (Enter keeps the last choice). The chosen agent is shown in the browser UI. It reads the agent's own store at review time and does not copy the secret into Guided Review config.
+
+No key still walks one unit per file. **Structure with AI** asks for a key. The browser UI can save one to that config file.
 
 ## Notes
 
@@ -51,5 +62,5 @@ Line comments stay in the session. There is no GitHub submit. **Copy notes** put
 ## Flags
 
 ```
-npm run review -- [dir] --base main --port 8787 --no-open --staged --no-untracked
+npm run review -- [dir] --base main --port 8787 --no-open --staged --no-untracked --agent claude-code
 ```

--- a/packages/ui/src/components/Select.test.tsx
+++ b/packages/ui/src/components/Select.test.tsx
@@ -1,8 +1,8 @@
-import { render, screen, within } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useState } from "react";
+import { createRef, useState } from "react";
 import { describe, expect, it, vi } from "vitest";
-import { Select, type SelectOption } from "./Select";
+import { Select, type SelectHandle, type SelectOption } from "./Select";
 
 const OPTIONS: SelectOption[] = [
   { value: "a", label: "Alpha" },
@@ -119,6 +119,22 @@ describe("Select", () => {
     expect(screen.getAllByRole("option")).toHaveLength(3);
   });
 
+  it("renders trailing content on the trigger before the chevron", () => {
+    render(
+      <Select
+        aria-label="Fruit"
+        value="a"
+        options={OPTIONS}
+        onChange={() => {}}
+        trailing={<span data-testid="shortcut-hint">d</span>}
+      />,
+    );
+
+    const combobox = screen.getByRole("combobox", { name: /fruit/i });
+    expect(within(combobox).getByTestId("shortcut-hint")).toHaveTextContent("d");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
   it("renders custom option content", async () => {
     const user = userEvent.setup();
     render(
@@ -143,5 +159,46 @@ describe("Select", () => {
     expect(screen.getByTestId("custom-a")).toBeInTheDocument();
     await user.click(screen.getByRole("combobox"));
     expect(within(screen.getByRole("listbox")).getByTestId("custom-a")).toBeInTheDocument();
+  });
+
+  it("focusAndOpen focuses the trigger and opens the listbox", () => {
+    const selectRef = createRef<SelectHandle>();
+    render(
+      <Select
+        aria-label="Fruit"
+        value="a"
+        options={OPTIONS}
+        onChange={() => {}}
+        selectRef={selectRef}
+      />,
+    );
+
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    act(() => {
+      selectRef.current?.focusAndOpen();
+    });
+
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("combobox")).toHaveFocus();
+  });
+
+  it("focusAndOpen is a no-op when disabled", () => {
+    const selectRef = createRef<SelectHandle>();
+    render(
+      <Select
+        aria-label="Fruit"
+        value="a"
+        options={OPTIONS}
+        onChange={() => {}}
+        selectRef={selectRef}
+        disabled
+      />,
+    );
+
+    act(() => {
+      selectRef.current?.focusAndOpen();
+    });
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/Select.tsx
+++ b/packages/ui/src/components/Select.tsx
@@ -5,12 +5,14 @@ import {
   useCallback,
   useEffect,
   useId,
+  useImperativeHandle,
   useLayoutEffect,
   useMemo,
   useRef,
   useState,
   type KeyboardEvent,
   type ReactNode,
+  type Ref,
 } from "react";
 import { cn } from "../cn";
 
@@ -34,11 +36,17 @@ export interface SelectOption<T extends string = string> {
   group?: string;
 }
 
+export type SelectHandle = {
+  /** Focus the trigger and open the list. No-op when disabled. */
+  focusAndOpen: () => void;
+};
+
 export interface SelectProps<T extends string = string> {
   id?: string;
   /** Accessible name when no visible label is associated via htmlFor. */
   "aria-labelledby"?: string;
   "aria-label"?: string;
+  "aria-keyshortcuts"?: string;
   value: T;
   options: SelectOption<T>[];
   onChange: (value: T) => void;
@@ -48,6 +56,10 @@ export interface SelectProps<T extends string = string> {
   menuClassName?: string;
   /** Placeholder when value is not in options (should be rare after normalize). */
   placeholder?: string;
+  /** Imperative handle — used so a parent keyboard layer can open the list. */
+  selectRef?: Ref<SelectHandle | null>;
+  /** Rendered on the closed trigger, before the chevron (e.g. a shortcut badge). */
+  trailing?: ReactNode;
 }
 
 function findNextEnabled(options: SelectOption[], from: number, direction: 1 | -1): number {
@@ -69,6 +81,7 @@ export function Select<T extends string = string>({
   id,
   "aria-labelledby": ariaLabelledBy,
   "aria-label": ariaLabel,
+  "aria-keyshortcuts": ariaKeyShortcuts,
   value,
   options,
   onChange,
@@ -76,6 +89,8 @@ export function Select<T extends string = string>({
   className,
   menuClassName,
   placeholder = "Select…",
+  selectRef,
+  trailing,
 }: SelectProps<T>) {
   const listboxId = useId();
   const rootRef = useRef<HTMLDivElement>(null);
@@ -105,6 +120,18 @@ export function Select<T extends string = string>({
     setHighlightIndex(selectedIndex >= 0 ? selectedIndex : findNextEnabled(options, -1, 1));
     setOpen(true);
   }, [disabled, options, selectedIndex]);
+
+  useImperativeHandle(
+    selectRef,
+    () => ({
+      focusAndOpen: () => {
+        if (disabled) return;
+        triggerRef.current?.focus();
+        openList();
+      },
+    }),
+    [disabled, openList],
+  );
 
   const selectIndex = useCallback(
     (index: number) => {
@@ -237,6 +264,7 @@ export function Select<T extends string = string>({
         aria-activedescendant={activeDescendant}
         aria-labelledby={ariaLabelledBy}
         aria-label={ariaLabel}
+        aria-keyshortcuts={ariaKeyShortcuts}
         disabled={disabled}
         className={cn(
           "flex w-full items-center gap-2 rounded-md border border-border bg-surface-raised px-2.5 py-2 text-left text-base text-foreground",
@@ -259,6 +287,7 @@ export function Select<T extends string = string>({
             <span className="text-muted">{placeholder}</span>
           )}
         </span>
+        {trailing ? <span className="shrink-0">{trailing}</span> : null}
         <svg
           aria-hidden
           className={cn(

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -14,4 +14,4 @@ export { Textarea } from "./components/Textarea";
 export { Label } from "./components/Label";
 
 export { Select } from "./components/Select";
-export type { SelectOption } from "./components/Select";
+export type { SelectHandle, SelectOption } from "./components/Select";


### PR DESCRIPTION
Part 7 of 13 in the local-review CLI stack. Base: [#82](https://github.com/nshntarora/guidedreview/pull/82).

Local overlay can pick a review scope (commits, uncommitted, structure CTA). CLI wires that UI, documents it, and lands the internals that shipped in the same stretch: Select can open on demand, shared coding-agent parse helpers, flags that require a value, apply-settings without persisting agent secrets, parallel git stats.

**Out of scope (later PRs):** scope icons and shortcuts, settings/about page, Generate Prompt.