### PR TITLE
feat: support a custom provider base URL

### DIFF
--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -31,11 +31,13 @@ export interface CliConfigFile {
   model?: string;
   apiKey?: string;
   codingAgent?: CodingAgentId;
+  baseUrl?: string;
 }
 
-export type ConfigPatch = Omit<Partial<CliConfigFile>, "codingAgent" | "apiKey"> & {
+export type ConfigPatch = Omit<Partial<CliConfigFile>, "codingAgent" | "apiKey" | "baseUrl"> & {
   codingAgent?: CodingAgentId | null;
   apiKey?: string | null;
+  baseUrl?: string | null;
 };
 
 export interface PublicCliSettings {
@@ -45,6 +47,7 @@ export interface PublicCliSettings {
   last4: string | null;
   codingAgent: CodingAgentId | null;
   configPath: string;
+  baseUrl: string | null;
 }
 
 export interface PublicCodingAgent {
@@ -83,6 +86,17 @@ function envKeyFor(provider: ProviderId): string | undefined {
   }
 }
 
+function envBaseUrlFor(provider: ProviderId): string | undefined {
+  switch (provider) {
+    case "anthropic":
+      return process.env.ANTHROPIC_BASE_URL;
+    case "openai":
+      return process.env.OPENAI_BASE_URL;
+    case "grok":
+      return process.env.XAI_BASE_URL || process.env.GROK_BASE_URL;
+  }
+}
+
 export async function readConfigFile(): Promise<CliConfigFile> {
   let raw: string;
   try {
@@ -107,12 +121,14 @@ export async function writeConfigFile(next: CliConfigFile): Promise<void> {
 
 export async function patchConfigFile(partial: ConfigPatch): Promise<void> {
   const current = await readConfigFile();
-  const { codingAgent, apiKey, ...rest } = partial;
+  const { codingAgent, apiKey, baseUrl, ...rest } = partial;
   const next: CliConfigFile = { ...current, ...rest };
   if (codingAgent === null) delete next.codingAgent;
   else if (codingAgent !== undefined) next.codingAgent = codingAgent;
   if (apiKey === null) delete next.apiKey;
   else if (apiKey !== undefined) next.apiKey = apiKey;
+  if (baseUrl === null) delete next.baseUrl;
+  else if (baseUrl !== undefined) next.baseUrl = baseUrl;
   await writeConfigFile(next);
 }
 
@@ -123,7 +139,7 @@ export async function patchConfigFile(partial: ConfigPatch): Promise<void> {
 export function applyProviderSettings(
   current: ProviderSettings,
   codingAgent: CodingAgentId | null,
-  body: Partial<Pick<ProviderSettings, "provider" | "model" | "apiKey">>,
+  body: Partial<Pick<ProviderSettings, "provider" | "model" | "apiKey" | "baseUrl">>,
 ): {
   settings: ProviderSettings;
   codingAgent: CodingAgentId | null;
@@ -131,12 +147,15 @@ export function applyProviderSettings(
 } {
   const hasNewKey = typeof body.apiKey === "string" && body.apiKey.length > 0;
   const requestedModel = body.model ?? current.model;
+  // Unlike apiKey, baseUrl isn't sensitive, so an explicit blank clears it.
+  const nextBaseUrl = body.baseUrl !== undefined ? body.baseUrl.trim() : current.baseUrl;
   const normalized = normalizeProviderSettings({
     provider: body.provider ?? current.provider,
     model: requestedModel,
     apiKey: hasNewKey ? body.apiKey : current.apiKey,
     authScheme: hasNewKey ? undefined : current.authScheme,
     extraHeaders: hasNewKey ? undefined : current.extraHeaders,
+    baseUrl: nextBaseUrl,
   });
   const settings: ProviderSettings = {
     ...normalized,
@@ -149,6 +168,7 @@ export function applyProviderSettings(
     persist: {
       provider: settings.provider,
       model: settings.model,
+      baseUrl: nextBaseUrl ? nextBaseUrl : null,
       ...(hasNewKey ? { apiKey: settings.apiKey, codingAgent: null } : {}),
     },
   };
@@ -172,12 +192,16 @@ export async function resolveSettings(flags: {
     provider,
     model,
     apiKey: file.apiKey ?? "",
+    baseUrl: file.baseUrl,
   });
   const envKey = envKeyFor(normalized.provider);
+  const envBaseUrl = envBaseUrlFor(normalized.provider)?.trim() || undefined;
+  const resolvedBaseUrl = envBaseUrl ?? file.baseUrl;
   const settings: ProviderSettings = {
     ...normalized,
     apiKey: envKey ?? file.apiKey ?? "",
     model: flags.model ?? normalized.model ?? defaultModelFor(normalized.provider),
+    ...(resolvedBaseUrl ? { baseUrl: resolvedBaseUrl } : {}),
   };
 
   if (settings.apiKey) {
@@ -230,6 +254,7 @@ export function publicSettings(
     last4: key ? key.slice(-4) : null,
     codingAgent: codingAgent ?? null,
     configPath: configPath(),
+    baseUrl: settings.baseUrl ?? null,
   };
 }
 

--- a/apps/cli/src/server/createServer.ts
+++ b/apps/cli/src/server/createServer.ts
@@ -86,6 +86,7 @@ interface SettingsBody {
   model?: string;
   apiKey?: string;
   codingAgent?: CodingAgentId | null;
+  baseUrl?: string;
 }
 
 type RequestWithRaw = Request & { rawBody?: Buffer };
@@ -147,6 +148,7 @@ function parseSettingsBody(value: unknown): SettingsBody | null {
   }
   if (typeof raw.model === "string") body.model = raw.model;
   if (typeof raw.apiKey === "string") body.apiKey = raw.apiKey;
+  if (typeof raw.baseUrl === "string") body.baseUrl = raw.baseUrl;
   if (raw.codingAgent === null) body.codingAgent = null;
   else if (typeof raw.codingAgent === "string") {
     if (!isCodingAgentId(raw.codingAgent)) return null;

--- a/apps/cli/src/ui/settings/Settings.test.tsx
+++ b/apps/cli/src/ui/settings/Settings.test.tsx
@@ -14,6 +14,7 @@ const settings: PublicSettings = {
   last4: "key1",
   codingAgent: null,
   configPath: "/tmp/guided-review/config.json",
+  baseUrl: null,
 };
 
 const agents: PublicAgent[] = [
@@ -205,6 +206,7 @@ describe("Settings", () => {
     expect(JSON.parse(String(put?.[1]?.body))).toEqual({
       provider: "openai",
       model: defaultModelFor("openai"),
+      baseUrl: "",
       codingAgent: "codex",
     });
   });

--- a/apps/cli/src/ui/settings/Settings.tsx
+++ b/apps/cli/src/ui/settings/Settings.tsx
@@ -28,6 +28,7 @@ export interface PublicSettings {
   last4: string | null;
   codingAgent: string | null;
   configPath: string;
+  baseUrl: string | null;
 }
 
 export interface PublicAgent {
@@ -170,6 +171,39 @@ function ApiKeyField({
   );
 }
 
+function BaseUrlField({
+  baseUrl,
+  placeholder,
+  busy,
+  onChange,
+}: {
+  baseUrl: string;
+  placeholder: string;
+  busy: boolean;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div>
+      <Label htmlFor="baseUrl">Base URL</Label>
+      <Input
+        id="baseUrl"
+        type="text"
+        autoComplete="off"
+        placeholder={placeholder}
+        value={baseUrl}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={busy}
+        aria-describedby="baseUrl-hint"
+        data-testid="settings-base-url"
+      />
+      <p id="baseUrl-hint" className="mt-1.5 m-0 text-sm text-muted">
+        Optional. Point requests at a proxy or gateway instead of the provider&apos;s public API.
+        Leave blank to use the default.
+      </p>
+    </div>
+  );
+}
+
 function agentForProvider(
   agents: PublicAgent[] | null,
   provider: ProviderId,
@@ -182,6 +216,7 @@ interface SettingsSnapshot {
   provider: ProviderId;
   model: string;
   useSubscription: boolean;
+  baseUrl: string;
 }
 
 interface SettingsProps {
@@ -194,6 +229,7 @@ function snapshotFromPublished(data: PublicSettings): SettingsSnapshot {
     provider: data.provider,
     model: data.model,
     useSubscription: Boolean(data.codingAgent),
+    baseUrl: data.baseUrl ?? "",
   };
 }
 
@@ -204,6 +240,7 @@ export function Settings({ onSaved, onDirtyChange }: SettingsProps) {
   const [hasKey, setHasKey] = useState(false);
   const [last4, setLast4] = useState<string | null>(null);
   const [useSubscription, setUseSubscription] = useState(false);
+  const [baseUrl, setBaseUrl] = useState("");
   const [configPath, setConfigPath] = useState("~/.config/guided-review/config.json");
   const [agents, setAgents] = useState<PublicAgent[] | null>(null);
   const [loaded, setLoaded] = useState(false);
@@ -230,6 +267,7 @@ export function Settings({ onSaved, onDirtyChange }: SettingsProps) {
         setHasKey(data.hasKey);
         setLast4(data.last4);
         setUseSubscription(Boolean(data.codingAgent));
+        setBaseUrl(data.baseUrl ?? "");
         setConfigPath(data.configPath);
         setAgents(listed);
         setSaved(snapshotFromPublished(data));
@@ -280,6 +318,7 @@ export function Settings({ onSaved, onDirtyChange }: SettingsProps) {
     setHasKey(data.hasKey);
     setLast4(data.last4);
     setUseSubscription(Boolean(data.codingAgent));
+    setBaseUrl(data.baseUrl ?? "");
     setConfigPath(data.configPath);
     setApiKey("");
     setSaved(snapshotFromPublished(data));
@@ -295,13 +334,15 @@ export function Settings({ onSaved, onDirtyChange }: SettingsProps) {
       provider !== saved.provider ||
         model !== saved.model ||
         useSubscription !== saved.useSubscription ||
+        baseUrl !== saved.baseUrl ||
         apiKey !== "",
     );
-  }, [loaded, saved, provider, model, useSubscription, apiKey, onDirtyChange]);
+  }, [loaded, saved, provider, model, useSubscription, baseUrl, apiKey, onDirtyChange]);
 
   const payload = () => ({
     provider,
     model,
+    baseUrl: baseUrl.trim(),
     ...(useSubscription
       ? { codingAgent: agentIdForProvider(provider) }
       : { codingAgent: null, ...(apiKey ? { apiKey } : {}) }),
@@ -376,6 +417,7 @@ export function Settings({ onSaved, onDirtyChange }: SettingsProps) {
   const onProviderChange = (next: ProviderId) => {
     setProvider(next);
     setModel(defaultModelFor(next));
+    setBaseUrl("");
     setSaveStatus({ kind: "idle" });
     setConnection({ kind: "idle" });
   };
@@ -521,6 +563,19 @@ export function Settings({ onSaved, onDirtyChange }: SettingsProps) {
                 }}
               />
             )}
+
+            <HelpDetails title="Advanced">
+              <BaseUrlField
+                baseUrl={baseUrl}
+                placeholder={providerDef.baseUrlPlaceholder}
+                busy={busy}
+                onChange={(value) => {
+                  setBaseUrl(value);
+                  setSaveStatus({ kind: "idle" });
+                  setConnection({ kind: "idle" });
+                }}
+              />
+            </HelpDetails>
 
             <div className="flex flex-wrap items-center gap-2.5 pt-1">
               <Button onClick={() => void onSave()} disabled={busy} data-testid="settings-save">

--- a/packages/core/src/providers/anthropic.test.ts
+++ b/packages/core/src/providers/anthropic.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AnnotateReviewInput } from "./types";
 
-vi.mock("./http", () => ({
+vi.mock("./http", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./http")>()),
   postProviderJson: vi.fn(),
 }));
 

--- a/packages/core/src/providers/anthropic.ts
+++ b/packages/core/src/providers/anthropic.ts
@@ -1,12 +1,16 @@
 import type { ProviderSettings } from "../types";
 import { buildUserPrompt, SYSTEM_PROMPT } from "../review/buildPrompt";
 import { REVIEW_PLAN_JSON_SCHEMA } from "../review/reviewSchema";
-import { postProviderJson } from "./http";
+import { postProviderJson, resolveApiUrl } from "./http";
 import { readSseJsonStream } from "./sse";
 import type { AnnotateReviewInput, AnnotateStreamEvent, ProviderClient } from "./types";
 import { ProviderError } from "./types";
 
-const API_URL = "https://api.anthropic.com/v1/messages";
+const DEFAULT_API_URL = "https://api.anthropic.com/v1/messages";
+
+function apiUrl(settings: ProviderSettings): string {
+  return resolveApiUrl(settings.baseUrl, DEFAULT_API_URL, "/v1/messages");
+}
 
 function headers(settings: ProviderSettings): Record<string, string> {
   const result: Record<string, string> = {
@@ -35,7 +39,7 @@ export const anthropicProvider: ProviderClient = {
     options?: { signal?: AbortSignal },
   ): AsyncGenerator<AnnotateStreamEvent, void, unknown> {
     const response = await postProviderJson(
-      API_URL,
+      apiUrl(settings),
       headers(settings),
       {
         model: settings.model,
@@ -91,7 +95,7 @@ export const anthropicProvider: ProviderClient = {
 
   async testConnection(settings: ProviderSettings): Promise<void> {
     await postProviderJson(
-      API_URL,
+      apiUrl(settings),
       headers(settings),
       {
         model: settings.model,

--- a/packages/core/src/providers/catalog.ts
+++ b/packages/core/src/providers/catalog.ts
@@ -21,6 +21,8 @@ interface ProviderDefinition {
   iconSrc: string;
   /** Default model id when this provider is selected. */
   defaultModelId: string;
+  /** Example value shown as the Base URL field's placeholder. */
+  baseUrlPlaceholder: string;
 }
 
 interface ModelDefinition {
@@ -39,6 +41,7 @@ export const PROVIDERS: Record<ProviderId, ProviderDefinition> = {
     keyPlaceholder: "sk-ant-…",
     iconSrc: "providers/claude.svg",
     defaultModelId: "claude-opus-4-8",
+    baseUrlPlaceholder: "https://api.anthropic.com",
   },
   openai: {
     id: "openai",
@@ -46,6 +49,7 @@ export const PROVIDERS: Record<ProviderId, ProviderDefinition> = {
     keyPlaceholder: "sk-…",
     iconSrc: "providers/openai.svg",
     defaultModelId: "gpt-4.1",
+    baseUrlPlaceholder: "https://api.openai.com/v1",
   },
   grok: {
     id: "grok",
@@ -53,6 +57,7 @@ export const PROVIDERS: Record<ProviderId, ProviderDefinition> = {
     keyPlaceholder: "xai-…",
     iconSrc: "providers/grok.svg",
     defaultModelId: "grok-4",
+    baseUrlPlaceholder: "https://api.x.ai/v1",
   },
 };
 
@@ -110,12 +115,14 @@ export function normalizeProviderSettings(stored: {
   apiKey?: string;
   authScheme?: "api-key" | "bearer";
   extraHeaders?: Record<string, string>;
+  baseUrl?: string;
 }): {
   provider: ProviderId;
   model: string;
   apiKey: string;
   authScheme?: "api-key" | "bearer";
   extraHeaders?: Record<string, string>;
+  baseUrl?: string;
 } {
   const provider =
     stored.provider && stored.provider in PROVIDERS ? (stored.provider as ProviderId) : "anthropic";
@@ -127,5 +134,6 @@ export function normalizeProviderSettings(stored: {
     apiKey: stored.apiKey ?? "",
     ...(stored.authScheme ? { authScheme: stored.authScheme } : {}),
     ...(stored.extraHeaders ? { extraHeaders: stored.extraHeaders } : {}),
+    ...(stored.baseUrl ? { baseUrl: stored.baseUrl } : {}),
   };
 }

--- a/packages/core/src/providers/http.ts
+++ b/packages/core/src/providers/http.ts
@@ -47,6 +47,27 @@ export async function parseProviderHttpError(response: Response): Promise<Provid
   }
 }
 
+/**
+ * Join a user-supplied `baseUrl` override with a provider's request path,
+ * avoiding double-appending when the override already includes part or all
+ * of that path (e.g. a proxy configured with `.../v1` when the path is
+ * `/v1/messages`, or the full path already).
+ */
+export function resolveApiUrl(
+  baseUrl: string | undefined,
+  defaultUrl: string,
+  path: string,
+): string {
+  const base = baseUrl?.trim().replace(/\/+$/, "");
+  if (!base) return defaultUrl;
+  if (base.endsWith(path)) return base;
+  const [firstSegment, ...rest] = path.split("/").filter(Boolean);
+  if (rest.length > 0 && base.endsWith(`/${firstSegment}`)) {
+    return `${base}/${rest.join("/")}`;
+  }
+  return `${base}${path}`;
+}
+
 function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === "AbortError";
 }

--- a/packages/core/src/providers/openaiCompatible.test.ts
+++ b/packages/core/src/providers/openaiCompatible.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AnnotateReviewInput } from "./types";
 
-vi.mock("./http", () => ({
+vi.mock("./http", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./http")>()),
   postProviderJson: vi.fn(),
 }));
 

--- a/packages/core/src/providers/openaiCompatible.ts
+++ b/packages/core/src/providers/openaiCompatible.ts
@@ -1,7 +1,7 @@
 import type { ProviderSettings } from "../types";
 import { buildUserPrompt, SYSTEM_PROMPT } from "../review/buildPrompt";
 import { REVIEW_PLAN_JSON_SCHEMA } from "../review/reviewSchema";
-import { postProviderJson } from "./http";
+import { postProviderJson, resolveApiUrl } from "./http";
 import { readSseJsonStream } from "./sse";
 import type { AnnotateReviewInput, AnnotateStreamEvent, ProviderClient } from "./types";
 import { ProviderError } from "./types";
@@ -16,10 +16,12 @@ import { ProviderError } from "./types";
  * Streams completion deltas so the overlay can surface completed units early.
  */
 export function createOpenAICompatibleProvider(
-  baseUrl: string,
+  defaultBaseUrl: string,
   displayName: string,
 ): ProviderClient {
-  const chatUrl = `${baseUrl}/chat/completions`;
+  const defaultChatUrl = `${defaultBaseUrl}/chat/completions`;
+  const chatUrl = (settings: ProviderSettings) =>
+    resolveApiUrl(settings.baseUrl, defaultChatUrl, "/chat/completions");
   const headers = (settings: ProviderSettings) => ({
     authorization: `Bearer ${settings.apiKey}`,
     ...settings.extraHeaders,
@@ -31,7 +33,7 @@ export function createOpenAICompatibleProvider(
       options?: { signal?: AbortSignal },
     ): AsyncGenerator<AnnotateStreamEvent, void, unknown> {
       const response = await postProviderJson(
-        chatUrl,
+        chatUrl(settings),
         headers(settings),
         {
           model: settings.model,
@@ -96,7 +98,7 @@ export function createOpenAICompatibleProvider(
 
     async testConnection(settings: ProviderSettings): Promise<void> {
       await postProviderJson(
-        chatUrl,
+        chatUrl(settings),
         headers(settings),
         {
           model: settings.model,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -141,6 +141,11 @@ export interface ProviderSettings {
   authScheme?: "api-key" | "bearer";
   /** Merged into the provider request. Used by agent adapters (e.g. Anthropic beta). */
   extraHeaders?: Record<string, string>;
+  /**
+   * Overrides the provider's default API host, e.g. to point at a proxy or
+   * gateway. Falls back to the provider's public API when unset.
+   */
+  baseUrl?: string;
 }
 
 // ---- Annotate stream (host-agnostic) ----------------------------------------


### PR DESCRIPTION
Fixes #106 

Tested with https://github.com/rynfar/meridian and pointing it to `localhost:3456`.

```
ANTHROPIC_BASE_URL=http://localhost:3456 node apps/cli/dist/bin.js
```

<img width="636" height="994" alt="image" src="https://github.com/user-attachments/assets/d5ccd0c7-c8ab-43b8-9b8f-2a9fb6ce4663" />
