### PR TITLE
feat(overlay): add local scope icons and keyboard shortcuts

### DIFF
--- a/apps/cli/src/ui/App.tsx
+++ b/apps/cli/src/ui/App.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { buildFileReviewPlan, getProvider, type ProviderId } from "@guided-review/core";
 import type { ReviewSessionPayload } from "../server/createServer";
 import { Overlay } from "@extension/content/overlay/Overlay";
-import { ReviewHostProvider, setActiveReviewHost } from "@extension/content/overlay/host";
+import { ReviewHostProvider } from "@extension/content/overlay/host";
 import { restoreSession, useReviewStore } from "@extension/content/overlay/store";
 import type { LocalDiffControls } from "@extension/content/overlay/localReview";
 import { createLocalReviewHost } from "./host";
@@ -35,7 +35,6 @@ export function App() {
       }),
     [token],
   );
-  setActiveReviewHost(host);
 
   const applyMeta = useCallback((session: ReviewSessionPayload) => {
     setCommits(session.commits);

--- a/apps/extension/src/content/overlay/Overlay.test.tsx
+++ b/apps/extension/src/content/overlay/Overlay.test.tsx
@@ -11,6 +11,7 @@ import * as messaging from "@extension/lib/messaging";
 import * as oauthConfig from "@extension/lib/github/oauthConfig";
 import { createGitHubReviewHost } from "@extension/content/githubHost";
 import { createMemoryReviewHost, setActiveReviewHost } from "./host";
+import type { LocalDiffControls } from "./localReview";
 
 const sampleAuth = {
   accessToken: "gho_test",
@@ -121,6 +122,78 @@ function seedReadyReview(unitIndex = 1): void {
   });
 }
 
+function localDiffFixture(overrides: Partial<LocalDiffControls> = {}): LocalDiffControls {
+  return {
+    scopes: [
+      {
+        id: "branch",
+        label: "feat vs main",
+        description: "Committed work on this branch.",
+        meta: "1 commit · 1 file · +1 −0",
+        stat: { files: 1, additions: 1, deletions: 0 },
+        empty: false,
+      },
+      {
+        id: "uncommitted",
+        label: "Uncommitted changes",
+        description: "Staged and unstaged work versus HEAD.",
+        meta: "1 file · +2 −0",
+        stat: { files: 1, additions: 2, deletions: 0 },
+        empty: false,
+      },
+      {
+        id: "commit:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        label: "Add header",
+        description: "Ada · 2026-01-02",
+        meta: "aaaaaaa · 1 file · +1 −0",
+        stat: { files: 1, additions: 1, deletions: 0 },
+        empty: false,
+      },
+    ],
+    selectedScope: "branch",
+    commits: [
+      {
+        sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        shortSha: "aaaaaaa",
+        subject: "Add header",
+        body: "",
+        author: "Ada",
+        authoredAt: "2026-01-02T00:00:00Z",
+        stat: { files: 1, additions: 1, deletions: 0 },
+      },
+    ],
+    onSelectScope: vi.fn(),
+    onStructureReview: vi.fn(),
+    structuring: false,
+    structured: false,
+    ...overrides,
+  };
+}
+
+function renderLocalOverlay(overrides: Partial<LocalDiffControls> = {}): LocalDiffControls {
+  setActiveReviewHost(
+    createMemoryReviewHost({
+      kind: "local",
+      exportNotes: vi.fn(),
+      submit: undefined,
+    }),
+  );
+  seedReadyReview(0);
+  useReviewStore.setState({
+    prContext: prContextFixture({
+      source: "local",
+      title: "feat",
+      description: "raw log",
+      descriptionHtml: "",
+      author: undefined,
+      number: undefined,
+    }),
+  });
+  const localDiff = localDiffFixture(overrides);
+  render(<Overlay allowExit={false} localDiff={localDiff} />);
+  return localDiff;
+}
+
 describe("Overlay", () => {
   beforeEach(() => {
     setActiveReviewHost(createGitHubReviewHost());
@@ -196,79 +269,12 @@ describe("Overlay", () => {
   });
 
   it("shows the local scope picker, commit cards, and structure trigger", () => {
-    setActiveReviewHost(
-      createMemoryReviewHost({
-        kind: "local",
-        exportNotes: vi.fn(),
-        submit: undefined,
-      }),
-    );
-    seedReadyReview(0);
-    useReviewStore.setState({
-      prContext: prContextFixture({
-        source: "local",
-        title: "feat",
-        description: "raw log",
-        descriptionHtml: "",
-        author: undefined,
-        number: undefined,
-      }),
-    });
-    const onSelectScope = vi.fn();
-    const onStructureReview = vi.fn();
-    render(
-      <Overlay
-        allowExit={false}
-        localDiff={{
-          scopes: [
-            {
-              id: "branch",
-              label: "feat vs main",
-              description: "Committed work on this branch.",
-              meta: "1 commit · 1 file · +1 −0",
-              stat: { files: 1, additions: 1, deletions: 0 },
-              empty: false,
-            },
-            {
-              id: "uncommitted",
-              label: "Uncommitted changes",
-              description: "Staged and unstaged work versus HEAD.",
-              meta: "1 file · +2 −0",
-              stat: { files: 1, additions: 2, deletions: 0 },
-              empty: false,
-            },
-            {
-              id: "commit:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-              label: "Add header",
-              description: "Ada · 2026-01-02",
-              meta: "aaaaaaa · 1 file · +1 −0",
-              stat: { files: 1, additions: 1, deletions: 0 },
-              empty: false,
-            },
-          ],
-          selectedScope: "branch",
-          commits: [
-            {
-              sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-              shortSha: "aaaaaaa",
-              subject: "Add header",
-              body: "",
-              author: "Ada",
-              authoredAt: "2026-01-02T00:00:00Z",
-              stat: { files: 1, additions: 1, deletions: 0 },
-            },
-          ],
-          onSelectScope,
-          onStructureReview,
-          structuring: false,
-          structured: false,
-        }}
-      />,
-    );
+    renderLocalOverlay();
 
     const picker = screen.getByRole("combobox", { name: /diff to review/i });
     expect(picker).toBeInTheDocument();
     expect(picker).toHaveTextContent("feat vs main");
+    expect(picker.querySelector("[data-slot=kbd]")).toHaveTextContent("d");
     expect(picker).not.toHaveTextContent("1 commit · 1 file");
     expect(screen.queryByText(/main\s*←\s*feat/)).not.toBeInTheDocument();
     expect(screen.queryByText(/main\s*←\s*feature/)).not.toBeInTheDocument();
@@ -284,6 +290,43 @@ describe("Overlay", () => {
     expect(commitOption).toBeInTheDocument();
     expect(commitOption.querySelector(".text-diff-add")).toHaveTextContent("+1");
     expect(commitOption.querySelector(".text-diff-del")).toHaveTextContent("−0");
+  });
+
+  describe("local review keyboard", () => {
+    it("opens the scope picker on d and structures on ⌘/Ctrl+I", () => {
+      const { onStructureReview } = renderLocalOverlay();
+
+      const picker = screen.getByRole("combobox", { name: /diff to review/i });
+      expect(picker).toHaveAttribute("aria-expanded", "false");
+
+      fireEvent.keyDown(window, { key: "i", metaKey: true });
+      expect(onStructureReview).toHaveBeenCalledTimes(1);
+      fireEvent.keyDown(window, { key: "i", ctrlKey: true });
+      expect(onStructureReview).toHaveBeenCalledTimes(2);
+
+      fireEvent.keyDown(window, { key: "d" });
+      expect(picker).toHaveAttribute("aria-expanded", "true");
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+
+    it("does not structure after the review is already structured", () => {
+      const { onStructureReview } = renderLocalOverlay({ structured: true });
+
+      expect(screen.queryByTestId("structure-review")).not.toBeInTheDocument();
+      fireEvent.keyDown(window, { key: "i", metaKey: true });
+      expect(onStructureReview).not.toHaveBeenCalled();
+    });
+
+    it("does not bind local shortcuts on a GitHub review", () => {
+      seedReadyReview(0);
+      render(<Overlay />);
+
+      expect(screen.queryByRole("combobox", { name: /diff to review/i })).not.toBeInTheDocument();
+      fireEvent.keyDown(window, { key: "d" });
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      fireEvent.keyDown(window, { key: "i", metaKey: true });
+      expect(useReviewStore.getState().isOpen).toBe(true);
+    });
   });
 
   it("shows the full layout with the PR description unit while loading", () => {

--- a/apps/extension/src/content/overlay/Overlay.tsx
+++ b/apps/extension/src/content/overlay/Overlay.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId, useMemo, useRef, useState } from "react";
+import type { SelectHandle } from "@guided-review/ui";
 import type { ReviewErrorInfo, ReviewPlan } from "@extension/lib/types";
 import {
   buildDisplayUnits,
@@ -100,6 +101,7 @@ export function Overlay({ onRequestClose, onRetry, allowExit = true, localDiff }
   const previousFocusRef = useRef<Element | null>(null);
   /** Pending `v` leader for view-mode chords (`v+u` / `v+s`). */
   const viewChordRef = useRef<ViewChordPending>(null);
+  const scopeSelectRef = useRef<SelectHandle | null>(null);
   const confirmationOpen = useConfirmationOpen();
   const titleId = useId();
 
@@ -290,6 +292,14 @@ export function Overlay({ onRequestClose, onRetry, allowExit = true, localDiff }
     openDiffSearch,
     closeDiffSearch,
     diffSearchKeyRef,
+    openScopePicker:
+      localDiff && localDiff.scopes.length > 0
+        ? () => scopeSelectRef.current?.focusAndOpen()
+        : undefined,
+    structureReview:
+      localDiff && !localDiff.structured && !localDiff.structuring
+        ? localDiff.onStructureReview
+        : undefined,
   });
 
   const statusAnnouncement = statusAnnouncementText(
@@ -333,6 +343,7 @@ export function Overlay({ onRequestClose, onRetry, allowExit = true, localDiff }
         onExit={requestExit}
         allowExit={allowExit}
         localDiff={localDiff}
+        scopeSelectRef={scopeSelectRef}
         notesCount={draftComments.length}
         onSubmitReview={() => {
           if (host.exportNotes) {

--- a/apps/extension/src/content/overlay/components/ContextPanel.tsx
+++ b/apps/extension/src/content/overlay/components/ContextPanel.tsx
@@ -2,6 +2,7 @@ import type { ReviewErrorInfo, ReviewUnit } from "@extension/lib/types";
 import { ConnectProviderPrompt } from "./ConnectProviderPrompt";
 import { KeyboardShortcuts } from "./KeyboardShortcuts";
 import { Button, Spinner } from "@guided-review/ui";
+import { ShortcutKeys } from "./ShortcutKeys";
 import {
   BUILD_PLAN_PRIMARY,
   missingMetadataHint,
@@ -119,8 +120,14 @@ export function ContextPanel({
         </div>
         {onStructureReview && !structured && !loading ? (
           <div className="mt-4">
-            <Button size="sm" onClick={onStructureReview} data-testid="structure-review">
+            <Button
+              size="sm"
+              onClick={onStructureReview}
+              data-testid="structure-review"
+              aria-keyshortcuts="Meta+I Control+I"
+            >
               Structure with AI
+              <ShortcutKeys keys={["mod", "I"]} join="chord" />
             </Button>
           </div>
         ) : null}
@@ -145,7 +152,11 @@ export function ContextPanel({
             </div>
           </div>
         ) : (
-          <KeyboardShortcuts allowExit={host.kind !== "local"} />
+          <KeyboardShortcuts
+            allowExit={host.kind !== "local"}
+            showScopePicker={host.kind === "local"}
+            showStructureReview={Boolean(onStructureReview && !structured)}
+          />
         )}
       </div>
     );

--- a/apps/extension/src/content/overlay/components/KeyboardShortcuts.tsx
+++ b/apps/extension/src/content/overlay/components/KeyboardShortcuts.tsx
@@ -51,6 +51,18 @@ const LOCAL_SHORTCUTS: readonly ShortcutRow[] = SHORTCUTS.map((row) =>
     : row,
 );
 
+const SCOPE_PICKER_SHORTCUT: ShortcutRow = {
+  keys: ["d"],
+  join: "none",
+  description: "Choose which diff to review",
+};
+
+const STRUCTURE_REVIEW_SHORTCUT: ShortcutRow = {
+  keys: ["mod", "I"],
+  join: "chord",
+  description: "Structure with AI",
+};
+
 function ShortcutRowKeys({ row }: { row: ShortcutRow }) {
   if ("chordWithAlternatives" in row) {
     const { modifier, alternatives } = row.chordWithAlternatives;
@@ -69,8 +81,20 @@ function ShortcutRowKeys({ row }: { row: ShortcutRow }) {
   return <ShortcutKeys keys={row.keys} join={row.join} />;
 }
 
-export function KeyboardShortcuts({ allowExit = true }: { allowExit?: boolean }) {
-  const rows = allowExit ? SHORTCUTS : LOCAL_SHORTCUTS;
+export function KeyboardShortcuts({
+  allowExit = true,
+  showScopePicker = false,
+  showStructureReview = false,
+}: {
+  allowExit?: boolean;
+  showScopePicker?: boolean;
+  showStructureReview?: boolean;
+}) {
+  const rows = [
+    ...(showScopePicker ? [SCOPE_PICKER_SHORTCUT] : []),
+    ...(showStructureReview ? [STRUCTURE_REVIEW_SHORTCUT] : []),
+    ...(allowExit ? SHORTCUTS : LOCAL_SHORTCUTS),
+  ];
   return (
     <section
       className="mt-4 border-t border-border-strong pt-3"

--- a/apps/extension/src/content/overlay/components/ProgressHeader.tsx
+++ b/apps/extension/src/content/overlay/components/ProgressHeader.tsx
@@ -1,7 +1,8 @@
+import type { Ref } from "react";
 import type { ParsedDiff } from "@extension/lib/types";
 import type { ReviewContext } from "@guided-review/core";
 import { summarizeDiff } from "@guided-review/core";
-import { Kbd, Select } from "@guided-review/ui";
+import { Kbd, Select, type SelectHandle } from "@guided-review/ui";
 import { useReviewHost } from "../host";
 import {
   isCommitScopeId,
@@ -11,6 +12,7 @@ import {
   type LocalDiffScopeOption,
 } from "../localReview";
 import { DiffStatCounts } from "./DiffStatCounts";
+import { ScopeIcon } from "./ScopeIcons";
 import { ModEnterChord } from "./ShortcutKeys";
 
 interface ProgressHeaderProps {
@@ -28,15 +30,11 @@ interface ProgressHeaderProps {
   /** When set, the primary action is copy-notes (no GitHub submit). */
   notesCount?: number;
   localDiff?: LocalDiffControls;
+  scopeSelectRef?: Ref<SelectHandle | null>;
 }
 
 const headerBtn =
   "inline-flex cursor-pointer items-center gap-1.5 rounded-md border px-3 py-1.5 text-base font-medium";
-
-function scopeMetaPrefix(scope: LocalDiffScopeOption): string | undefined {
-  const parts = scope.meta.split(" · ");
-  return parts.length >= 3 ? parts.slice(0, -2).join(" · ") : undefined;
-}
 
 function ScopeMeta({ scope }: { scope: LocalDiffScopeOption }) {
   const stat = scope.stat;
@@ -45,12 +43,34 @@ function ScopeMeta({ scope }: { scope: LocalDiffScopeOption }) {
   }
   return (
     <DiffStatCounts
-      prefix={scopeMetaPrefix(scope)}
+      prefix={scope.metaPrefix}
       files={stat.files}
       additions={stat.additions}
       deletions={stat.deletions}
       className="truncate font-mono text-xs"
     />
+  );
+}
+
+function ScopeTrigger({ scope }: { scope: LocalDiffScopeOption }) {
+  return (
+    <span className="flex min-w-0 items-center gap-2">
+      <ScopeIcon scope={scope} />
+      <span className="truncate">{scope.label}</span>
+    </span>
+  );
+}
+
+function ScopeOption({ scope }: { scope: LocalDiffScopeOption }) {
+  return (
+    <span className="flex min-w-0 items-start gap-2.5">
+      <ScopeIcon scope={scope} className="mt-0.5" />
+      <span className="flex min-w-0 flex-col gap-0.5">
+        <span className="truncate">{scope.label}</span>
+        <span className="truncate text-xs text-muted">{scope.description}</span>
+        <ScopeMeta scope={scope} />
+      </span>
+    </span>
   );
 }
 
@@ -64,6 +84,7 @@ export function ProgressHeader({
   onSubmitReview,
   notesCount,
   localDiff,
+  scopeSelectRef,
 }: ProgressHeaderProps) {
   const host = useReviewHost();
   const stats = diff ? summarizeDiff(diff) : null;
@@ -77,14 +98,8 @@ export function ProgressHeader({
     label: scope.label,
     disabled: scope.empty,
     group: isCommitScopeId(scope.id) ? RECENT_COMMITS_GROUP : undefined,
-    trigger: () => <span className="truncate">{scope.label}</span>,
-    content: () => (
-      <span className="flex min-w-0 flex-col gap-0.5">
-        <span className="truncate">{scope.label}</span>
-        <span className="truncate text-xs text-muted">{scope.description}</span>
-        <ScopeMeta scope={scope} />
-      </span>
-    ),
+    trigger: () => <ScopeTrigger scope={scope} />,
+    content: () => <ScopeOption scope={scope} />,
   }));
 
   return (
@@ -107,12 +122,15 @@ export function ProgressHeader({
               {localDiff && scopeOptions.length > 0 && (
                 <Select
                   aria-label="Diff to review"
+                  aria-keyshortcuts="d"
+                  selectRef={scopeSelectRef}
                   className="w-auto min-w-[10rem] max-w-[16rem]"
                   menuClassName="min-w-[20rem] max-w-[24rem]"
                   value={localDiff.selectedScope}
                   options={scopeOptions}
                   disabled={localDiff.scopeBusy}
                   onChange={localDiff.onSelectScope}
+                  trailing={<Kbd>d</Kbd>}
                 />
               )}
               {stats && (

--- a/apps/extension/src/content/overlay/components/ScopeIcons.tsx
+++ b/apps/extension/src/content/overlay/components/ScopeIcons.tsx
@@ -273,7 +273,7 @@ function CommitIcon(props: SVGProps<SVGSVGElement>) {
         width="8.25"
         height="4.35"
         rx="1.75"
-        className={INSET}
+        className={ACCENT_WASH}
         strokeWidth="1.1"
       />
       <rect
@@ -282,8 +282,8 @@ function CommitIcon(props: SVGProps<SVGSVGElement>) {
         width="5.25"
         height="1.5"
         rx="0.75"
-        className="fill-[var(--color-muted)]"
-        opacity="0.6"
+        className="fill-[var(--color-primary)]"
+        opacity="0.9"
       />
       <rect
         x="3.5"

--- a/apps/extension/src/content/overlay/components/ScopeIcons.tsx
+++ b/apps/extension/src/content/overlay/components/ScopeIcons.tsx
@@ -1,0 +1,327 @@
+import type { SVGProps } from "react";
+import { isCommitScopeId, type LocalDiffScopeOption } from "../localReview";
+
+/**
+ * Diff-scope marks for the local picker.
+ *
+ * Same canvas language as the landing-page illustrations: rounded panels,
+ * recessed chips, code bars, lime only as the accent, green/red only on
+ * added/removed lines. Dashed stroke means "not in the index."
+ */
+
+const SURFACE = "fill-[var(--color-surface-raised)] stroke-[var(--color-border)]";
+const INSET = "fill-[var(--color-background)] stroke-[var(--color-border)]";
+const ACCENT_WASH =
+  "fill-[color-mix(in_srgb,var(--color-primary)_14%,transparent)] stroke-[var(--color-primary)]";
+const ADD_WASH = "fill-[color-mix(in_srgb,var(--color-success)_20%,transparent)]";
+const DEL_WASH = "fill-[color-mix(in_srgb,var(--color-danger)_16%,transparent)]";
+
+type Kind = "branch" | "uncommitted" | "staged" | "unstaged" | "commit";
+
+export function scopeIconKind(scope: Pick<LocalDiffScopeOption, "id" | "label">): Kind {
+  if (scope.id === "branch") return "branch";
+  if (scope.id === "unstaged") return "unstaged";
+  if (scope.id === "uncommitted") {
+    return scope.label.startsWith("Staged") ? "staged" : "uncommitted";
+  }
+  if (isCommitScopeId(scope.id)) return "commit";
+  return "commit";
+}
+
+function frame(props: SVGProps<SVGSVGElement>) {
+  return {
+    viewBox: "0 0 20 20",
+    fill: "none",
+    xmlns: "http://www.w3.org/2000/svg",
+    "aria-hidden": true as const,
+    width: 20,
+    height: 20,
+    ...props,
+    className: ["size-5 shrink-0", props.className].filter(Boolean).join(" "),
+  };
+}
+
+/** `+` / `−` used on diff lines in the landing-page summaries scene. */
+function Plus({ x, y }: { x: number; y: number }) {
+  return (
+    <path
+      d={`M${x} ${y}h2.4M${x + 1.2} ${y - 1.2}v2.4`}
+      className="stroke-[var(--color-success)]"
+      strokeWidth="1.15"
+      strokeLinecap="round"
+    />
+  );
+}
+
+function Minus({ x, y }: { x: number; y: number }) {
+  return (
+    <path
+      d={`M${x} ${y}h2.4`}
+      className="stroke-[var(--color-danger)]"
+      strokeWidth="1.15"
+      strokeLinecap="round"
+    />
+  );
+}
+
+/** `{head} vs {base}` — a stack of commit cards; HEAD is the lime accent. */
+function BranchIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg {...frame(props)}>
+      <rect
+        x="2.25"
+        y="1.5"
+        width="15.5"
+        height="5.25"
+        rx="2"
+        className={ACCENT_WASH}
+        strokeWidth="1.2"
+      />
+      <rect
+        x="4.25"
+        y="3.2"
+        width="9"
+        height="1.8"
+        rx="0.9"
+        className="fill-[var(--color-primary)]"
+        opacity="0.9"
+      />
+      <rect
+        x="2.25"
+        y="7.4"
+        width="15.5"
+        height="5.25"
+        rx="2"
+        className={SURFACE}
+        strokeWidth="1.2"
+      />
+      <rect
+        x="4.25"
+        y="9.1"
+        width="7.5"
+        height="1.8"
+        rx="0.9"
+        className="fill-[var(--color-muted)]"
+        opacity="0.45"
+      />
+      <rect
+        x="2.25"
+        y="13.25"
+        width="15.5"
+        height="5.25"
+        rx="2"
+        className={INSET}
+        strokeWidth="1.2"
+      />
+      <rect
+        x="4.25"
+        y="14.95"
+        width="6"
+        height="1.8"
+        rx="0.9"
+        className="fill-[var(--color-muted)]"
+        opacity="0.3"
+      />
+    </svg>
+  );
+}
+
+/** Working tree vs HEAD — a solid hunk with add, context, and delete. */
+function UncommittedIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg {...frame(props)}>
+      <rect
+        x="1.6"
+        y="1.6"
+        width="16.8"
+        height="16.8"
+        rx="4"
+        className={SURFACE}
+        strokeWidth="1.2"
+      />
+      <rect x="3" y="3.4" width="14" height="4.1" rx="1.2" className={ADD_WASH} />
+      <Plus x={4.15} y={5.45} />
+      <rect
+        x="7.6"
+        y="4.65"
+        width="7.8"
+        height="1.6"
+        rx="0.8"
+        className="fill-[var(--color-success)]"
+        opacity="0.85"
+      />
+      <rect
+        x="4.15"
+        y="9.2"
+        width="10.5"
+        height="1.55"
+        rx="0.75"
+        className="fill-[var(--color-muted)]"
+        opacity="0.35"
+      />
+      <rect x="3" y="12.5" width="14" height="4.1" rx="1.2" className={DEL_WASH} />
+      <Minus x={4.15} y={14.55} />
+      <rect
+        x="7.6"
+        y="13.75"
+        width="6.4"
+        height="1.6"
+        rx="0.8"
+        className="fill-[var(--color-danger)]"
+        opacity="0.85"
+      />
+    </svg>
+  );
+}
+
+/** Index vs HEAD — the hunk sitting in a lime staging tray. */
+function StagedIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg {...frame(props)}>
+      <rect
+        x="1.5"
+        y="13.25"
+        width="17"
+        height="5.25"
+        rx="2.25"
+        className={ACCENT_WASH}
+        strokeWidth="1.2"
+      />
+      <rect x="3.1" y="1.6" width="13.8" height="14" rx="3" className={SURFACE} strokeWidth="1.2" />
+      <rect x="4.35" y="3.35" width="11.3" height="4" rx="1.2" className={ADD_WASH} />
+      <Plus x={5.4} y={5.35} />
+      <rect
+        x="8.7"
+        y="4.55"
+        width="5.4"
+        height="1.55"
+        rx="0.75"
+        className="fill-[var(--color-success)]"
+        opacity="0.85"
+      />
+      <rect x="4.35" y="8.85" width="11.3" height="4" rx="1.2" className={DEL_WASH} />
+      <Minus x={5.4} y={10.85} />
+      <rect
+        x="8.7"
+        y="10.05"
+        width="4.5"
+        height="1.55"
+        rx="0.75"
+        className="fill-[var(--color-danger)]"
+        opacity="0.85"
+      />
+    </svg>
+  );
+}
+
+/** Unstaged edits only — dashed card: not in the index. */
+function UnstagedIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg {...frame(props)}>
+      <rect
+        x="1.6"
+        y="1.6"
+        width="16.8"
+        height="16.8"
+        rx="4"
+        className={SURFACE}
+        strokeWidth="1.2"
+        strokeDasharray="2.5 1.8"
+      />
+      <rect x="3.15" y="4.15" width="13.7" height="4.35" rx="1.2" className={ADD_WASH} />
+      <Plus x={4.3} y={6.3} />
+      <rect
+        x="7.75"
+        y="5.5"
+        width="7.4"
+        height="1.6"
+        rx="0.8"
+        className="fill-[var(--color-success)]"
+        opacity="0.85"
+      />
+      <rect x="3.15" y="11.5" width="13.7" height="4.35" rx="1.2" className={DEL_WASH} />
+      <Minus x={4.3} y={13.65} />
+      <rect
+        x="7.75"
+        y="12.85"
+        width="6"
+        height="1.6"
+        rx="0.8"
+        className="fill-[var(--color-danger)]"
+        opacity="0.85"
+      />
+    </svg>
+  );
+}
+
+/** One commit — a single card with a hash chip and subject line. */
+function CommitIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg {...frame(props)}>
+      <rect
+        x="1.6"
+        y="2.25"
+        width="16.8"
+        height="15.5"
+        rx="3.5"
+        className={SURFACE}
+        strokeWidth="1.2"
+      />
+      <rect
+        x="3.5"
+        y="4.35"
+        width="8.25"
+        height="4.35"
+        rx="1.75"
+        className={INSET}
+        strokeWidth="1.1"
+      />
+      <rect
+        x="5"
+        y="5.75"
+        width="5.25"
+        height="1.5"
+        rx="0.75"
+        className="fill-[var(--color-muted)]"
+        opacity="0.6"
+      />
+      <rect
+        x="3.5"
+        y="10.85"
+        width="12.4"
+        height="2"
+        rx="1"
+        className="fill-[var(--color-foreground)]"
+        opacity="0.55"
+      />
+      <rect
+        x="3.5"
+        y="14"
+        width="8.25"
+        height="1.55"
+        rx="0.75"
+        className="fill-[var(--color-muted)]"
+        opacity="0.35"
+      />
+    </svg>
+  );
+}
+
+const ICONS: Record<Kind, (props: SVGProps<SVGSVGElement>) => ReturnType<typeof BranchIcon>> = {
+  branch: BranchIcon,
+  uncommitted: UncommittedIcon,
+  staged: StagedIcon,
+  unstaged: UnstagedIcon,
+  commit: CommitIcon,
+};
+
+export function ScopeIcon({
+  scope,
+  className,
+}: {
+  scope: Pick<LocalDiffScopeOption, "id" | "label">;
+  className?: string;
+}) {
+  const Icon = ICONS[scopeIconKind(scope)];
+  return <Icon className={className} />;
+}

--- a/apps/extension/src/content/overlay/host.ts
+++ b/apps/extension/src/content/overlay/host.ts
@@ -1,5 +1,5 @@
 /**
- * Host adapter for the review overlay. Chrome/GitHub (and later the CLI)
+ * Host adapter for the review overlay. Chrome/GitHub and the local CLI
  * implement this; overlay components must not import `chrome.*`.
  */
 

--- a/apps/extension/src/content/overlay/localReview.ts
+++ b/apps/extension/src/content/overlay/localReview.ts
@@ -1,4 +1,4 @@
-/** Individual commit scopes and the Change summary list. */
+/** Individual commit scopes and the Change summary list. Keep in sync with apps/cli/src/git/localDiff.ts. */
 export const MAX_RECENT_COMMITS = 5;
 
 export const RECENT_COMMITS_GROUP = "Last 5 commits";
@@ -42,6 +42,8 @@ export interface LocalDiffScopeOption {
   label: string;
   description: string;
   meta: string;
+  /** Extra shown ahead of file/+− counts (commit count, short SHA). */
+  metaPrefix?: string;
   stat?: DiffStat;
   empty: boolean;
 }

--- a/apps/extension/src/content/overlay/useOverlayKeyboard.ts
+++ b/apps/extension/src/content/overlay/useOverlayKeyboard.ts
@@ -19,7 +19,7 @@
  *  5. Comment composer / any editable (Esc, ⌘Enter save)
  *  6. ⌘/Ctrl+Enter open Submit Review
  *  7. View chords (`v` then `u`/`s`)
- *  8. Comment mode keys, else navigate mode keys
+ *  8. Comment mode keys, else navigate mode keys (`d` scope picker, ⌘/Ctrl+I structure)
  *
  * Do not redesign this as a generic keyboard framework. The ref pattern exists
  * only because capture ownership and React synthetic handlers cannot both win.
@@ -131,6 +131,10 @@ interface UseOverlayKeyboardOptions {
   closeDiffSearch: () => void;
   /** Diff search: Arrow/Enter routing while the palette owns the keyboard. */
   diffSearchKeyRef: MutableRefObject<((e: KeyboardEvent) => boolean) | null>;
+  /** Local: focus and open the diff-scope picker. */
+  openScopePicker?: () => void;
+  /** Local: start Structure with AI when the CTA is still available. */
+  structureReview?: () => void;
 }
 
 /**
@@ -161,6 +165,8 @@ export function useOverlayKeyboard({
   openDiffSearch,
   closeDiffSearch,
   diffSearchKeyRef,
+  openScopePicker,
+  structureReview,
 }: UseOverlayKeyboardOptions): void {
   // Mirror modal flags into refs on every render so the capture listener never
   // sees a stale open state between React commit (modal paints) and this
@@ -188,6 +194,10 @@ export function useOverlayKeyboard({
   openDiffSearchRef.current = openDiffSearch;
   const closeDiffSearchRef = useRef(closeDiffSearch);
   closeDiffSearchRef.current = closeDiffSearch;
+  const openScopePickerRef = useRef(openScopePicker);
+  openScopePickerRef.current = openScopePicker;
+  const structureReviewRef = useRef(structureReview);
+  structureReviewRef.current = structureReview;
 
   useEffect(() => {
     if (!isOpen) return;
@@ -394,7 +404,18 @@ export function useOverlayKeyboard({
             store.enterCommentMode(selectableForUnit);
           }
           return;
+        case "d":
+        case "D":
+          if (event.metaKey || event.ctrlKey || event.altKey) return;
+          if (!openScopePickerRef.current) return;
+          event.preventDefault();
+          openScopePickerRef.current();
+          return;
         default:
+          if (isStructureShortcut(event) && structureReviewRef.current) {
+            event.preventDefault();
+            structureReviewRef.current();
+          }
           return;
       }
     }
@@ -405,6 +426,15 @@ export function useOverlayKeyboard({
         !event.altKey &&
         !event.shiftKey &&
         event.key.toLowerCase() === "f"
+      );
+    }
+
+    function isStructureShortcut(event: KeyboardEvent): boolean {
+      return (
+        (event.metaKey || event.ctrlKey) &&
+        !event.altKey &&
+        !event.shiftKey &&
+        event.key.toLowerCase() === "i"
       );
     }
 

--- a/apps/web/config/docs.ts
+++ b/apps/web/config/docs.ts
@@ -110,8 +110,8 @@ export const DOCS_PAGES: DocsPage[] = [
     section: "Product",
     title: "Keyboard shortcuts",
     description:
-      "Keyboard-first shortcuts for review navigation, diff search, unified/split view, comments, and submitting a review.",
-    blurb: "navigate, search, comment, and submit without leaving the keyboard",
+      "Keyboard-first shortcuts for review navigation, diff search, unified/split view, comments, submitting a review, and local CLI review.",
+    blurb: "navigate, search, comment, submit, and local review",
     load: () => import("@web/content/help/keyboard-shortcuts.mdx"),
   },
   {

--- a/apps/web/content/help/keyboard-shortcuts.mdx
+++ b/apps/web/content/help/keyboard-shortcuts.mdx
@@ -82,10 +82,10 @@ Full submit flow: [Submit a review](/docs/submit-review). Auth gate: [Connect Gi
 
 These apply only in the [CLI walkthrough](/docs/local-review), not on a GitHub PR.
 
-| Shortcut           | Action                                                                 |
-| ------------------ | ---------------------------------------------------------------------- |
-| `d`                | Open the diff-to-review picker                                         |
-| `⌘/Ctrl` + `I`     | Structure with AI (until a plan has been built)                        |
+| Shortcut       | Action                                          |
+| -------------- | ----------------------------------------------- |
+| `d`            | Open the diff-to-review picker                  |
+| `⌘/Ctrl` + `I` | Structure with AI (until a plan has been built) |
 
 Once the picker is open, `↑` / `↓` move, `Enter` selects, and `Esc` closes. Type a letter to jump to a matching scope.
 

--- a/apps/web/content/help/keyboard-shortcuts.mdx
+++ b/apps/web/content/help/keyboard-shortcuts.mdx
@@ -4,6 +4,7 @@ export const toc = [
   { id: "diff-search", label: "Diff search", level: 2 },
   { id: "comment-mode", label: "Comment mode", level: 2 },
   { id: "submit-and-modals", label: "Submit and modals", level: 2 },
+  { id: "local-review", label: "Local review", level: 2 },
   { id: "marketing-site", label: "Marketing site", level: 2 },
 ];
 
@@ -76,6 +77,19 @@ Details and draft editing: [Leave line comments](/docs/leave-comments). Drafts s
 | `Enter` / `Esc`     | Dismiss the post-submit success dialog and exit                                                                         |
 
 Full submit flow: [Submit a review](/docs/submit-review). Auth gate: [Connect GitHub](/docs/connect-github). If submit fails: [Troubleshooting](/docs/troubleshooting#github-connect-and-submit).
+
+## Local review
+
+These apply only in the [CLI walkthrough](/docs/local-review), not on a GitHub PR.
+
+| Shortcut           | Action                                                                 |
+| ------------------ | ---------------------------------------------------------------------- |
+| `d`                | Open the diff-to-review picker                                         |
+| `⌘/Ctrl` + `I`     | Structure with AI (until a plan has been built)                        |
+
+Once the picker is open, `↑` / `↓` move, `Enter` selects, and `Esc` closes. Type a letter to jump to a matching scope.
+
+`⌘/Ctrl` + `I` on the [marketing site](#marketing-site) still opens install. That chord structures a review only inside the local overlay.
 
 ## Marketing site
 

--- a/apps/web/content/help/local-review.mdx
+++ b/apps/web/content/help/local-review.mdx
@@ -45,7 +45,7 @@ Base resolution, in order: `--base` → `origin/HEAD` → `main` → `master`.
 
 If every scope is empty: `Nothing to review against <base>.` and exit 0. Not a git repo: an error that says what failed.
 
-The walkthrough starts one unit per file. **Structure with AI** on the Change summary card is the opt-in LLM call. It groups files and adds context — it does not review for you.
+The walkthrough starts one unit per file. **Structure with AI** on the Change summary card is the opt-in LLM call. It groups files and adds context — it does not review for you. Press `d` to open the dropdown, or `⌘/Ctrl` + `I` to structure — same keys as [Keyboard shortcuts](/docs/keyboard-shortcuts#local-review).
 
 ## API keys
 


### PR DESCRIPTION
Part 8 of 13 in the local-review CLI stack. Base: [#83](https://github.com/nshntarora/guidedreview/pull/83).

Scope icons in the overlay, local-review keyboard shortcuts, and the commit-hash chip treatment.

**Out of scope (later PRs):** settings entry / stale banner, settings/about UI.