### PR TITLE
style(extension): overlay padding and generate-prompt copy

### DIFF
--- a/apps/extension/src/content/overlay/Overlay.tsx
+++ b/apps/extension/src/content/overlay/Overlay.tsx
@@ -406,38 +406,42 @@ export function Overlay({
       <div className="flex min-h-0 flex-1">
         <main
           id="main-content"
-          className="min-w-0 flex-[1_1_68%] overflow-y-auto border-r border-border bg-surface px-8 py-6"
+          className="min-w-0 flex-[1_1_68%] overflow-y-auto border-r border-border bg-surface"
           ref={codeColRef}
           data-testid="code-col"
           tabIndex={-1}
         >
-          {isDescriptionUnit ? (
-            <DescriptionPane
-              prContext={prContext}
-              diff={diff}
-              commits={localDiff?.commits}
-              uncommitted={localDiff?.scopes.find(
-                (scope) => scope.id === "uncommitted" && !scope.empty,
-              )}
-            />
-          ) : (
-            <DiffPane
-              files={resolvedFiles}
-              unitTitle={
-                currentReviewUnit ? (currentReviewUnit.displayTitle ?? currentReviewUnit.title) : ""
-              }
-              unitTitleTooltip={currentReviewUnit?.title}
-              isTestsUnit={currentReviewUnit?.kind === "tests"}
-              unitId={currentReviewUnit?.id}
-              selectableForUnit={selectableForUnit}
-              searchScrollTarget={searchScrollTarget}
-              onSearchScrollTargetConsumed={clearSearchScrollTarget}
-            />
-          )}
+          <div className="px-8 py-6">
+            {isDescriptionUnit ? (
+              <DescriptionPane
+                prContext={prContext}
+                diff={diff}
+                commits={localDiff?.commits}
+                uncommitted={localDiff?.scopes.find(
+                  (scope) => scope.id === "uncommitted" && !scope.empty,
+                )}
+              />
+            ) : (
+              <DiffPane
+                files={resolvedFiles}
+                unitTitle={
+                  currentReviewUnit
+                    ? (currentReviewUnit.displayTitle ?? currentReviewUnit.title)
+                    : ""
+                }
+                unitTitleTooltip={currentReviewUnit?.title}
+                isTestsUnit={currentReviewUnit?.kind === "tests"}
+                unitId={currentReviewUnit?.id}
+                selectableForUnit={selectableForUnit}
+                searchScrollTarget={searchScrollTarget}
+                onSearchScrollTargetConsumed={clearSearchScrollTarget}
+              />
+            )}
+          </div>
         </main>
 
         <aside
-          className="flex max-w-[420px] min-w-[300px] flex-[1_1_32%] flex-col overflow-hidden bg-background py-6"
+          className="flex max-w-[420px] min-w-[300px] flex-[1_1_32%] flex-col overflow-hidden bg-background"
           aria-label="Review context and plan"
         >
           <div
@@ -445,7 +449,7 @@ export function Overlay({
             ref={contextPaneRef}
             data-testid="context-pane"
           >
-            <div className="px-5">
+            <div className="px-5 py-6">
               <ContextPanel
                 unit={currentReviewUnit}
                 hasTitle={Boolean(prContext?.title?.trim())}

--- a/apps/extension/src/content/overlay/components/GeneratePromptModal.tsx
+++ b/apps/extension/src/content/overlay/components/GeneratePromptModal.tsx
@@ -76,7 +76,7 @@ export function GeneratePromptModal({
 
       <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
         <p className="m-0 mb-3 text-base text-muted">
-          Copy this into your coding agent to apply the feedback from your notes.
+          Paste this into your coding agent. Built from your notes — nothing is sent for you.
         </p>
         <pre
           className="m-0 whitespace-pre-wrap break-words rounded-md border border-border bg-surface px-3 py-3 font-mono text-sm leading-relaxed text-foreground"

--- a/apps/extension/src/content/overlay/components/Sidebar.tsx
+++ b/apps/extension/src/content/overlay/components/Sidebar.tsx
@@ -32,10 +32,10 @@ export function Sidebar({ plan, currentUnitIndex, stillBuilding, onSelectUnit }:
 
   return (
     <nav
-      className="mt-6 min-h-0 flex-[1_1_50%] overflow-y-auto border-t border-border-strong pt-4"
+      className="min-h-0 flex-[1_1_50%] overflow-y-auto border-t border-border-strong"
       aria-label="Review Units"
     >
-      <div className="px-5">
+      <div className="px-5 pt-4 pb-6">
         <div className="px-2 pb-1 pt-2.5 text-xs tracking-[0.04em] text-muted uppercase">
           Review Units
         </div>


### PR DESCRIPTION
Part 13 of 13 in the local-review CLI stack. Base: [#88](https://github.com/nshntarora/guidedreview/pull/88).

Move overlay padding onto inner panes so the code and context columns scroll under a flush edge. Generate Prompt copy states the prompt is local-only — Guided Review does not send it anywhere.

This is the top of the stack. Diff vs `main` is the full local-review CLI.