### PR TITLE
ci: run production builds on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,50 @@
+# Production builds for every workspace package that defines a `build` script.
+# Runs alongside Tests so a passing unit suite cannot hide a broken Next/Vite/zip build.
+
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  HUSKY: "0"
+  NEXT_TELEMETRY_DISABLED: "1"
+  CI: "true"
+
+jobs:
+  build:
+    name: Build packages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: apps/web/.next/cache
+          key: next-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'apps/web/package.json', 'apps/web/next.config.ts', 'packages/ui/package.json') }}
+          restore-keys: |
+            next-${{ runner.os }}-
+
+      - name: Build packages
+        run: pnpm --filter "./apps/**" --filter "./packages/**" --if-present build

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ More detail: [apps/extension/README.md](apps/extension/README.md) · [apps/web/R
 
 ```bash
 pnpm build:extension     # typecheck + Vite → apps/extension/dist (+ zip)
-pnpm build               # extension, then marketing site
+pnpm build               # every workspace package with a build script (extension, site, CLI)
 pnpm build:web           # Next.js static export → apps/web/out
 ```
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev:extension": "pnpm --filter @guided-review/extension dev",
     "dev:web": "pnpm --filter @guided-review/web dev",
     "dev:cli": "pnpm --filter @guided-review/cli dev",
-    "build": "pnpm run build:extension && pnpm run build:web",
+    "build": "pnpm --filter \"./apps/**\" --filter \"./packages/**\" --if-present build",
     "build:cli": "pnpm --filter @guided-review/cli build",
     "review": "pnpm --filter @guided-review/cli start --",
     "build:extension": "pnpm --filter @guided-review/extension build",


### PR DESCRIPTION
PRs currently gate on Tests (lint, typecheck, unit, path-filtered e2e). A passing unit suite can still hide a broken production build — e2e only builds some packages, and only when their path filters match. Core-only changes never build the extension; the extension zip step never runs in CI.

This adds a **Build** workflow that runs on `pull_request` and `push` to `main`, in parallel with Tests. After one install it runs:

```bash
pnpm --filter "./apps/**" --filter "./packages/**" --if-present build
```

Today that compiles the website (Next static export), the extension (typecheck + Vite + zip), and the CLI (typecheck + Vite + server bundle). `packages/core` and `packages/ui` have no `build` script and are skipped. A later package that adds one is included automatically.

Root `pnpm build` uses the same command so local and CI both include the CLI.

Deploy is unchanged: it already builds the marketing site itself, and a CLI/extension failure should not skip a site deploy.

If branch protection uses required checks, add **Build packages** after this lands.