### PR TITLE
feat(cli): loopback server, TTY banner, and labeled logs

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -10,6 +10,6 @@ npm run review -- --base main --no-open
 
 Do not run `npx guided-review` — that name is taken on npm by another tool (Bun shebang). This package is `@guided-review/cli` and is workspace-only for now.
 
-The CLI binds `127.0.0.1` only. Every `/api/*` route requires the token printed in the URL. Keys live in `~/.config/guided-review/config.json`, provider env vars, or a coding agent already on the machine (Claude Code, Codex, Grok). No Guided Review backend.
+The CLI binds `127.0.0.1` only. The terminal keeps a short banner (URL, diff, last pull) and logs real events, not polling. Keys live in `~/.config/guided-review/config.json`, provider env vars, or a coding agent already on the machine (Claude Code, Codex, Grok). No Guided Review backend.
 
 See [Review local changes](https://guidedreview.dev/docs/local-review).

--- a/apps/cli/e2e/fixtures.ts
+++ b/apps/cli/e2e/fixtures.ts
@@ -15,7 +15,6 @@ const UI_DIR = path.resolve(__dirname, "../dist/ui");
 
 export interface ReviewServer {
   baseURL: string;
-  token: string;
   repoDir: string;
 }
 
@@ -55,11 +54,9 @@ export const test = base.extend<{ reviewServer: ReviewServer }>({
 
     await createReviewRepo(repoDir);
     const snapshot = await buildLocalReview({ cwd: repoDir });
-    const token = randomBytes(16).toString("hex");
     const server = createReviewServer({
       snapshot,
       settings: { provider: "anthropic", model: "claude-opus-4-8", apiKey: "" },
-      token,
       staticDir: UI_DIR,
       detectAgents: async () => [],
       testConnection: async () => {},
@@ -68,7 +65,7 @@ export const test = base.extend<{ reviewServer: ReviewServer }>({
     const port = await listen(server);
     const baseURL = `http://127.0.0.1:${port}`;
 
-    await use({ baseURL, token, repoDir });
+    await use({ baseURL, repoDir });
 
     await new Promise<void>((resolve, reject) => {
       server.closeAllConnections();
@@ -85,7 +82,7 @@ export const expect = test.expect;
 
 export function reviewUrl(server: ReviewServer, hash = ""): string {
   const suffix = hash ? (hash.startsWith("#") ? hash : `#${hash}`) : "";
-  return `${server.baseURL}/?token=${server.token}${suffix}`;
+  return `${server.baseURL}/${suffix}`;
 }
 
 export async function commitInRepo(repoDir: string, file: string, contents: string): Promise<void> {

--- a/apps/cli/e2e/review.spec.ts
+++ b/apps/cli/e2e/review.spec.ts
@@ -1,7 +1,7 @@
 import { commitInRepo, expect, reviewUrl, test } from "./fixtures";
 
 test.describe("CLI review overlay", () => {
-  test("boots a file-by-file review from the session token", async ({ page, reviewServer }) => {
+  test("boots a file-by-file review", async ({ page, reviewServer }) => {
     await page.goto(reviewUrl(reviewServer), { waitUntil: "domcontentloaded" });
 
     const units = page.getByRole("navigation", { name: "Review Units" });
@@ -13,15 +13,6 @@ test.describe("CLI review overlay", () => {
 
     await page.keyboard.press("ArrowDown");
     await expect(page.getByRole("listbox")).toHaveCount(0);
-  });
-
-  test("missing token shows the boot error", async ({ page, reviewServer }) => {
-    await page.goto(reviewServer.baseURL + "/", { waitUntil: "domcontentloaded" });
-
-    await expect(
-      page.getByText("Missing session token. Open the URL printed by the CLI."),
-    ).toBeVisible();
-    await expect(page.getByTestId("structure-review")).toHaveCount(0);
   });
 
   test("Structure with AI without a key opens settings", async ({ page, reviewServer }) => {

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -26,6 +26,7 @@
     "express": "^5.1.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
+    "winston": "^3.19.0",
     "zustand": "^5.0.14"
   },
   "devDependencies": {

--- a/apps/cli/scripts/bundle-server.mjs
+++ b/apps/cli/scripts/bundle-server.mjs
@@ -13,4 +13,10 @@ await build({
   target: "node22",
   packages: "bundle",
   external: [],
+  // CJS deps (express → debug) call require("tty"). ESM bundles have no
+  // require; createRequire restores it for Node builtins and remaining CJS.
+  banner: {
+    js: `import { createRequire as __guidedReviewCreateRequire } from "node:module";
+const require = __guidedReviewCreateRequire(import.meta.url);`,
+  },
 });

--- a/apps/cli/src/args.test.ts
+++ b/apps/cli/src/args.test.ts
@@ -7,6 +7,7 @@ describe("parseArgs", () => {
     expect(args.open).toBe(true);
     expect(args.includeUntracked).toBe(true);
     expect(args.staged).toBe(false);
+    expect(args.port).toBe(7182);
   });
 
   it("parses flags", () => {

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -1,7 +1,10 @@
+/** ASCII 'G' (71) + 'R' (82). `--port 0` still means “any free port”. */
+export const DEFAULT_PORT = 7182;
+
 export interface CliArgs {
   cwd: string;
   base?: string;
-  port?: number;
+  port: number;
   open: boolean;
   staged: boolean;
   includeUntracked: boolean;
@@ -22,6 +25,7 @@ function takeValue(flag: string, argv: string[], index: number): string {
 export function parseArgs(argv: string[]): CliArgs {
   const args: CliArgs = {
     cwd: process.cwd(),
+    port: DEFAULT_PORT,
     open: true,
     staged: false,
     includeUntracked: true,
@@ -89,13 +93,13 @@ export function parseArgs(argv: string[]): CliArgs {
 
 export const HELP = `Usage: npm run review -- [dir] [options]
 
-Review local changes against the main branch. Opens a browser UI.
+Review a local branch, commit, or working tree. Opens a browser UI.
 (Workspace CLI: @guided-review/cli. Not the npm package named guided-review.)
 
   --base <ref>       Base branch (default: origin/HEAD, then main, then master)
-  --port <n>         Listen port (default: first free port)
+  --port <n>         Listen port (default: ${DEFAULT_PORT})
   --no-open          Print the URL without opening a browser
-  --staged           Only staged changes vs the merge-base
+  --staged           Start on staged (index vs HEAD) changes
   --no-untracked     Skip untracked files
   --provider <id>    anthropic | openai | grok
   --model <id>       Provider model id

--- a/apps/cli/src/banner.test.ts
+++ b/apps/cli/src/banner.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { formatBanner, PRODUCT_MARK } from "./banner";
+
+const status = {
+  url: "http://127.0.0.1:7182/",
+  files: 173,
+  scope: "branch",
+  headRef: "feat",
+  baseRef: "main",
+  provider: "grok",
+  model: "grok-4.6",
+  agent: "grok",
+  hasKey: true,
+  lastPullAt: new Date(2026, 0, 2, 0, 40, 53),
+  diffFresh: "up to date" as const,
+};
+
+describe("formatBanner", () => {
+  it("renders the mark, URL, diff, model, and last pull", () => {
+    const text = formatBanner(status);
+    expect(text).toContain(PRODUCT_MARK);
+    expect(text).toContain("Guided Review");
+    expect(text).toContain("http://127.0.0.1:7182/");
+    expect(text).toContain("173 files");
+    expect(text).toContain("feat vs main");
+    expect(text).toContain("branch");
+    expect(text).toContain("grok/grok-4.6");
+    expect(text).toContain("agent grok");
+    expect(text).toContain("key yes");
+    expect(text).toContain("last pull 00:40:53");
+    expect(text).toContain("up to date");
+    expect(text.split("\n")).toHaveLength(6);
+  });
+
+  it("shows a changed diff and placeholders for missing fields", () => {
+    const text = formatBanner({ files: 1, diffFresh: "changed" });
+    expect(text).toContain("1 file · — · —");
+    expect(text).toContain("last pull — · changed");
+    expect(text).not.toContain("agent");
+    expect(text).not.toContain("key ");
+  });
+});

--- a/apps/cli/src/banner.ts
+++ b/apps/cli/src/banner.ts
@@ -1,0 +1,58 @@
+export const PRODUCT_MARK = "//!?";
+
+export type DiffFreshness = "up to date" | "changed";
+
+export type CliStatus = {
+  url?: string;
+  files?: number;
+  scope?: string;
+  headRef?: string;
+  baseRef?: string;
+  provider?: string;
+  model?: string;
+  agent?: string | null;
+  hasKey?: boolean;
+  lastPullAt?: Date | null;
+  diffFresh?: DiffFreshness;
+};
+
+const LIME = "\x1b[38;2;202;255;87m";
+const RESET = "\x1b[0m";
+
+function clock(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+}
+
+function filesLine(status: CliStatus): string {
+  const files =
+    status.files === undefined ? "—" : `${status.files} file${status.files === 1 ? "" : "s"}`;
+  const vs = status.headRef && status.baseRef ? `${status.headRef} vs ${status.baseRef}` : "—";
+  return `${files} · ${vs} · ${status.scope ?? "—"}`;
+}
+
+function modelLine(status: CliStatus): string {
+  const model = status.provider && status.model ? `${status.provider}/${status.model}` : "—";
+  const agent = status.agent ? ` · agent ${status.agent}` : "";
+  const key = status.hasKey === undefined ? "" : ` · key ${status.hasKey ? "yes" : "no"}`;
+  return `${model}${agent}${key}`;
+}
+
+function pullLine(status: CliStatus): string {
+  const pulled = status.lastPullAt ? clock(status.lastPullAt) : "—";
+  return `last pull ${pulled} · ${status.diffFresh ?? "—"}`;
+}
+
+/** Fixed 6-line banner so a TTY sticky header does not jump. */
+export function formatBanner(status: CliStatus, options?: { color?: boolean }): string {
+  const mark = options?.color ? `${LIME}${PRODUCT_MARK}${RESET}` : PRODUCT_MARK;
+  const url = status.url ?? "—";
+  return [
+    `  ${mark}  Guided Review`,
+    `        ${url}`,
+    "",
+    `  ${filesLine(status)}`,
+    `  ${modelLine(status)}`,
+    `  ${pullLine(status)}`,
+  ].join("\n");
+}

--- a/apps/cli/src/bin.ts
+++ b/apps/cli/src/bin.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import { randomBytes } from "node:crypto";
 import { spawn } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -7,6 +6,8 @@ import { HELP, parseArgs } from "./args";
 import { resolveSettings } from "./config";
 import { GitError } from "./git/run";
 import { buildLocalReview, reviewHasChanges } from "./git/localDiff";
+import { createCliDisplay } from "./display";
+import { createLogger, labeled } from "./log";
 import { createReviewServer, createServerShutdown, listen } from "./server/createServer";
 
 function openBrowser(url: string): void {
@@ -41,39 +42,58 @@ async function main(): Promise<void> {
     agent: args.agent,
   });
 
-  const token = randomBytes(16).toString("hex");
+  const display = createCliDisplay(process.stderr);
+  const logger = createLogger();
+  const cli = labeled(logger, "cli");
   const staticDir = path.join(path.dirname(fileURLToPath(import.meta.url)), "ui");
+  const { settings, codingAgent } = resolved;
   const server = createReviewServer({
     snapshot: local,
-    settings: resolved.settings,
-    codingAgent: resolved.codingAgent,
-    token,
+    settings,
+    codingAgent,
     staticDir,
+    logger,
+    onStatus: (patch) => display.setStatus(patch),
   });
 
-  const port = await listen(server, args.port ?? 0);
-  const url = `http://127.0.0.1:${port}/?token=${token}`;
-
-  process.stdout.write(
-    `Reviewing ${local.diff.files.length} file(s) on ${local.context.headRef} vs ${local.context.baseRef}.\n`,
-  );
-  process.stdout.write(`${url}\n`);
-  process.stdout.write("Ctrl+C to stop.\n");
-  const { settings, codingAgent } = resolved;
-  process.stderr.write(
-    `${settings.provider}/${settings.model}${codingAgent ? ` via ${codingAgent}` : ""}${settings.apiKey ? "" : "  no key"}\n`,
-  );
+  let port: number;
+  try {
+    port = await listen(server, args.port);
+  } catch (error) {
+    display.close();
+    throw error;
+  }
+  const url = `http://127.0.0.1:${port}/`;
+  display.setStatus({
+    url,
+    files: local.diff.files.length,
+    scope: local.selectedScope,
+    headRef: local.context.headRef,
+    baseRef: local.context.baseRef,
+    provider: settings.provider,
+    model: settings.model,
+    agent: codingAgent ?? null,
+    hasKey: Boolean(settings.apiKey),
+    lastPullAt: new Date(),
+    diffFresh: "up to date",
+  });
 
   if (args.open) openBrowser(url);
 
   const shutdown = createServerShutdown(server);
-  process.on("SIGINT", shutdown);
-  process.on("SIGTERM", shutdown);
+  const onStop = () => {
+    cli.info("shutting down");
+    display.close();
+    shutdown();
+  };
+  process.on("SIGINT", onStop);
+  process.on("SIGTERM", onStop);
 }
 
 main().catch((error: unknown) => {
+  const logger = createLogger();
   const message =
     error instanceof GitError || error instanceof Error ? error.message : "guided-review failed.";
-  process.stderr.write(`${message}\n`);
+  labeled(logger, "cli").error(message);
   process.exit(1);
 });

--- a/apps/cli/src/config.test.ts
+++ b/apps/cli/src/config.test.ts
@@ -83,17 +83,15 @@ describe("resolveSettings", () => {
         }),
       },
     });
-    const logs: string[] = [];
     const resolved = await resolveSettings({
       io,
       persist: true,
       isTTY: false,
-      log: (message) => logs.push(message),
+      log: () => undefined,
     });
     expect(resolved.codingAgent).toBe("claude-code");
     expect(resolved.settings.apiKey).toBe("sk-ant-oat01-live");
     expect(resolved.settings.authScheme).toBe("bearer");
-    expect(logs.join("\n")).toMatch(/Claude Code/);
 
     const saved = JSON.parse(await readFile(path.join(dir, "config.json"), "utf8")) as {
       codingAgent?: string;

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -215,7 +215,6 @@ export async function resolveSettings(flags: {
       codingAgent: chosen.id,
     });
   }
-  log(`Using ${chosen.displayName} for summaries.`);
   return { settings: fromAgent, codingAgent: chosen.id };
 }
 

--- a/apps/cli/src/display.ts
+++ b/apps/cli/src/display.ts
@@ -1,0 +1,75 @@
+import { formatBanner, type CliStatus } from "./banner";
+
+export type CliDisplay = {
+  setStatus: (patch: Partial<CliStatus>) => void;
+  close: () => void;
+};
+
+export function createCliDisplay(stream: NodeJS.WriteStream): CliDisplay {
+  const tty = Boolean(stream.isTTY);
+  const color = tty && !process.env.NO_COLOR;
+  let status: CliStatus = {};
+  let painted = false;
+  let closed = false;
+  let bannerLines = 0;
+
+  function write(chunk: string): void {
+    stream.write(chunk);
+  }
+
+  function paint(reset: boolean): void {
+    const lines = formatBanner(status, { color }).split("\n");
+    // Trailing spacer so logs do not sit against "last pull".
+    bannerLines = lines.length + 1;
+
+    if (!tty) {
+      if (!painted) {
+        write(`${lines.join("\n")}\n\n`);
+        painted = true;
+      }
+      return;
+    }
+
+    if (reset || !painted) {
+      write("\x1b[2J\x1b[H");
+      for (const line of lines) write(`${line}\x1b[K\n`);
+      write("\x1b[K\n");
+      const rows = stream.rows ?? 24;
+      const top = Math.min(bannerLines + 1, rows);
+      write(`\x1b[${top};${rows}r`);
+      write(`\x1b[${top};1H`);
+      painted = true;
+      return;
+    }
+
+    write("\x1b7");
+    write("\x1b[H");
+    for (const line of lines) write(`${line}\x1b[K\n`);
+    write("\x1b[K");
+    write("\x1b8");
+  }
+
+  function onResize(): void {
+    if (closed || !painted) return;
+    paint(true);
+  }
+
+  if (tty) stream.on("resize", onResize);
+
+  return {
+    setStatus(patch) {
+      if (closed) return;
+      status = { ...status, ...patch };
+      paint(false);
+    },
+    close() {
+      if (closed) return;
+      closed = true;
+      if (tty) {
+        stream.off("resize", onResize);
+        write("\x1b[r");
+        write("\n");
+      }
+    },
+  };
+}

--- a/apps/cli/src/log.ts
+++ b/apps/cli/src/log.ts
@@ -1,0 +1,71 @@
+import { PassThrough } from "node:stream";
+import winston from "winston";
+
+const STDERR_LEVELS = ["error", "warn", "info", "http", "verbose", "debug", "silly"];
+
+const ALLOWED_LEVELS = new Set(["error", "warn", "info", "debug"]);
+
+export type LogLabel = "cli" | "http" | "session" | "settings" | "diff" | "plan" | "ui";
+
+export type CapturedLog = {
+  level: string;
+  label?: string;
+  message: string;
+};
+
+function resolveLevel(): string {
+  const raw = process.env.GUIDED_REVIEW_LOG_LEVEL?.toLowerCase();
+  if (raw && ALLOWED_LEVELS.has(raw)) return raw;
+  return "info";
+}
+
+function consoleFormat(colorize: boolean): winston.Logform.Format {
+  return winston.format.combine(
+    winston.format.timestamp({ format: "HH:mm:ss.SSS" }),
+    winston.format.errors({ stack: true }),
+    colorize ? winston.format.colorize({ level: true }) : winston.format.uncolorize(),
+    winston.format.printf((info) => {
+      const label = typeof info.label === "string" ? ` [${info.label}]` : "";
+      const body = info.stack ?? info.message;
+      return `${info.timestamp}  ${info.level}${label}  ${body}`;
+    }),
+  );
+}
+
+export function createLogger(options?: {
+  silent?: boolean;
+  transports?: winston.transport[];
+}): winston.Logger {
+  const colorize = Boolean(process.stderr.isTTY) && !options?.silent;
+  return winston.createLogger({
+    level: resolveLevel(),
+    silent: options?.silent,
+    format: consoleFormat(colorize),
+    transports: options?.transports ?? [
+      new winston.transports.Console({
+        stderrLevels: STDERR_LEVELS,
+      }),
+    ],
+  });
+}
+
+export function createCapturingLogger(): { logger: winston.Logger; records: CapturedLog[] } {
+  const records: CapturedLog[] = [];
+  const logger = winston.createLogger({
+    level: "debug",
+    format: winston.format.printf((info) => {
+      records.push({
+        level: String(info.level),
+        label: typeof info.label === "string" ? info.label : undefined,
+        message: String(info.message),
+      });
+      return "";
+    }),
+    transports: [new winston.transports.Stream({ stream: new PassThrough().resume() })],
+  });
+  return { logger, records };
+}
+
+export function labeled(logger: winston.Logger, label: LogLabel): winston.Logger {
+  return logger.child({ label });
+}

--- a/apps/cli/src/server/createServer.test.ts
+++ b/apps/cli/src/server/createServer.test.ts
@@ -8,6 +8,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { ParsedDiff } from "@guided-review/core";
 import { buildLocalReview, type LocalReviewSnapshot } from "../git/localDiff";
 import { configPath } from "../config";
+import type { CliStatus } from "../banner";
+import { createCapturingLogger } from "../log";
 import {
   createReviewServer,
   createServerShutdown,
@@ -96,21 +98,17 @@ const snapshot: LocalReviewSnapshot = {
 };
 
 describe("createReviewServer", () => {
-  it("serves the session only with the token and streams no_api_key without a key", async () => {
-    const logs: string[] = [];
+  it("serves the session and streams no_api_key without a key", async () => {
+    const { logger, records } = createCapturingLogger();
     const server = createReviewServer({
       snapshot,
       settings: { provider: "anthropic", model: "claude-opus-4-8", apiKey: "" },
-      token: "secret",
-      log: (message) => logs.push(message),
+      logger,
     });
     const port = await listen(server);
     const base = `http://127.0.0.1:${port}`;
 
-    const denied = await fetch(`${base}/api/session`);
-    expect(denied.status).toBe(401);
-
-    const session = await fetch(`${base}/api/session?token=secret`).then(
+    const session = await fetch(`${base}/api/session`).then(
       (r) => r.json() as Promise<ReviewSessionPayload>,
     );
     expect(session.diff.files).toHaveLength(1);
@@ -119,13 +117,23 @@ describe("createReviewServer", () => {
     expect(session.commits).toHaveLength(1);
     expect(session.scopes).toHaveLength(3);
 
-    const planRes = await fetch(`${base}/api/plan?token=secret`);
+    const planRes = await fetch(`${base}/api/plan`);
     const body = await planRes.text();
     expect(body.startsWith(":")).toBe(true);
     expect(body).toContain("no_api_key");
-    expect(logs.some((line) => line.includes("401 unauthorized"))).toBe(true);
-    expect(logs.some((line) => line.includes("GET /api/session"))).toBe(true);
-    expect(logs.some((line) => line.includes("no API key"))).toBe(true);
+    expect(
+      records.some(
+        (line) =>
+          line.level === "info" &&
+          (line.label === "http" || line.message.includes("GET /api/session")),
+      ),
+    ).toBe(false);
+    expect(
+      records.some((line) => line.label === "session" && line.message.includes("file(s)")),
+    ).toBe(false);
+    expect(
+      records.some((line) => line.label === "plan" && line.message.includes("no API key")),
+    ).toBe(true);
 
     await new Promise<void>((resolve, reject) =>
       server.close((err) => (err ? reject(err) : resolve())),
@@ -152,19 +160,18 @@ describe("createReviewServer", () => {
     const server = createReviewServer({
       snapshot: live,
       settings: { provider: "anthropic", model: "claude-opus-4-8", apiKey: "" },
-      token: "secret",
     });
     const port = await listen(server);
     const base = `http://127.0.0.1:${port}`;
 
-    const unknown = await fetch(`${base}/api/diff?token=secret`, {
+    const unknown = await fetch(`${base}/api/diff`, {
       method: "PUT",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ scope: "nope" }),
     });
     expect(unknown.status).toBe(400);
 
-    const switched = await fetch(`${base}/api/diff?token=secret`, {
+    const switched = await fetch(`${base}/api/diff`, {
       method: "PUT",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ scope: "uncommitted" }),
@@ -173,7 +180,7 @@ describe("createReviewServer", () => {
     expect(switched.diff.files.map((file) => file.path)).toContain("dirty.ts");
     expect(switched.diff.files.map((file) => file.path)).not.toContain("feat.ts");
 
-    const session = await fetch(`${base}/api/session?token=secret`).then(
+    const session = await fetch(`${base}/api/session`).then(
       (r) => r.json() as Promise<{ selectedScope: string; diff: ParsedDiff }>,
     );
     expect(session.selectedScope).toBe("uncommitted");
@@ -200,43 +207,63 @@ describe("createReviewServer", () => {
     await git(["commit", "-m", "add feat"]);
 
     const live = await buildLocalReview({ cwd, scope: "branch" });
+    const { logger, records } = createCapturingLogger();
+    const patches: Partial<CliStatus>[] = [];
     const server = createReviewServer({
       snapshot: live,
       settings: { provider: "anthropic", model: "claude-opus-4-8", apiKey: "" },
-      token: "secret",
+      logger,
+      onStatus: (patch) => patches.push(patch),
     });
     const port = await listen(server);
     const base = `http://127.0.0.1:${port}`;
 
-    const before = await fetch(`${base}/api/diff-status?token=secret`).then(
+    const before = await fetch(`${base}/api/diff-status`).then(
       (r) => r.json() as Promise<{ changed: boolean; hash: string }>,
     );
     expect(before.changed).toBe(false);
+    expect(patches.some((patch) => patch.diffFresh === "up to date")).toBe(true);
 
     await writeFile(path.join(cwd, "feat.ts"), "export const n = 2;\n");
     await git(["add", "feat.ts"]);
     await git(["commit", "-m", "edit feat"]);
 
-    const status = await fetch(`${base}/api/diff-status?token=secret`).then(
+    const status = await fetch(`${base}/api/diff-status`).then(
       (r) => r.json() as Promise<{ changed: boolean; hash: string }>,
     );
     expect(status.changed).toBe(true);
     expect(status.hash).not.toBe(before.hash);
 
-    const plan = await fetch(`${base}/api/plan?token=secret`).then((r) => r.text());
+    const plan = await fetch(`${base}/api/plan`).then((r) => r.text());
     expect(plan).toContain("no_api_key");
 
-    const reloaded = await fetch(`${base}/api/session?token=secret`).then(
+    const reloaded = await fetch(`${base}/api/session`).then(
       (r) => r.json() as Promise<ReviewSessionPayload>,
     );
     expect(reloaded.diffHash).toBe(status.hash);
+    expect(
+      patches.some(
+        (patch) =>
+          patch.files === reloaded.diff.files.length &&
+          patch.scope === "branch" &&
+          patch.lastPullAt instanceof Date,
+      ),
+    ).toBe(true);
+    expect(
+      records.some(
+        (line) =>
+          line.level === "info" &&
+          line.label === "http" &&
+          line.message.includes("GET /api/diff-status"),
+      ),
+    ).toBe(false);
     expect(
       reloaded.diff.files.some((file) =>
         file.hunks.some((h) => h.lines.some((line) => line.content.includes("n = 2"))),
       ),
     ).toBe(true);
 
-    const after = await fetch(`${base}/api/diff-status?token=secret`).then(
+    const after = await fetch(`${base}/api/diff-status`).then(
       (r) => r.json() as Promise<{ changed: boolean }>,
     );
     expect(after.changed).toBe(false);
@@ -250,7 +277,6 @@ describe("createReviewServer", () => {
     const server = createReviewServer({
       snapshot,
       settings: { provider: "anthropic", model: "claude-opus-4-8", apiKey: "" },
-      token: "secret",
     });
     const port = await listen(server);
 
@@ -318,12 +344,11 @@ describe("createReviewServer", () => {
           extraHeaders: { "anthropic-beta": "oauth-2025-04-20" },
         },
         codingAgent: "claude-code",
-        token: "secret",
       });
       const port = await listen(server);
       const base = `http://127.0.0.1:${port}`;
 
-      const saved = await fetch(`${base}/api/settings?token=secret`, {
+      const saved = await fetch(`${base}/api/settings`, {
         method: "PUT",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ provider: "anthropic", model: "claude-opus-4-8" }),
@@ -357,12 +382,11 @@ describe("createReviewServer", () => {
           extraHeaders: { "anthropic-beta": "oauth-2025-04-20" },
         },
         codingAgent: "claude-code",
-        token: "secret",
       });
       const port = await listen(server);
       const base = `http://127.0.0.1:${port}`;
 
-      const saved = await fetch(`${base}/api/settings?token=secret`, {
+      const saved = await fetch(`${base}/api/settings`, {
         method: "PUT",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
@@ -392,10 +416,9 @@ describe("createReviewServer", () => {
       const server = createReviewServer({
         snapshot,
         settings: { provider: "anthropic", model: "claude-opus-4-8", apiKey: "" },
-        token: "secret",
       });
       const port = await listen(server);
-      const res = await fetch(`http://127.0.0.1:${port}/api/settings?token=secret`, {
+      const res = await fetch(`http://127.0.0.1:${port}/api/settings`, {
         method: "PUT",
         headers: { "content-type": "application/json" },
         body: "{",
@@ -416,7 +439,7 @@ describe("createReviewServer", () => {
       const server = createReviewServer({
         snapshot,
         settings: { provider: "openai", model: "gpt-4.1", apiKey: "sk-old" },
-        token: "secret",
+
         detectAgents: async () => [
           {
             id: "codex",
@@ -433,7 +456,7 @@ describe("createReviewServer", () => {
         ],
       });
       const port = await listen(server);
-      const saved = await fetch(`http://127.0.0.1:${port}/api/settings?token=secret`, {
+      const saved = await fetch(`http://127.0.0.1:${port}/api/settings`, {
         method: "PUT",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ codingAgent: "codex" }),
@@ -465,11 +488,11 @@ describe("createReviewServer", () => {
       const server = createReviewServer({
         snapshot,
         settings: { provider: "anthropic", model: "claude-opus-4-8", apiKey: "" },
-        token: "secret",
+
         detectAgents: async () => [],
       });
       const port = await listen(server);
-      const res = await fetch(`http://127.0.0.1:${port}/api/settings?token=secret`, {
+      const res = await fetch(`http://127.0.0.1:${port}/api/settings`, {
         method: "PUT",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ codingAgent: "codex" }),
@@ -486,7 +509,7 @@ describe("createReviewServer", () => {
       const server = createReviewServer({
         snapshot,
         settings: { provider: "anthropic", model: "claude-opus-4-8", apiKey: "" },
-        token: "secret",
+
         detectAgents: async () => [
           {
             id: "claude-code",
@@ -502,10 +525,7 @@ describe("createReviewServer", () => {
         ],
       });
       const port = await listen(server);
-      const denied = await fetch(`http://127.0.0.1:${port}/api/agents`);
-      expect(denied.status).toBe(401);
-
-      const body = await fetch(`http://127.0.0.1:${port}/api/agents?token=secret`).then(
+      const body = await fetch(`http://127.0.0.1:${port}/api/agents`).then(
         (r) =>
           r.json() as Promise<{
             agents: { id: string; displayName: string; usable: boolean }[];
@@ -553,25 +573,6 @@ describe("createReviewServer", () => {
       else process.env.GUIDED_REVIEW_CONFIG_DIR = prevConfigDir;
     });
 
-    it("rejects a missing token", async () => {
-      const server = createReviewServer({
-        snapshot,
-        settings: { provider: "anthropic", model: "claude-opus-4-8", apiKey: "sk-x" },
-        token: "secret",
-        testConnection: async () => undefined,
-      });
-      const port = await listen(server);
-      const res = await fetch(`http://127.0.0.1:${port}/api/settings/test`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({}),
-      });
-      expect(res.status).toBe(401);
-      await new Promise<void>((resolve, reject) =>
-        server.close((err) => (err ? reject(err) : resolve())),
-      );
-    });
-
     it("returns ok when the probe succeeds", async () => {
       const dir = await mkdir(path.join(os.tmpdir(), `gr-cfg-${Date.now()}`), { recursive: true });
       process.env.GUIDED_REVIEW_CONFIG_DIR = dir!;
@@ -579,13 +580,13 @@ describe("createReviewServer", () => {
       const server = createReviewServer({
         snapshot,
         settings: { provider: "anthropic", model: "claude-opus-4-8", apiKey: "sk-old" },
-        token: "secret",
+
         testConnection: async (next) => {
           calls.push(next.apiKey);
         },
       });
       const port = await listen(server);
-      const body = await fetch(`http://127.0.0.1:${port}/api/settings/test?token=secret`, {
+      const body = await fetch(`http://127.0.0.1:${port}/api/settings/test`, {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ provider: "openai", model: "gpt-4.1", apiKey: "sk-new" }),
@@ -603,13 +604,13 @@ describe("createReviewServer", () => {
       const server = createReviewServer({
         snapshot,
         settings: { provider: "anthropic", model: "claude-opus-4-8", apiKey: "sk-bad" },
-        token: "secret",
+
         testConnection: async () => {
           throw new Error("Invalid API key");
         },
       });
       const port = await listen(server);
-      const res = await fetch(`http://127.0.0.1:${port}/api/settings/test?token=secret`, {
+      const res = await fetch(`http://127.0.0.1:${port}/api/settings/test`, {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({}),

--- a/apps/cli/src/server/createServer.ts
+++ b/apps/cli/src/server/createServer.ts
@@ -34,33 +34,25 @@ import {
   type LocalReviewSnapshot,
 } from "../git/localDiff";
 import { GitError } from "../git/run";
-
-export type ServerLog = (message: string) => void;
-
-function defaultLog(message: string): void {
-  process.stderr.write(`${new Date().toISOString().slice(11, 23)}  ${message}\n`);
-}
-
-function formatThrown(error: unknown): string {
-  if (error instanceof Error) return error.stack ?? error.message;
-  return String(error);
-}
+import type { CliStatus } from "../banner";
+import { createLogger, labeled } from "../log";
+import type { Logger } from "winston";
 
 function describePlanEvent(event: AnnotateReviewStreamEvent): string | null {
   switch (event.type) {
     case "STATUS":
-      return `plan  ${event.phase}`;
+      return event.phase;
     case "UNIT":
-      return `plan  unit ${event.unit.id} (${event.unit.files.length} file(s))`;
+      return `unit ${event.unit.id} (${event.unit.files.length} file(s))`;
     case "DONE":
-      return `plan  done ${event.plan.units.length} unit(s)`;
+      return `done ${event.plan.units.length} unit(s)`;
     case "ERROR": {
       const parts = [
         event.error.statusCode !== undefined ? String(event.error.statusCode) : null,
         event.error.code,
         event.error.message,
       ].filter((part): part is string => Boolean(part));
-      return `plan  error ${parts.join(" ")}`;
+      return parts.join(" ");
     }
   }
 }
@@ -80,9 +72,9 @@ export interface CreateReviewServerOptions {
   snapshot: LocalReviewSnapshot;
   settings: ProviderSettings;
   codingAgent?: CodingAgentId | null;
-  token: string;
   staticDir?: string;
-  log?: ServerLog;
+  logger?: Logger;
+  onStatus?: (patch: Partial<CliStatus>) => void;
   detectAgents?: () => Promise<DetectedAgent[]>;
   testConnection?: (settings: ProviderSettings) => Promise<void>;
 }
@@ -122,6 +114,22 @@ function sessionPayload(
   };
 }
 
+function sessionStatus(
+  snapshot: LocalReviewSnapshot,
+  published: ReturnType<typeof publicSettings>,
+): Partial<CliStatus> {
+  return {
+    files: snapshot.diff.files.length,
+    scope: snapshot.selectedScope,
+    headRef: snapshot.context.headRef,
+    baseRef: snapshot.context.baseRef,
+    provider: published.provider,
+    model: published.model,
+    agent: published.codingAgent ?? null,
+    hasKey: published.hasKey,
+  };
+}
+
 function parseSettingsBody(value: unknown): SettingsBody | null {
   if (!value || typeof value !== "object") return null;
   const raw = value as Record<string, unknown>;
@@ -143,7 +151,14 @@ export function createReviewServer(options: CreateReviewServerOptions) {
   let settings = options.settings;
   let codingAgent = options.codingAgent ?? null;
   let snapshot = options.snapshot;
-  const log = options.log ?? defaultLog;
+  const logger = options.logger ?? createLogger({ silent: true });
+  const onStatus = options.onStatus;
+  const httpLog = labeled(logger, "http");
+  const sessionLog = labeled(logger, "session");
+  const settingsLog = labeled(logger, "settings");
+  const diffLog = labeled(logger, "diff");
+  const planLog = labeled(logger, "plan");
+  const uiLog = labeled(logger, "ui");
   const detectAgents = options.detectAgents ?? (() => detectAll(createDefaultAgentIo()));
   const testConnection =
     options.testConnection ??
@@ -198,27 +213,29 @@ export function createReviewServer(options: CreateReviewServerOptions) {
       next();
       return;
     }
-    const header = req.headers.authorization;
-    const token = typeof req.query.token === "string" ? req.query.token : undefined;
-    if (header === `Bearer ${options.token}` || token === options.token) {
-      next();
-      return;
-    }
-    log(`${req.method} ${req.path}  401 unauthorized`);
-    sendJson(res, 401, { error: "Unauthorized. Open the URL printed by the CLI." });
+    const started = Date.now();
+    res.on("finish", () => {
+      const line = `${req.method} ${req.path} ${res.statusCode} ${Date.now() - started}ms`;
+      if (res.statusCode >= 400) httpLog.warn(line);
+      else httpLog.debug(line);
+    });
+    next();
   });
 
   app.get("/api/session", async (_req, res) => {
     try {
       snapshot = await rebuildLocalReview(snapshot.repo, snapshot.selectedScope);
+      const published = publicSettings(settings, codingAgent);
+      onStatus?.({
+        ...sessionStatus(snapshot, published),
+        lastPullAt: new Date(),
+        diffFresh: "up to date",
+      });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      log(`GET /api/session  rebuild failed, serving last snapshot  ${message}`);
+      sessionLog.warn(`rebuild failed, serving last snapshot  ${message}`);
     }
     const published = publicSettings(settings, codingAgent);
-    log(
-      `GET /api/session  ${snapshot.diff.files.length} file(s)  ${snapshot.selectedScope}  ${published.provider}/${published.model}  key=${published.hasKey ? "yes" : "no"}${published.codingAgent ? `  agent=${published.codingAgent}` : ""}`,
-    );
     sendJson(res, 200, sessionPayload(snapshot, published));
   });
 
@@ -226,7 +243,9 @@ export function createReviewServer(options: CreateReviewServerOptions) {
     try {
       const hash = await currentDiffHash(snapshot.repo, snapshot.selectedScope);
       const served = hashDiff(snapshot.raw);
-      sendJson(res, 200, { hash, changed: hash !== served });
+      const changed = hash !== served;
+      onStatus?.({ diffFresh: changed ? "changed" : "up to date" });
+      sendJson(res, 200, { hash, changed });
     } catch (error) {
       const message =
         error instanceof GitError ? error.message : "Could not check the current diff.";
@@ -255,9 +274,15 @@ export function createReviewServer(options: CreateReviewServerOptions) {
       return;
     }
     const published = applied.published;
-    log(
-      `PUT /api/settings  ${published.provider}/${published.model}  key=${published.hasKey ? "yes" : "no"}${published.codingAgent ? `  agent=${published.codingAgent}` : ""}`,
+    settingsLog.info(
+      `${published.provider}/${published.model}  key=${published.hasKey ? "yes" : "no"}${published.codingAgent ? `  agent=${published.codingAgent}` : ""}`,
     );
+    onStatus?.({
+      provider: published.provider,
+      model: published.model,
+      agent: published.codingAgent ?? null,
+      hasKey: published.hasKey,
+    });
     sendJson(res, 200, published);
   });
 
@@ -283,11 +308,11 @@ export function createReviewServer(options: CreateReviewServerOptions) {
     }
     try {
       await testConnection(settings);
-      log(`POST /api/settings/test  ok  ${settings.provider}/${settings.model}`);
+      settingsLog.info(`test ok  ${settings.provider}/${settings.model}`);
       sendJson(res, 200, { ok: true });
     } catch (error) {
       const message = describeErrorMessage(error);
-      log(`POST /api/settings/test  fail  ${message}`);
+      settingsLog.warn(`test fail  ${message}`);
       sendJson(res, 200, { ok: false, error: message });
     }
   });
@@ -317,7 +342,12 @@ export function createReviewServer(options: CreateReviewServerOptions) {
       }
       snapshot = next;
       const published = publicSettings(settings, codingAgent);
-      log(`PUT /api/diff  ${scope}  ${next.diff.files.length} file(s)`);
+      diffLog.info(`${scope}  ${next.diff.files.length} file(s)`);
+      onStatus?.({
+        ...sessionStatus(next, published),
+        lastPullAt: new Date(),
+        diffFresh: "up to date",
+      });
       sendJson(res, 200, sessionPayload(next, published));
     } catch (error) {
       const message = error instanceof GitError ? error.message : "Could not load that diff.";
@@ -341,11 +371,11 @@ export function createReviewServer(options: CreateReviewServerOptions) {
     let planFinished = false;
     req.on("close", () => {
       abort.abort();
-      if (!planFinished) log("plan  client closed");
+      if (!planFinished) planLog.warn("client closed");
     });
 
     if (!settings.apiKey) {
-      log("plan  no API key");
+      planLog.warn("no API key");
       res.write(
         `data: ${JSON.stringify({
           type: "ERROR",
@@ -357,8 +387,8 @@ export function createReviewServer(options: CreateReviewServerOptions) {
       return;
     }
 
-    log(
-      `GET /api/plan  ${settings.provider}/${settings.model}  ${snapshot.selectedScope}  ${snapshot.diff.files.length} file(s)`,
+    planLog.info(
+      `${settings.provider}/${settings.model}  ${snapshot.selectedScope}  ${snapshot.diff.files.length} file(s)`,
     );
 
     for await (const event of annotateReview({
@@ -369,7 +399,10 @@ export function createReviewServer(options: CreateReviewServerOptions) {
     })) {
       if (abort.signal.aborted) return;
       const line = describePlanEvent(event);
-      if (line) log(line);
+      if (line) {
+        if (event.type === "ERROR") planLog.error(line);
+        else planLog.info(line);
+      }
       res.write(`data: ${JSON.stringify(event)}\n\n`);
     }
     planFinished = true;
@@ -385,7 +418,7 @@ export function createReviewServer(options: CreateReviewServerOptions) {
     }
     res.sendFile(path.join(staticDir, "index.html"), (err) => {
       if (!err) return;
-      log("UI not built. Run npm run build -w @guided-review/cli.");
+      uiLog.warn("UI not built. Run npm run build -w @guided-review/cli.");
       if (!res.headersSent) {
         sendJson(res, 404, { error: "UI not built. Run npm run build -w @guided-review/cli." });
       } else {
@@ -399,7 +432,7 @@ export function createReviewServer(options: CreateReviewServerOptions) {
       sendJson(res, 400, { error: "Request body must be JSON." });
       return;
     }
-    log(`server error  ${formatThrown(err)}`);
+    logger.error(err instanceof Error ? err : String(err));
     const message = err instanceof Error ? err.message : "Server error.";
     if (!res.headersSent) sendJson(res, 500, { error: message });
     else res.end();

--- a/apps/cli/src/ui/App.tsx
+++ b/apps/cli/src/ui/App.tsx
@@ -18,10 +18,6 @@ function parseAppHash(hash: string): AppRoute {
   return "review";
 }
 
-function tokenFromLocation(): string {
-  return new URLSearchParams(window.location.search).get("token") ?? "";
-}
-
 function useHashRoute(): AppRoute {
   const [route, setRoute] = useState<AppRoute>(() =>
     typeof window !== "undefined" ? parseAppHash(window.location.hash) : "review",
@@ -37,7 +33,6 @@ function useHashRoute(): AppRoute {
 }
 
 export function App() {
-  const token = tokenFromLocation();
   const route = useHashRoute();
   const [bootError, setBootError] = useState<string | null>(null);
   const [commits, setCommits] = useState<ReviewSessionPayload["commits"]>([]);
@@ -58,12 +53,11 @@ export function App() {
   const host = useMemo(
     () =>
       createLocalReviewHost({
-        token,
         onConnectProvider: () => {
           window.location.hash = "settings";
         },
       }),
-    [token],
+    [],
   );
 
   const applyPublishedSettings = useCallback((published: PublicSettings) => {
@@ -141,15 +135,10 @@ export function App() {
   }, [host]);
 
   useEffect(() => {
-    if (!token) {
-      setBootError("Missing session token. Open the URL printed by the CLI.");
-      return;
-    }
-
     let cancelled = false;
 
     async function boot() {
-      const res = await fetch(`/api/session?token=${encodeURIComponent(token)}`);
+      const res = await fetch("/api/session");
       if (!res.ok) {
         const body = (await res.json().catch(() => ({}))) as { error?: string };
         throw new Error(body.error ?? `Could not load the review (${res.status}).`);
@@ -181,15 +170,15 @@ export function App() {
       cancelled = true;
       cancelStreamRef.current?.();
     };
-  }, [applyMeta, applyPublishedSettings, installFilePlan, token]);
+  }, [applyMeta, applyPublishedSettings, installFilePlan]);
 
   async function selectScope(scope: string) {
-    if (!token || scope === selectedScope || scopeBusy) return;
+    if (scope === selectedScope || scopeBusy) return;
     setScopeBusy(true);
     cancelStreamRef.current?.();
     cancelStreamRef.current = undefined;
     try {
-      const res = await fetch(`/api/diff?token=${encodeURIComponent(token)}`, {
+      const res = await fetch("/api/diff", {
         method: "PUT",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ scope }),
@@ -214,7 +203,7 @@ export function App() {
   const structuring = status === "loading" || status === "streaming";
 
   useEffect(() => {
-    if (!token || status !== "ready" || structuring || scopeBusy) return;
+    if (status !== "ready" || structuring || scopeBusy) return;
 
     let cancelled = false;
     let inFlight = false;
@@ -223,7 +212,7 @@ export function App() {
       if (inFlight) return;
       inFlight = true;
       try {
-        const res = await fetch(`/api/diff-status?token=${encodeURIComponent(token)}`);
+        const res = await fetch("/api/diff-status");
         const body = (await res.json().catch(() => ({}))) as { changed?: boolean };
         if (!cancelled && res.ok && body.changed) setStale(true);
       } catch {
@@ -239,7 +228,7 @@ export function App() {
       cancelled = true;
       window.clearInterval(id);
     };
-  }, [token, status, structuring, scopeBusy]);
+  }, [status, structuring, scopeBusy]);
 
   const localDiff: LocalDiffControls = {
     scopes,
@@ -286,7 +275,6 @@ export function App() {
       />
       {(route === "settings" || route === "about") && (
         <SettingsApp
-          token={token}
           route={route}
           onSaved={applyPublishedSettings}
           onClose={() => {

--- a/apps/cli/src/ui/host.ts
+++ b/apps/cli/src/ui/host.ts
@@ -2,17 +2,8 @@ import type { AnnotateReviewStreamEvent, ParsedDiff, ReviewContext } from "@guid
 import type { ReviewHost, StreamPlanHandlers } from "@extension/content/overlay/host";
 import type { DiffViewMode } from "@extension/content/overlay/diffView";
 
-function api(path: string, token: string): string {
-  const url = new URL(path, window.location.origin);
-  url.searchParams.set("token", token);
-  return url.toString();
-}
-
-export function createLocalReviewHost(options: {
-  token: string;
-  onConnectProvider: () => void;
-}): ReviewHost {
-  const { token, onConnectProvider } = options;
+export function createLocalReviewHost(options: { onConnectProvider: () => void }): ReviewHost {
+  const { onConnectProvider } = options;
 
   return {
     kind: "local",
@@ -25,7 +16,7 @@ export function createLocalReviewHost(options: {
       return raw ? (JSON.parse(raw) as unknown) : null;
     },
     streamPlan: (_diff: ParsedDiff, _context: ReviewContext, handlers: StreamPlanHandlers) => {
-      const source = new EventSource(api("/api/plan", token));
+      const source = new EventSource("/api/plan");
       let settled = false;
       const finish = (fn: () => void) => {
         if (settled) return;

--- a/apps/cli/src/ui/settings/About.tsx
+++ b/apps/cli/src/ui/settings/About.tsx
@@ -64,7 +64,7 @@ export function About() {
             <code className="rounded bg-surface-raised px-1 py-0.5 font-mono text-sm text-foreground">
               127.0.0.1
             </code>{" "}
-            and opens a tokenized URL.
+            and opens the printed URL.
           </li>
           <li>Walk the change file by file — no model call yet.</li>
           <li>

--- a/apps/cli/src/ui/settings/Settings.test.tsx
+++ b/apps/cli/src/ui/settings/Settings.test.tsx
@@ -101,7 +101,7 @@ describe("Settings", () => {
   });
 
   it("hydrates the form from the server", async () => {
-    render(<Settings token="secret" />);
+    render(<Settings />);
 
     expect(await screen.findByRole("combobox", { name: /provider/i })).toHaveTextContent("OpenAI");
     expect(screen.getByRole("combobox", { name: /model/i })).toHaveTextContent("GPT-4.1");
@@ -131,7 +131,7 @@ describe("Settings", () => {
         settings: { ...settings, codingAgent: "codex", last4: "cret" },
       }),
     );
-    render(<Settings token="secret" />);
+    render(<Settings />);
 
     const toggle = await screen.findByRole("switch", { name: /use my subscription/i });
     expect(toggle).toHaveAttribute("aria-checked", "true");
@@ -141,7 +141,7 @@ describe("Settings", () => {
 
   it("resets the model to the provider default when the provider changes", async () => {
     const user = userEvent.setup();
-    render(<Settings token="secret" />);
+    render(<Settings />);
     await screen.findByRole("combobox", { name: /provider/i });
     await chooseOption(user, /provider/i, /Grok/);
     expect(screen.getByRole("combobox", { name: /model/i })).toHaveTextContent("Grok 4");
@@ -160,7 +160,7 @@ describe("Settings", () => {
       }),
     });
     vi.stubGlobal("fetch", fetchMock);
-    render(<Settings token="secret" onSaved={onSaved} />);
+    render(<Settings onSaved={onSaved} />);
 
     await screen.findByRole("combobox", { name: /provider/i });
     await user.type(screen.getByLabelText(/api key/i), "sk-new-key");
@@ -191,7 +191,7 @@ describe("Settings", () => {
       }),
     });
     vi.stubGlobal("fetch", fetchMock);
-    render(<Settings token="secret" />);
+    render(<Settings />);
 
     await screen.findByRole("combobox", { name: /provider/i });
     await user.click(screen.getByRole("switch", { name: /use my subscription/i }));
@@ -218,7 +218,7 @@ describe("Settings", () => {
         putStatus: 500,
       }),
     );
-    render(<Settings token="secret" />);
+    render(<Settings />);
     await screen.findByRole("combobox", { name: /provider/i });
     await user.click(screen.getByRole("button", { name: "Save" }));
     expect(await screen.findByText("Error: Disk full")).toBeInTheDocument();
@@ -232,14 +232,14 @@ describe("Settings", () => {
         settings: { ...settings, hasKey: false, last4: null },
       }),
     );
-    render(<Settings token="secret" />);
+    render(<Settings />);
     await screen.findByRole("combobox", { name: /provider/i });
     expect(screen.getByRole("button", { name: /test connection/i })).toBeDisabled();
   });
 
   it("shows a success status when the connection test succeeds", async () => {
     const user = userEvent.setup();
-    render(<Settings token="secret" />);
+    render(<Settings />);
     await screen.findByRole("combobox", { name: /provider/i });
     await user.click(screen.getByRole("button", { name: /test connection/i }));
     await waitFor(() => expect(screen.getByText("Connection OK")).toBeInTheDocument());
@@ -253,7 +253,7 @@ describe("Settings", () => {
         test: { ok: false, error: "Invalid API key" },
       }),
     );
-    render(<Settings token="secret" />);
+    render(<Settings />);
     await screen.findByRole("combobox", { name: /provider/i });
     await user.click(screen.getByRole("button", { name: /test connection/i }));
     await waitFor(() => expect(screen.getByText("Error: Invalid API key")).toBeInTheDocument());
@@ -279,7 +279,7 @@ describe("Settings", () => {
         test: { ok: false, error: reason },
       }),
     );
-    render(<Settings token="secret" />);
+    render(<Settings />);
 
     expect(await screen.findByTestId("subscription-status")).toHaveTextContent(reason);
     await user.click(screen.getByRole("button", { name: /test connection/i }));
@@ -311,7 +311,7 @@ describe("SettingsApp", () => {
 
   it("shows the about view when the route is about", async () => {
     vi.stubGlobal("fetch", mockFetch({}));
-    render(<SettingsApp token="secret" route="about" onClose={vi.fn()} />);
+    render(<SettingsApp route="about" onClose={vi.fn()} />);
 
     expect(await screen.findByRole("heading", { name: "How it works" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Chrome extension" })).toBeInTheDocument();
@@ -329,14 +329,14 @@ describe("SettingsApp", () => {
     vi.stubGlobal("fetch", mockFetch({}));
     const user = userEvent.setup();
     const onClose = vi.fn();
-    const { rerender } = render(<SettingsApp token="secret" route="settings" onClose={onClose} />);
+    const { rerender } = render(<SettingsApp route="settings" onClose={onClose} />);
 
     await screen.findByRole("combobox", { name: /provider/i });
     await user.click(screen.getByTestId("settings-close"));
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(screen.queryByTestId("confirmation-dialog")).not.toBeInTheDocument();
 
-    rerender(<SettingsApp token="secret" route="settings" onClose={onClose} />);
+    rerender(<SettingsApp route="settings" onClose={onClose} />);
     await user.keyboard("{Escape}");
     expect(onClose).toHaveBeenCalledTimes(2);
   });
@@ -345,14 +345,14 @@ describe("SettingsApp", () => {
     vi.stubGlobal("fetch", mockFetch({}));
     window.location.hash = "settings";
     const onClose = vi.fn();
-    const { rerender } = render(<SettingsApp token="secret" route="settings" onClose={onClose} />);
+    const { rerender } = render(<SettingsApp route="settings" onClose={onClose} />);
 
     await screen.findByRole("combobox", { name: /provider/i });
     fireEvent.keyDown(window, { key: ",", metaKey: true });
     expect(onClose).not.toHaveBeenCalled();
     expect(window.location.hash).toBe("#settings");
 
-    rerender(<SettingsApp token="secret" route="about" onClose={onClose} />);
+    rerender(<SettingsApp route="about" onClose={onClose} />);
     window.location.hash = "about";
     fireEvent.keyDown(window, { key: ",", metaKey: true });
     expect(onClose).not.toHaveBeenCalled();
@@ -363,7 +363,7 @@ describe("SettingsApp", () => {
     vi.stubGlobal("fetch", mockFetch({}));
     const user = userEvent.setup();
     const onClose = vi.fn();
-    render(<SettingsApp token="secret" route="settings" onClose={onClose} />);
+    render(<SettingsApp route="settings" onClose={onClose} />);
 
     await screen.findByRole("combobox", { name: /provider/i });
     await user.type(screen.getByLabelText(/api key/i), "sk-new");

--- a/apps/cli/src/ui/settings/Settings.tsx
+++ b/apps/cli/src/ui/settings/Settings.tsx
@@ -44,12 +44,6 @@ type ActionStatus =
   | { kind: "ok"; message: string }
   | { kind: "error"; message: string };
 
-function apiUrl(path: string, token: string): string {
-  const url = new URL(path, window.location.origin);
-  url.searchParams.set("token", token);
-  return url.toString();
-}
-
 function agentIdForProvider(provider: ProviderId): "claude-code" | "codex" | "grok" {
   switch (provider) {
     case "anthropic":
@@ -203,7 +197,6 @@ interface SettingsSnapshot {
 }
 
 interface SettingsProps {
-  token: string;
   onSaved?: (settings: PublicSettings) => void;
   onDirtyChange?: (dirty: boolean) => void;
 }
@@ -216,7 +209,7 @@ function snapshotFromPublished(data: PublicSettings): SettingsSnapshot {
   };
 }
 
-export function Settings({ token, onSaved, onDirtyChange }: SettingsProps) {
+export function Settings({ onSaved, onDirtyChange }: SettingsProps) {
   const [provider, setProvider] = useState<ProviderId>("anthropic");
   const [model, setModel] = useState(defaultModelFor("anthropic"));
   const [apiKey, setApiKey] = useState("");
@@ -235,8 +228,8 @@ export function Settings({ token, onSaved, onDirtyChange }: SettingsProps) {
     async function load() {
       try {
         const [settingsRes, agentsRes] = await Promise.all([
-          fetch(apiUrl("/api/settings", token)),
-          fetch(apiUrl("/api/agents", token)),
+          fetch("/api/settings"),
+          fetch("/api/agents"),
         ]);
         if (!settingsRes.ok) throw new Error("Could not load settings.");
         const data = (await settingsRes.json()) as PublicSettings;
@@ -264,7 +257,7 @@ export function Settings({ token, onSaved, onDirtyChange }: SettingsProps) {
     return () => {
       cancelled = true;
     };
-  }, [token]);
+  }, []);
 
   const busy = saveStatus.kind === "working" || connection.kind === "working";
   const providerDef = getProvider(provider);
@@ -327,7 +320,7 @@ export function Settings({ token, onSaved, onDirtyChange }: SettingsProps) {
   });
 
   const persist = async (): Promise<PublicSettings> => {
-    const res = await fetch(apiUrl("/api/settings", token), {
+    const res = await fetch("/api/settings", {
       method: "PUT",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(payload()),
@@ -354,7 +347,7 @@ export function Settings({ token, onSaved, onDirtyChange }: SettingsProps) {
     setConnection({ kind: "working" });
     setSaveStatus({ kind: "idle" });
     try {
-      const res = await fetch(apiUrl("/api/settings/test", token), {
+      const res = await fetch("/api/settings/test", {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify(payload()),
@@ -366,7 +359,7 @@ export function Settings({ token, onSaved, onDirtyChange }: SettingsProps) {
       if (!res.ok) throw new Error(data.error ?? "Connection test failed unexpectedly.");
       if (data.ok) {
         setConnection({ kind: "ok", message: "Connection OK" });
-        const published = await fetch(apiUrl("/api/settings", token)).then(
+        const published = await fetch("/api/settings").then(
           (r) => r.json() as Promise<PublicSettings>,
         );
         applyPublished(published);

--- a/apps/cli/src/ui/settings/SettingsApp.tsx
+++ b/apps/cli/src/ui/settings/SettingsApp.tsx
@@ -160,12 +160,10 @@ function SettingsShell({
 }
 
 export function SettingsApp({
-  token,
   route,
   onSaved,
   onClose,
 }: {
-  token: string;
   route: SettingsRoute;
   onSaved?: (settings: PublicSettings) => void;
   onClose: () => void;
@@ -204,7 +202,7 @@ export function SettingsApp({
   return (
     <SettingsShell route={route} onClose={requestClose}>
       <div hidden={route !== "settings"}>
-        <Settings token={token} onSaved={onSaved} onDirtyChange={setDirty} />
+        <Settings onSaved={onSaved} onDirtyChange={setDirty} />
       </div>
       {route === "about" ? <About /> : null}
     </SettingsShell>

--- a/apps/web/config/docs.ts
+++ b/apps/web/config/docs.ts
@@ -56,8 +56,8 @@ export const DOCS_PAGES: DocsPage[] = [
     section: "Getting Started",
     title: "Review local changes",
     description:
-      "Run Guided Review from your terminal against the main branch. The CLI serves the same walkthrough in the browser.",
-    blurb: "CLI for local git diffs vs main",
+      "Run Guided Review from your terminal on a local branch, commit, or working tree. The CLI serves the same walkthrough in the browser.",
+    blurb: "CLI for local branch, commit, or working-tree diffs",
     load: () => import("@web/content/help/local-review.mdx"),
   },
   {

--- a/apps/web/content/help/local-review.mdx
+++ b/apps/web/content/help/local-review.mdx
@@ -28,7 +28,7 @@ Pass flags after `--`:
 npm run review -- --base main --no-open
 ```
 
-The CLI binds `127.0.0.1`, prints a tokenized URL, and opens it unless you pass `--no-open`. Ctrl+C stops the server.
+The CLI binds `127.0.0.1:7182` (ASCII G+R), keeps a short terminal banner (URL, diff, last pull), and opens the UI unless you pass `--no-open`. Only real events (structure, scope change, errors) go to the log below. Override with `--port`. `--port 0` picks any free port. Ctrl+C stops the server.
 
 ## What it compares
 
@@ -51,15 +51,21 @@ The walkthrough starts one unit per file. **Structure with AI** on the Change su
 
 Same providers as the extension: Anthropic, OpenAI, Grok.
 
-Resolution, in order: `--provider` / `--model` / `--agent` and env (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `XAI_API_KEY` or `GROK_API_KEY`) → a key already saved in `~/.config/guided-review/config.json` → a coding agent already on this machine (Claude Code, Codex, or Grok). If more than one agent has a usable key, the CLI asks which to use each run (Enter keeps the last choice). The chosen agent is shown in the browser UI. It reads the agent's own store at review time and does not copy the secret into Guided Review config.
+Resolution, in order:
+
+1. `--provider` / `--model` / `--agent` and env (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `XAI_API_KEY` or `GROK_API_KEY`)
+2. A key already saved in `~/.config/guided-review/config.json`
+3. A coding agent already on this machine (Claude Code, Codex, or Grok)
+
+If more than one agent has a usable key, the CLI asks which to use each run (Enter keeps the last choice). The chosen agent is shown in the browser UI. It reads the agent's own store at review time and does not copy the secret into Guided Review config.
 
 No key still walks one unit per file. **Structure with AI** asks for a key.
 
-The local UI has a **Settings** page (header **Settings**, `⌘/Ctrl` + `,`, or **Connect AI Provider** when no key is set). Pick a provider and model, then either paste an API key or turn on **Use my subscription** to borrow Claude Code / Codex / Grok already on this machine. A saved API key always wins. Subscription reads the agent's store at review time and does not copy the secret into Guided Review config — it is unofficial and can break, so a console key is the better option. Save writes `~/.config/guided-review/config.json` (or `$XDG_CONFIG_HOME` / `GUIDED_REVIEW_CONFIG_DIR`). Flags and env still win for that run.
+The local UI has **Settings** (header, `⌘/Ctrl` + `,`, or **Connect AI Provider** when no key is set). Paste an API key, or turn on **Use my subscription** to borrow Claude Code / Codex / Grok on this machine. A saved API key always wins. Subscription is unofficial and can break — a console key is the better option. Save writes `~/.config/guided-review/config.json` (or `$XDG_CONFIG_HOME` / `GUIDED_REVIEW_CONFIG_DIR`). Flags and env still win for that run.
 
 ## Notes
 
-Line comments stay in the session. There is no GitHub submit. **Copy notes** puts markdown on the clipboard.
+Line comments stay in the session. There is no GitHub submit. **Generate Prompt** builds a coding-agent prompt from those notes and copies it — Guided Review does not send it anywhere.
 
 ## Flags
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "express": "^5.1.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
+        "winston": "^3.19.0",
         "zustand": "^5.0.14"
       },
       "bin": {
@@ -652,6 +653,15 @@
         "node": ">=16"
       }
     },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/@crxjs/vite-plugin": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@crxjs/vite-plugin/-/vite-plugin-2.7.1.tgz",
@@ -840,6 +850,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -3063,6 +3084,16 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
     "node_modules/@speed-highlight/core": {
       "version": "1.2.24",
       "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
@@ -3728,6 +3759,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -4382,6 +4419,12 @@
         "astring": "bin/astring"
       }
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
     "node_modules/bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -4810,6 +4853,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4829,6 +4885,48 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.1.tgz",
+      "integrity": "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.1.tgz",
+      "integrity": "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -5252,6 +5350,12 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -5921,6 +6025,12 @@
         }
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
     "node_modules/fflate": {
       "version": "0.4.9",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.9.tgz",
@@ -5998,6 +6108,12 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -6580,7 +6696,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6820,6 +6935,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -7134,6 +7255,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/longest-streak": {
@@ -8345,6 +8483,15 @@
         "wrappy": "1"
       }
     },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
     "node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -8794,6 +8941,20 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
@@ -9074,7 +9235,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9090,6 +9250,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -9541,6 +9710,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -9563,6 +9741,15 @@
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
@@ -9750,6 +9937,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -9857,6 +10050,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/trough": {
@@ -10196,6 +10398,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -10805,6 +11013,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/word-wrap": {


### PR DESCRIPTION
Part 12 of 13 in the local-review CLI stack. Base: [#87](https://github.com/nshntarora/guidedreview/pull/87).

The server is loopback-only, so drop the URL session token on `/api`. Winston labeled logs, sticky TTY banner (URL, diff, last pull), default listen port `7182`, and the ESM bundle `require` restore for Express/debug. Docs cover port, banner, and generate-prompt notes.

**Out of scope (later PRs):** overlay inner-pane padding and generate-prompt copy.